### PR TITLE
feat: add PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.0",
         "vatly/vatly-api-php": "^0.1.0-alpha.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",
-        "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^11.0"
+        "phpstan/phpstan": "^1.12",
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,6 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
@@ -13,9 +12,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <source>
-        <include>
-            <directory>src</directory>
-        </include>
-    </source>
 </phpunit>

--- a/src/Actions/BaseAction.php
+++ b/src/Actions/BaseAction.php
@@ -8,9 +8,10 @@ use Vatly\API\VatlyApiClient;
 
 abstract class BaseAction
 {
-    public function __construct(
-        protected readonly VatlyApiClient $vatlyApiClient,
-    ) {
-        //
+    protected VatlyApiClient $vatlyApiClient;
+
+    public function __construct(VatlyApiClient $vatlyApiClient)
+    {
+        $this->vatlyApiClient = $vatlyApiClient;
     }
 }

--- a/src/Builders/CheckoutBuilder.php
+++ b/src/Builders/CheckoutBuilder.php
@@ -24,11 +24,14 @@ class CheckoutBuilder
     /** @var array<int, array<string, mixed>> */
     protected array $items = [];
 
-    public function __construct(
-        protected BillableInterface $owner,
-        protected readonly CreateCheckout $createCheckout,
-    ) {
-        //
+    protected BillableInterface $owner;
+
+    protected CreateCheckout $createCheckout;
+
+    public function __construct(BillableInterface $owner, CreateCheckout $createCheckout)
+    {
+        $this->owner = $owner;
+        $this->createCheckout = $createCheckout;
     }
 
     /**
@@ -61,7 +64,7 @@ class CheckoutBuilder
         array $items,
         string $redirectUrlSuccess,
         string $redirectUrlCanceled,
-        array $payloadOverrides = [],
+        array $payloadOverrides = []
     ): Checkout {
         $this
             ->withTestmode($this->testmode)
@@ -78,14 +81,14 @@ class CheckoutBuilder
         return $this->createCheckout->execute($payload);
     }
 
-    public function withRedirectUrlSuccess(string $url): static
+    public function withRedirectUrlSuccess(string $url): self
     {
         $this->redirectUrlSuccess = $url;
 
         return $this;
     }
 
-    public function withRedirectUrlCanceled(string $url): static
+    public function withRedirectUrlCanceled(string $url): self
     {
         $this->redirectUrlCanceled = $url;
 
@@ -95,7 +98,7 @@ class CheckoutBuilder
     /**
      * @param array<string, mixed> $metadata
      */
-    public function withMetadata(array $metadata): static
+    public function withMetadata(array $metadata): self
     {
         $this->metadata = $metadata;
 
@@ -105,7 +108,7 @@ class CheckoutBuilder
     /**
      * @param array<int, array<string, mixed>> $items
      */
-    public function withItems(array $items): static
+    public function withItems(array $items): self
     {
         foreach ($items as $item) {
             $this->items[] = $item;

--- a/src/Builders/SubscriptionBuilder.php
+++ b/src/Builders/SubscriptionBuilder.php
@@ -21,37 +21,46 @@ class SubscriptionBuilder
 
     protected string $redirectUrlCanceled = '';
 
+    protected ConfigurationInterface $config;
+
+    protected BillableInterface $owner;
+
+    protected CheckoutBuilder $checkoutBuilder;
+
     public function __construct(
-        protected readonly ConfigurationInterface $config,
-        protected BillableInterface $owner,
-        protected CheckoutBuilder $checkoutBuilder,
+        ConfigurationInterface $config,
+        BillableInterface $owner,
+        CheckoutBuilder $checkoutBuilder
     ) {
+        $this->config = $config;
+        $this->owner = $owner;
+        $this->checkoutBuilder = $checkoutBuilder;
         $this->redirectUrlSuccess = $this->config->getDefaultRedirectUrlSuccess();
         $this->redirectUrlCanceled = $this->config->getDefaultRedirectUrlCanceled();
     }
 
-    public function toPlan(string $planId): static
+    public function toPlan(string $planId): self
     {
         $this->planId = $planId;
 
         return $this;
     }
 
-    public function withRedirectUrlSuccess(string $redirectUrlSuccess): static
+    public function withRedirectUrlSuccess(string $redirectUrlSuccess): self
     {
         $this->redirectUrlSuccess = $redirectUrlSuccess;
 
         return $this;
     }
 
-    public function withRedirectUrlCanceled(string $redirectUrlCanceled): static
+    public function withRedirectUrlCanceled(string $redirectUrlCanceled): self
     {
         $this->redirectUrlCanceled = $redirectUrlCanceled;
 
         return $this;
     }
 
-    public function withQuantity(int $quantity): static
+    public function withQuantity(int $quantity): self
     {
         $this->quantity = $quantity;
 

--- a/src/Events/LocalSubscriptionCreated.php
+++ b/src/Events/LocalSubscriptionCreated.php
@@ -6,16 +6,12 @@ namespace Vatly\Fluent\Events;
 
 use Vatly\Fluent\Contracts\SubscriptionInterface;
 
-/**
- * Event dispatched when a local subscription record is created.
- *
- * This is an application-level event (vs webhook events from Vatly).
- */
 class LocalSubscriptionCreated
 {
-    public function __construct(
-        public readonly SubscriptionInterface $subscription,
-    ) {
-        //
+    public SubscriptionInterface $subscription;
+
+    public function __construct(SubscriptionInterface $subscription)
+    {
+        $this->subscription = $subscription;
     }
 }

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -4,33 +4,36 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
-/**
- * Event representing an order being paid at Vatly.
- */
 class OrderPaid
 {
     public const VATLY_EVENT_NAME = 'order.paid';
 
-    public function __construct(
-        public readonly string $customerId,
-        public readonly string $orderId,
-        public readonly int $total,
-        public readonly string $currency,
-        public readonly ?string $invoiceNumber,
-        public readonly ?string $paymentMethod,
-    ) {
-        //
+    public string $customerId;
+    public string $orderId;
+    public int $total;
+    public string $currency;
+    public ?string $invoiceNumber;
+    public ?string $paymentMethod;
+
+    public function __construct(string $customerId, string $orderId, int $total, string $currency, ?string $invoiceNumber, ?string $paymentMethod)
+    {
+        $this->customerId = $customerId;
+        $this->orderId = $orderId;
+        $this->total = $total;
+        $this->currency = $currency;
+        $this->invoiceNumber = $invoiceNumber;
+        $this->paymentMethod = $paymentMethod;
     }
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
-            orderId: $webhook->resourceId,
-            total: $webhook->object['data']['total'],
-            currency: $webhook->object['data']['currency'],
-            invoiceNumber: $webhook->object['data']['invoiceNumber'] ?? null,
-            paymentMethod: $webhook->object['data']['paymentMethod'] ?? null,
+            $webhook->object['data']['customerId'],
+            $webhook->resourceId,
+            $webhook->object['data']['total'],
+            $webhook->object['data']['currency'],
+            $webhook->object['data']['invoiceNumber'] ?? null,
+            $webhook->object['data']['paymentMethod'] ?? null
         );
     }
 }

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -4,25 +4,24 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
-/**
- * Event representing a subscription being canceled immediately at Vatly.
- */
 class SubscriptionCanceledImmediately
 {
     public const VATLY_EVENT_NAME = 'subscription.canceled_immediately';
 
-    public function __construct(
-        public readonly string $customerId,
-        public readonly string $subscriptionId,
-    ) {
-        //
+    public string $customerId;
+    public string $subscriptionId;
+
+    public function __construct(string $customerId, string $subscriptionId)
+    {
+        $this->customerId = $customerId;
+        $this->subscriptionId = $subscriptionId;
     }
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
-            subscriptionId: $webhook->resourceId,
+            $webhook->object['data']['customerId'],
+            $webhook->resourceId
         );
     }
 }

--- a/src/Events/SubscriptionCanceledWithGracePeriod.php
+++ b/src/Events/SubscriptionCanceledWithGracePeriod.php
@@ -7,27 +7,27 @@ namespace Vatly\Fluent\Events;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-/**
- * Event representing a subscription being canceled with a grace period at Vatly.
- */
 class SubscriptionCanceledWithGracePeriod
 {
     public const VATLY_EVENT_NAME = 'subscription.canceled_with_grace_period';
 
-    public function __construct(
-        public readonly string $customerId,
-        public readonly string $subscriptionId,
-        public readonly DateTimeInterface $endsAt,
-    ) {
-        //
+    public string $customerId;
+    public string $subscriptionId;
+    public DateTimeInterface $endsAt;
+
+    public function __construct(string $customerId, string $subscriptionId, DateTimeInterface $endsAt)
+    {
+        $this->customerId = $customerId;
+        $this->subscriptionId = $subscriptionId;
+        $this->endsAt = $endsAt;
     }
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
-            subscriptionId: $webhook->resourceId,
-            endsAt: new DateTimeImmutable($webhook->object['data']['endsAt']),
+            $webhook->object['data']['customerId'],
+            $webhook->resourceId,
+            new DateTimeImmutable($webhook->object['data']['endsAt'])
         );
     }
 }

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -13,26 +13,38 @@ class SubscriptionStarted
 
     public const DEFAULT_TYPE = 'default';
 
+    public string $customerId;
+    public string $subscriptionId;
+    public string $planId;
+    public string $type;
+    public string $name;
+    public int $quantity;
+
     public function __construct(
-        public readonly string $customerId,
-        public readonly string $subscriptionId,
-        public readonly string $planId,
-        public readonly string $type,
-        public readonly string $name,
-        public readonly int $quantity,
+        string $customerId,
+        string $subscriptionId,
+        string $planId,
+        string $type,
+        string $name,
+        int $quantity
     ) {
-        //
+        $this->customerId = $customerId;
+        $this->subscriptionId = $subscriptionId;
+        $this->planId = $planId;
+        $this->type = $type;
+        $this->name = $name;
+        $this->quantity = $quantity;
     }
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
-            subscriptionId: $webhook->resourceId,
-            planId: $webhook->object['data']['subscriptionPlanId'],
-            type: self::DEFAULT_TYPE,
-            name: $webhook->object['data']['name'],
-            quantity: $webhook->object['data']['quantity'],
+            $webhook->object['data']['customerId'],
+            $webhook->resourceId,
+            $webhook->object['data']['subscriptionPlanId'],
+            self::DEFAULT_TYPE,
+            $webhook->object['data']['name'],
+            $webhook->object['data']['quantity']
         );
     }
 }

--- a/src/Events/UnsupportedWebhookReceived.php
+++ b/src/Events/UnsupportedWebhookReceived.php
@@ -4,34 +4,38 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
-/**
- * Event representing an unsupported/unknown webhook event from Vatly.
- */
 class UnsupportedWebhookReceived
 {
+    public string $eventName;
+    public string $resourceId;
+    public string $resourceName;
+    /** @var array<string, mixed> */
+    public array $object;
+    public string $raisedAt;
+    public bool $testmode;
+
     /**
      * @param array<string, mixed> $object
      */
-    public function __construct(
-        public readonly string $eventName,
-        public readonly string $resourceId,
-        public readonly string $resourceName,
-        public readonly array $object,
-        public readonly string $raisedAt,
-        public readonly bool $testmode,
-    ) {
-        //
+    public function __construct(string $eventName, string $resourceId, string $resourceName, array $object, string $raisedAt, bool $testmode)
+    {
+        $this->eventName = $eventName;
+        $this->resourceId = $resourceId;
+        $this->resourceName = $resourceName;
+        $this->object = $object;
+        $this->raisedAt = $raisedAt;
+        $this->testmode = $testmode;
     }
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            eventName: $webhook->eventName,
-            resourceId: $webhook->resourceId,
-            resourceName: $webhook->resourceName,
-            object: $webhook->object,
-            raisedAt: $webhook->raisedAt,
-            testmode: $webhook->testmode,
+            $webhook->eventName,
+            $webhook->resourceId,
+            $webhook->resourceName,
+            $webhook->object,
+            $webhook->raisedAt,
+            $webhook->testmode
         );
     }
 }

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -9,18 +9,31 @@ namespace Vatly\Fluent\Events;
  */
 class WebhookReceived
 {
+    public string $eventName;
+    public string $resourceId;
+    public string $resourceName;
+    /** @var array<string, mixed> */
+    public array $object;
+    public string $raisedAt;
+    public bool $testmode;
+
     /**
      * @param array<string, mixed> $object
      */
     public function __construct(
-        public readonly string $eventName,
-        public readonly string $resourceId,
-        public readonly string $resourceName,
-        public readonly array $object,
-        public readonly string $raisedAt,
-        public readonly bool $testmode,
+        string $eventName,
+        string $resourceId,
+        string $resourceName,
+        array $object,
+        string $raisedAt,
+        bool $testmode
     ) {
-        //
+        $this->eventName = $eventName;
+        $this->resourceId = $resourceId;
+        $this->resourceName = $resourceName;
+        $this->object = $object;
+        $this->raisedAt = $raisedAt;
+        $this->testmode = $testmode;
     }
 
     /**
@@ -38,9 +51,6 @@ class WebhookReceived
         ];
     }
 
-    /**
-     * Get the customer ID from the webhook payload, if present.
-     */
     public function getCustomerId(): ?string
     {
         return $this->object['data']['customerId'] ?? null;

--- a/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
+++ b/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
@@ -13,9 +13,12 @@ use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
 
 class CancelSubscriptionOnCanceled implements WebhookReactionInterface
 {
-    public function __construct(
-        private readonly SubscriptionRepositoryInterface $subscriptions,
-    ) {}
+    private SubscriptionRepositoryInterface $subscriptions;
+
+    public function __construct(SubscriptionRepositoryInterface $subscriptions)
+    {
+        $this->subscriptions = $subscriptions;
+    }
 
     public function supports(object $event): bool
     {
@@ -25,11 +28,13 @@ class CancelSubscriptionOnCanceled implements WebhookReactionInterface
 
     public function handle(object $event): void
     {
-        $subscriptionId = match (true) {
-            $event instanceof SubscriptionCanceledImmediately => $event->subscriptionId,
-            $event instanceof SubscriptionCanceledWithGracePeriod => $event->subscriptionId,
-            default => throw new \InvalidArgumentException('Unsupported event type'),
-        };
+        if ($event instanceof SubscriptionCanceledImmediately) {
+            $subscriptionId = $event->subscriptionId;
+        } elseif ($event instanceof SubscriptionCanceledWithGracePeriod) {
+            $subscriptionId = $event->subscriptionId;
+        } else {
+            throw new \InvalidArgumentException('Unsupported event type');
+        }
 
         $subscription = $this->subscriptions->findByVatlyId($subscriptionId);
 
@@ -37,11 +42,13 @@ class CancelSubscriptionOnCanceled implements WebhookReactionInterface
             return;
         }
 
-        $endsAt = match (true) {
-            $event instanceof SubscriptionCanceledImmediately => new DateTimeImmutable(),
-            $event instanceof SubscriptionCanceledWithGracePeriod => $event->endsAt,
-            default => throw new \InvalidArgumentException('Unsupported event type'),
-        };
+        if ($event instanceof SubscriptionCanceledImmediately) {
+            $endsAt = new DateTimeImmutable();
+        } elseif ($event instanceof SubscriptionCanceledWithGracePeriod) {
+            $endsAt = $event->endsAt;
+        } else {
+            throw new \InvalidArgumentException('Unsupported event type');
+        }
 
         $this->subscriptions->update($subscription, new UpdateSubscriptionData(
             endsAt: $endsAt,

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -12,9 +12,12 @@ use Vatly\Fluent\Events\OrderPaid;
 
 class StoreOrderOnPaid implements WebhookReactionInterface
 {
-    public function __construct(
-        private readonly OrderRepositoryInterface $orders,
-    ) {}
+    private OrderRepositoryInterface $orders;
+
+    public function __construct(OrderRepositoryInterface $orders)
+    {
+        $this->orders = $orders;
+    }
 
     public function supports(object $event): bool
     {

--- a/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
+++ b/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
@@ -14,10 +14,15 @@ use Vatly\Fluent\Events\SubscriptionStarted;
 
 class SyncSubscriptionOnStarted implements WebhookReactionInterface
 {
-    public function __construct(
-        private readonly SubscriptionRepositoryInterface $subscriptions,
-        private readonly EventDispatcherInterface $dispatcher,
-    ) {}
+    private SubscriptionRepositoryInterface $subscriptions;
+
+    private EventDispatcherInterface $dispatcher;
+
+    public function __construct(SubscriptionRepositoryInterface $subscriptions, EventDispatcherInterface $dispatcher)
+    {
+        $this->subscriptions = $subscriptions;
+        $this->dispatcher = $dispatcher;
+    }
 
     public function supports(object $event): bool
     {

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -20,13 +20,18 @@ class WebhookEventFactory
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
-        return match ($webhook->eventName) {
-            SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromWebhook($webhook),
-            SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
-            SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
-            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromWebhook($webhook),
-            default => UnsupportedWebhookReceived::fromWebhook($webhook),
-        };
+        switch ($webhook->eventName) {
+            case SubscriptionStarted::VATLY_EVENT_NAME:
+                return SubscriptionStarted::fromWebhook($webhook);
+            case SubscriptionCanceledImmediately::VATLY_EVENT_NAME:
+                return SubscriptionCanceledImmediately::fromWebhook($webhook);
+            case SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME:
+                return SubscriptionCanceledWithGracePeriod::fromWebhook($webhook);
+            case OrderPaid::VATLY_EVENT_NAME:
+                return OrderPaid::fromWebhook($webhook);
+            default:
+                return UnsupportedWebhookReceived::fromWebhook($webhook);
+        }
     }
 
     /**
@@ -37,18 +42,16 @@ class WebhookEventFactory
     public function parsePayload(array $payload): WebhookReceived
     {
         return new WebhookReceived(
-            eventName: $payload['eventName'] ?? '',
-            resourceId: $payload['resourceId'] ?? '',
-            resourceName: $payload['resourceName'] ?? '',
-            object: $payload['object'] ?? [],
-            raisedAt: $payload['raisedAt'] ?? '',
-            testmode: $payload['testmode'] ?? false,
+            $payload['eventName'] ?? '',
+            $payload['resourceId'] ?? '',
+            $payload['resourceName'] ?? '',
+            $payload['object'] ?? [],
+            $payload['raisedAt'] ?? '',
+            $payload['testmode'] ?? false
         );
     }
 
     /**
-     * Get the list of supported event names.
-     *
      * @return array<string>
      */
     public function getSupportedEvents(): array
@@ -61,9 +64,6 @@ class WebhookEventFactory
         ];
     }
 
-    /**
-     * Check if an event name is supported.
-     */
     public function isSupported(string $eventName): bool
     {
         return in_array($eventName, $this->getSupportedEvents(), true);

--- a/src/Webhooks/WebhookProcessor.php
+++ b/src/Webhooks/WebhookProcessor.php
@@ -11,28 +11,35 @@ use Vatly\Fluent\Contracts\WebhookReactionInterface;
 
 class WebhookProcessor
 {
+    private SignatureVerifier $signatureVerifier;
+    private WebhookEventFactory $eventFactory;
+    private WebhookCallRepositoryInterface $repository;
+    private EventDispatcherInterface $dispatcher;
+    private string $webhookSecret;
+
+    /** @var WebhookReactionInterface[] */
+    private array $reactions;
+
     /**
      * @param  WebhookReactionInterface[]  $reactions
      */
     public function __construct(
-        private readonly SignatureVerifier $signatureVerifier,
-        private readonly WebhookEventFactory $eventFactory,
-        private readonly WebhookCallRepositoryInterface $repository,
-        private readonly EventDispatcherInterface $dispatcher,
-        private readonly string $webhookSecret,
-        private readonly array $reactions = [],
+        SignatureVerifier $signatureVerifier,
+        WebhookEventFactory $eventFactory,
+        WebhookCallRepositoryInterface $repository,
+        EventDispatcherInterface $dispatcher,
+        string $webhookSecret,
+        array $reactions = []
     ) {
-        //
+        $this->signatureVerifier = $signatureVerifier;
+        $this->eventFactory = $eventFactory;
+        $this->repository = $repository;
+        $this->dispatcher = $dispatcher;
+        $this->webhookSecret = $webhookSecret;
+        $this->reactions = $reactions;
     }
 
     /**
-     * Handle an incoming webhook request.
-     *
-     * Flow: verify → parse → store → react → dispatch
-     *
-     * Reactions handle core billing logic (storing orders, syncing subscriptions).
-     * The dispatcher fires the event for framework-specific listeners (emails, etc).
-     *
      * @throws \Vatly\Fluent\Exceptions\InvalidWebhookSignatureException
      */
     public function handle(string $payload, string $signature): void
@@ -40,7 +47,6 @@ class WebhookProcessor
         $this->signatureVerifier->verify($signature, $payload, $this->webhookSecret);
 
         $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
-
         $webhook = $this->eventFactory->parsePayload($decoded);
 
         $this->repository->record(


### PR DESCRIPTION
## Summary
- lower the package PHP constraint to ^8.0
- replace PHP 8.1-only syntax with PHP 8.0-compatible equivalents
- downgrade PHPUnit/PHPStan dev tooling and align phpunit.xml with PHPUnit 9

## Testing
- composer test