### PR TITLE
feat: add Order support (contracts, events, webhook factory)

### DIFF
--- a/src/Contracts/OrderInterface.php
+++ b/src/Contracts/OrderInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Interface for order entities.
+ */
+interface OrderInterface
+{
+    /**
+     * Get the Vatly order ID.
+     */
+    public function getVatlyId(): string;
+
+    /**
+     * Get the order status.
+     */
+    public function getStatus(): string;
+
+    /**
+     * Get the invoice number.
+     */
+    public function getInvoiceNumber(): ?string;
+
+    /**
+     * Get the order total.
+     */
+    public function getTotal(): int;
+
+    /**
+     * Get the currency.
+     */
+    public function getCurrency(): string;
+
+    /**
+     * Get the payment method.
+     */
+    public function getPaymentMethod(): ?string;
+
+    /**
+     * Get the owner of this order.
+     */
+    public function getOwner(): BillableInterface;
+
+    /**
+     * Check if the order is paid.
+     */
+    public function isPaid(): bool;
+}

--- a/src/Contracts/OrderRepositoryInterface.php
+++ b/src/Contracts/OrderRepositoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Interface for order persistence.
+ */
+interface OrderRepositoryInterface
+{
+    /**
+     * Find an order by its Vatly ID.
+     */
+    public function findByVatlyId(string $vatlyId): ?OrderInterface;
+
+    /**
+     * Find all orders for an owner.
+     *
+     * @return OrderInterface[]
+     */
+    public function findAllByOwner(BillableInterface $owner): array;
+
+    /**
+     * Create a new order.
+     */
+    public function create(array $attributes): OrderInterface;
+
+    /**
+     * Update an order.
+     */
+    public function update(OrderInterface $order, array $attributes): OrderInterface;
+}

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+/**
+ * Event representing an order being paid at Vatly.
+ */
+class OrderPaid
+{
+    public const VATLY_EVENT_NAME = 'order.paid';
+
+    public function __construct(
+        public readonly string $customerId,
+        public readonly string $orderId,
+        public readonly int $total,
+        public readonly string $currency,
+        public readonly ?string $invoiceNumber,
+        public readonly ?string $paymentMethod,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            customerId: $webhook->object['data']['customerId'],
+            orderId: $webhook->resourceId,
+            total: $webhook->object['data']['total'],
+            currency: $webhook->object['data']['currency'],
+            invoiceNumber: $webhook->object['data']['invoiceNumber'] ?? null,
+            paymentMethod: $webhook->object['data']['paymentMethod'] ?? null,
+        );
+    }
+}

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
+use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
 use Vatly\Fluent\Events\SubscriptionStarted;
@@ -15,7 +16,7 @@ class WebhookEventFactory
     /**
      * Create a typed event from a raw webhook.
      *
-     * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|UnsupportedWebhookReceived
+     * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
@@ -23,6 +24,7 @@ class WebhookEventFactory
             SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromWebhook($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
+            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromWebhook($webhook),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
@@ -55,6 +57,7 @@ class WebhookEventFactory
             SubscriptionStarted::VATLY_EVENT_NAME,
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME,
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME,
+            OrderPaid::VATLY_EVENT_NAME,
         ];
     }
 

--- a/tests/Contracts/OrderInterfaceTest.php
+++ b/tests/Contracts/OrderInterfaceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\OrderInterface;
+
+test('it can be implemented and used', function () {
+    $order = createMockOrder();
+
+    expect($order->getVatlyId())->toBe('ord_test_123')
+        ->and($order->getStatus())->toBe('paid')
+        ->and($order->getInvoiceNumber())->toBe('INV-2024-001')
+        ->and($order->getTotal())->toBe(9900)
+        ->and($order->getCurrency())->toBe('EUR')
+        ->and($order->getPaymentMethod())->toBe('credit_card')
+        ->and($order->isPaid())->toBeTrue()
+        ->and($order->getOwner())->toBeInstanceOf(BillableInterface::class);
+});
+
+function createMockOrder(): OrderInterface
+{
+    return new class implements OrderInterface {
+        public function getVatlyId(): string
+        {
+            return 'ord_test_123';
+        }
+
+        public function getStatus(): string
+        {
+            return 'paid';
+        }
+
+        public function getInvoiceNumber(): ?string
+        {
+            return 'INV-2024-001';
+        }
+
+        public function getTotal(): int
+        {
+            return 9900;
+        }
+
+        public function getCurrency(): string
+        {
+            return 'EUR';
+        }
+
+        public function getPaymentMethod(): ?string
+        {
+            return 'credit_card';
+        }
+
+        public function getOwner(): BillableInterface
+        {
+            return new class implements BillableInterface {
+                public function getVatlyId(): ?string
+                {
+                    return 'cus_123';
+                }
+
+                public function setVatlyId(string $id): void {}
+
+                public function hasVatlyId(): bool
+                {
+                    return true;
+                }
+
+                public function getVatlyEmail(): ?string
+                {
+                    return 'test@example.com';
+                }
+
+                public function getVatlyName(): ?string
+                {
+                    return 'Test User';
+                }
+
+                public function getKey(): string|int
+                {
+                    return 1;
+                }
+
+                public function save(): void {}
+            };
+        }
+
+        public function isPaid(): bool
+        {
+            return true;
+        }
+    };
+}

--- a/tests/Events/OrderPaidTest.php
+++ b/tests/Events/OrderPaidTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\WebhookReceived;
+
+test('it has correct vatly event name constant', function () {
+    expect(OrderPaid::VATLY_EVENT_NAME)->toBe('order.paid');
+});
+
+test('it can be instantiated with all properties', function () {
+    $event = new OrderPaid(
+        customerId: 'cus_123',
+        orderId: 'ord_456',
+        total: 9900,
+        currency: 'EUR',
+        invoiceNumber: 'INV-2024-001',
+        paymentMethod: 'credit_card',
+    );
+
+    expect($event->customerId)->toBe('cus_123')
+        ->and($event->orderId)->toBe('ord_456')
+        ->and($event->total)->toBe(9900)
+        ->and($event->currency)->toBe('EUR')
+        ->and($event->invoiceNumber)->toBe('INV-2024-001')
+        ->and($event->paymentMethod)->toBe('credit_card');
+});
+
+test('it creates from webhook', function () {
+    $webhook = new WebhookReceived(
+        eventName: 'order.paid',
+        resourceId: 'ord_123',
+        resourceName: 'order',
+        object: [
+            'data' => [
+                'customerId' => 'cus_456',
+                'total' => 4999,
+                'currency' => 'USD',
+                'invoiceNumber' => 'INV-2024-002',
+                'paymentMethod' => 'ideal',
+            ],
+        ],
+        raisedAt: '2024-01-15T10:00:00Z',
+        testmode: false,
+    );
+
+    $event = OrderPaid::fromWebhook($webhook);
+
+    expect($event->customerId)->toBe('cus_456')
+        ->and($event->orderId)->toBe('ord_123')
+        ->and($event->total)->toBe(4999)
+        ->and($event->currency)->toBe('USD')
+        ->and($event->invoiceNumber)->toBe('INV-2024-002')
+        ->and($event->paymentMethod)->toBe('ideal');
+});
+
+test('it creates from webhook with nullable fields', function () {
+    $webhook = new WebhookReceived(
+        eventName: 'order.paid',
+        resourceId: 'ord_789',
+        resourceName: 'order',
+        object: [
+            'data' => [
+                'customerId' => 'cus_012',
+                'total' => 1500,
+                'currency' => 'GBP',
+            ],
+        ],
+        raisedAt: '2024-01-15T10:00:00Z',
+        testmode: false,
+    );
+
+    $event = OrderPaid::fromWebhook($webhook);
+
+    expect($event->customerId)->toBe('cus_012')
+        ->and($event->orderId)->toBe('ord_789')
+        ->and($event->total)->toBe(1500)
+        ->and($event->currency)->toBe('GBP')
+        ->and($event->invoiceNumber)->toBeNull()
+        ->and($event->paymentMethod)->toBeNull();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 |--------------------------------------------------------------------------
 */
 
-uses()->group('unit')->in('Actions', 'Builders', 'Events', 'Exceptions', 'Webhooks');
+uses()->group('unit')->in('Actions', 'Builders', 'Contracts', 'Events', 'Exceptions', 'Webhooks');


### PR DESCRIPTION
Closes #6

Adds Order support following the exact same pattern as Subscriptions:

**New files:**
- `src/Contracts/OrderInterface.php` — entity contract (getVatlyId, getStatus, getInvoiceNumber, getTotal, getCurrency, getPaymentMethod, getOwner, isPaid)
- `src/Contracts/OrderRepositoryInterface.php` — persistence contract (findByVatlyId, findAllByOwner, create, update)
- `src/Events/OrderPaid.php` — webhook event with `VATLY_EVENT_NAME = 'order.paid'` and `fromWebhook` static constructor

**Modified:**
- `WebhookEventFactory` — registered OrderPaid in `createFromWebhook` and `getSupportedEvents`

**Tests:** 73 pass (179 assertions)