### PR TITLE
chore: drop PHP 8.0 floor, sync OpenAPI changes, refresh README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -19,42 +19,47 @@ composer require vatly/vatly-fluent-php
 This package follows semantic versioning. During alpha, pin to exact versions if you need stability:
 
 ```bash
-composer require vatly/vatly-fluent-php:v0.3.0-alpha.2
+composer require vatly/vatly-fluent-php:v0.4.0-alpha.1
 ```
 
 ## Requirements
 
-- PHP 8.2+
+- PHP 8.0+
 - A Vatly API key ([vatly.com](https://vatly.com))
 
 ## What's included
 
+- **`Vatly` facade:** single entry point that lazy-instantiates actions and exposes the API client, signature verifier, and webhook event factory
 - **Actions:** CreateCheckout, CreateCustomer, GetCheckout, GetCustomer, GetSubscription, GetPaymentMethodUpdateUrl, CancelSubscription, SwapSubscriptionPlan
-- **Webhook handling:** Signature verification, event factory, typed event objects
-- **Contracts:** BillableInterface, repository interfaces for framework integration
-- **Responses:** Typed response objects for all actions
+- **Builders:** framework-agnostic `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`
+- **Webhook handling:** signature verification, event factory, typed event objects (`OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, etc.), and a `WebhookProcessor` that dispatches built-in reactions (sync subscription, store order, cancel subscription) plus your own
+- **Contracts:** `BillableInterface`, repository interfaces (`SubscriptionRepositoryInterface`, `OrderRepositoryInterface`, `CustomerRepositoryInterface`, `WebhookCallRepositoryInterface`), `EventDispatcherInterface`, `ConfigurationInterface` for framework integration
+- **Data DTOs:** immutable inputs for repository store/update operations (`StoreOrderData`, `StoreSubscriptionData`, `UpdateOrderData`, `UpdateSubscriptionData`)
+
+Actions return raw `Vatly\API\Resources\*` objects from the underlying [vatly-api-php](https://github.com/Vatly/vatly-api-php) client — there is no separate response wrapper layer.
 
 ## Usage
 
 ```php
-use Vatly\API\VatlyApiClient;
-use Vatly\Fluent\Actions\CreateCheckout;
+use Vatly\Fluent\Vatly;
 
-$client = new VatlyApiClient();
-$client->setApiKey('test_xxxxxxxxxxxx');
+$vatly = new Vatly('test_xxxxxxxxxxxx');
 
-$checkout = new CreateCheckout($client);
-$response = $checkout->execute([
-    'products' => ['subscription_plan_id'],
+$checkout = $vatly->createCheckout()->execute([
+    'products' => [
+        ['id' => 'subscription_plan_id', 'quantity' => 1],
+    ],
     'customerId' => 'cust_xxx',
     'redirectUrlSuccess' => 'https://example.com/success',
     'redirectUrlCanceled' => 'https://example.com/canceled',
 ]);
 ```
 
+`$checkout` is a `Vatly\API\Resources\Checkout` — see [vatly-api-php](https://github.com/Vatly/vatly-api-php) for the full resource shape.
+
 ## For framework integrations
 
-If you're using Laravel, see [vatly/vatly-laravel](https://github.com/Vatly/vatly-laravel) which provides Eloquent models, traits, builders, and event listeners on top of this package.
+If you're using Laravel, see [vatly/vatly-laravel](https://github.com/Vatly/vatly-laravel). It provides Eloquent models, a `Billable` trait, Eloquent-aware repositories (implementations of the contracts above), Laravel-flavoured builders (driven by `Illuminate\Database\Eloquent\Model` and `Collection`), an event-bus bridge, and a webhook controller — all on top of this package.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.0",
         "vatly/vatly-api-php": "^0.1.0-alpha.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheDirectory=".phpunit.cache"
+         cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
@@ -13,9 +13,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <source>
+    <coverage>
         <include>
             <directory>src</directory>
         </include>
-    </source>
+    </coverage>
 </phpunit>

--- a/src/Actions/BaseAction.php
+++ b/src/Actions/BaseAction.php
@@ -9,7 +9,8 @@ use Vatly\API\VatlyApiClient;
 abstract class BaseAction
 {
     public function __construct(
-        protected readonly VatlyApiClient $vatlyApiClient,
+        /** @readonly */
+        protected VatlyApiClient $vatlyApiClient,
     ) {
         //
     }

--- a/src/Builders/CheckoutBuilder.php
+++ b/src/Builders/CheckoutBuilder.php
@@ -25,8 +25,10 @@ class CheckoutBuilder
     protected array $items = [];
 
     public function __construct(
+        /** @readonly */
         protected BillableInterface $owner,
-        protected readonly CreateCheckout $createCheckout,
+        /** @readonly */
+        protected CreateCheckout $createCheckout,
     ) {
         //
     }

--- a/src/Builders/SubscriptionBuilder.php
+++ b/src/Builders/SubscriptionBuilder.php
@@ -22,8 +22,11 @@ class SubscriptionBuilder
     protected string $redirectUrlCanceled = '';
 
     public function __construct(
-        protected readonly ConfigurationInterface $config,
+        /** @readonly */
+        protected ConfigurationInterface $config,
+        /** @readonly */
         protected BillableInterface $owner,
+        /** @readonly */
         protected CheckoutBuilder $checkoutBuilder,
     ) {
         $this->redirectUrlSuccess = $this->config->getDefaultRedirectUrlSuccess();

--- a/src/Data/StoreOrderData.php
+++ b/src/Data/StoreOrderData.php
@@ -6,8 +6,10 @@ namespace Vatly\Fluent\Data;
 
 /**
  * Data for storing a new order from Vatly.
+ *
+ * @immutable
  */
-readonly class StoreOrderData
+class StoreOrderData
 {
     public function __construct(
         public string $vatlyId,

--- a/src/Data/StoreSubscriptionData.php
+++ b/src/Data/StoreSubscriptionData.php
@@ -6,8 +6,10 @@ namespace Vatly\Fluent\Data;
 
 /**
  * Data for storing a new subscription from Vatly.
+ *
+ * @immutable
  */
-readonly class StoreSubscriptionData
+class StoreSubscriptionData
 {
     public function __construct(
         public string $vatlyId,

--- a/src/Data/UpdateOrderData.php
+++ b/src/Data/UpdateOrderData.php
@@ -6,8 +6,10 @@ namespace Vatly\Fluent\Data;
 
 /**
  * Data for updating an existing order from Vatly.
+ *
+ * @immutable
  */
-readonly class UpdateOrderData
+class UpdateOrderData
 {
     public function __construct(
         public ?string $status = null,

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -8,8 +8,10 @@ use DateTimeInterface;
 
 /**
  * Data for updating an existing subscription from Vatly.
+ *
+ * @immutable
  */
-readonly class UpdateSubscriptionData
+class UpdateSubscriptionData
 {
     public function __construct(
         public ?string $planId = null,

--- a/src/Events/LocalSubscriptionCreated.php
+++ b/src/Events/LocalSubscriptionCreated.php
@@ -10,11 +10,13 @@ use Vatly\Fluent\Contracts\SubscriptionInterface;
  * Event dispatched when a local subscription record is created.
  *
  * This is an application-level event (vs webhook events from Vatly).
+ *
+ * @immutable
  */
 class LocalSubscriptionCreated
 {
     public function __construct(
-        public readonly SubscriptionInterface $subscription,
+        public SubscriptionInterface $subscription,
     ) {
         //
     }

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -6,18 +6,20 @@ namespace Vatly\Fluent\Events;
 
 /**
  * Event representing an order being paid at Vatly.
+ *
+ * @immutable
  */
 class OrderPaid
 {
     public const VATLY_EVENT_NAME = 'order.paid';
 
     public function __construct(
-        public readonly string $customerId,
-        public readonly string $orderId,
-        public readonly int $total,
-        public readonly string $currency,
-        public readonly ?string $invoiceNumber,
-        public readonly ?string $paymentMethod,
+        public string $customerId,
+        public string $orderId,
+        public int $total,
+        public string $currency,
+        public ?string $invoiceNumber,
+        public ?string $paymentMethod,
     ) {
         //
     }

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -6,14 +6,16 @@ namespace Vatly\Fluent\Events;
 
 /**
  * Event representing a subscription being canceled immediately at Vatly.
+ *
+ * @immutable
  */
 class SubscriptionCanceledImmediately
 {
     public const VATLY_EVENT_NAME = 'subscription.canceled_immediately';
 
     public function __construct(
-        public readonly string $customerId,
-        public readonly string $subscriptionId,
+        public string $customerId,
+        public string $subscriptionId,
     ) {
         //
     }

--- a/src/Events/SubscriptionCanceledWithGracePeriod.php
+++ b/src/Events/SubscriptionCanceledWithGracePeriod.php
@@ -9,15 +9,17 @@ use DateTimeInterface;
 
 /**
  * Event representing a subscription being canceled with a grace period at Vatly.
+ *
+ * @immutable
  */
 class SubscriptionCanceledWithGracePeriod
 {
     public const VATLY_EVENT_NAME = 'subscription.canceled_with_grace_period';
 
     public function __construct(
-        public readonly string $customerId,
-        public readonly string $subscriptionId,
-        public readonly DateTimeInterface $endsAt,
+        public string $customerId,
+        public string $subscriptionId,
+        public DateTimeInterface $endsAt,
     ) {
         //
     }

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -6,6 +6,8 @@ namespace Vatly\Fluent\Events;
 
 /**
  * Event representing a subscription being started at Vatly.
+ *
+ * @immutable
  */
 class SubscriptionStarted
 {
@@ -14,12 +16,12 @@ class SubscriptionStarted
     public const DEFAULT_TYPE = 'default';
 
     public function __construct(
-        public readonly string $customerId,
-        public readonly string $subscriptionId,
-        public readonly string $planId,
-        public readonly string $type,
-        public readonly string $name,
-        public readonly int $quantity,
+        public string $customerId,
+        public string $subscriptionId,
+        public string $planId,
+        public string $type,
+        public string $name,
+        public int $quantity,
     ) {
         //
     }

--- a/src/Events/UnsupportedWebhookReceived.php
+++ b/src/Events/UnsupportedWebhookReceived.php
@@ -6,6 +6,8 @@ namespace Vatly\Fluent\Events;
 
 /**
  * Event representing an unsupported/unknown webhook event from Vatly.
+ *
+ * @immutable
  */
 class UnsupportedWebhookReceived
 {
@@ -13,12 +15,12 @@ class UnsupportedWebhookReceived
      * @param array<string, mixed> $object
      */
     public function __construct(
-        public readonly string $eventName,
-        public readonly string $resourceId,
-        public readonly string $resourceName,
-        public readonly array $object,
-        public readonly string $raisedAt,
-        public readonly bool $testmode,
+        public string $eventName,
+        public string $resourceId,
+        public string $resourceName,
+        public array $object,
+        public string $raisedAt,
+        public bool $testmode,
     ) {
         //
     }

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -6,6 +6,8 @@ namespace Vatly\Fluent\Events;
 
 /**
  * Event representing a raw webhook call received from Vatly.
+ *
+ * @immutable
  */
 class WebhookReceived
 {
@@ -13,12 +15,12 @@ class WebhookReceived
      * @param array<string, mixed> $object
      */
     public function __construct(
-        public readonly string $eventName,
-        public readonly string $resourceId,
-        public readonly string $resourceName,
-        public readonly array $object,
-        public readonly string $raisedAt,
-        public readonly bool $testmode,
+        public string $eventName,
+        public string $resourceId,
+        public string $resourceName,
+        public array $object,
+        public string $raisedAt,
+        public bool $testmode,
     ) {
         //
     }

--- a/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
+++ b/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
@@ -11,10 +11,13 @@ use Vatly\Fluent\Data\UpdateSubscriptionData;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
 
+/**
+ * @immutable
+ */
 class CancelSubscriptionOnCanceled implements WebhookReactionInterface
 {
     public function __construct(
-        private readonly SubscriptionRepositoryInterface $subscriptions,
+        private SubscriptionRepositoryInterface $subscriptions,
     ) {}
 
     public function supports(object $event): bool

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -10,10 +10,13 @@ use Vatly\Fluent\Data\StoreOrderData;
 use Vatly\Fluent\Data\UpdateOrderData;
 use Vatly\Fluent\Events\OrderPaid;
 
+/**
+ * @immutable
+ */
 class StoreOrderOnPaid implements WebhookReactionInterface
 {
     public function __construct(
-        private readonly OrderRepositoryInterface $orders,
+        private OrderRepositoryInterface $orders,
     ) {}
 
     public function supports(object $event): bool

--- a/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
+++ b/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
@@ -12,11 +12,14 @@ use Vatly\Fluent\Data\UpdateSubscriptionData;
 use Vatly\Fluent\Events\LocalSubscriptionCreated;
 use Vatly\Fluent\Events\SubscriptionStarted;
 
+/**
+ * @immutable
+ */
 class SyncSubscriptionOnStarted implements WebhookReactionInterface
 {
     public function __construct(
-        private readonly SubscriptionRepositoryInterface $subscriptions,
-        private readonly EventDispatcherInterface $dispatcher,
+        private SubscriptionRepositoryInterface $subscriptions,
+        private EventDispatcherInterface $dispatcher,
     ) {}
 
     public function supports(object $event): bool

--- a/src/Webhooks/WebhookProcessor.php
+++ b/src/Webhooks/WebhookProcessor.php
@@ -9,18 +9,21 @@ use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 
+/**
+ * @immutable
+ */
 class WebhookProcessor
 {
     /**
      * @param  WebhookReactionInterface[]  $reactions
      */
     public function __construct(
-        private readonly SignatureVerifier $signatureVerifier,
-        private readonly WebhookEventFactory $eventFactory,
-        private readonly WebhookCallRepositoryInterface $repository,
-        private readonly EventDispatcherInterface $dispatcher,
-        private readonly string $webhookSecret,
-        private readonly array $reactions = [],
+        private SignatureVerifier $signatureVerifier,
+        private WebhookEventFactory $eventFactory,
+        private WebhookCallRepositoryInterface $repository,
+        private EventDispatcherInterface $dispatcher,
+        private string $webhookSecret,
+        private array $reactions = [],
     ) {
         //
     }

--- a/tests/Builders/CheckoutBuilderTest.php
+++ b/tests/Builders/CheckoutBuilderTest.php
@@ -214,7 +214,6 @@ class CheckoutBuilderTest extends TestCase
                 $checkout->id = 'chk_test_123';
                 $checkout->status = 'created';
                 $checkout->testmode = false;
-                $checkout->merchantId = 'merchant_test';
                 $checkout->redirectUrlSuccess = 'https://example.com/success';
                 $checkout->redirectUrlCanceled = 'https://example.com/canceled';
 

--- a/tests/Builders/SubscriptionBuilderTest.php
+++ b/tests/Builders/SubscriptionBuilderTest.php
@@ -208,7 +208,6 @@ class SubscriptionBuilderTest extends TestCase
                 $checkout->id = 'chk_sub_123';
                 $checkout->status = 'created';
                 $checkout->testmode = false;
-                $checkout->merchantId = 'merchant_test';
                 $checkout->redirectUrlSuccess = 'https://example.com/success';
                 $checkout->redirectUrlCanceled = 'https://example.com/canceled';
 


### PR DESCRIPTION
## Summary

Three coordinated changes batched so they ship together in one alpha bump.

### 1. PHP 8.0 support

- `composer.json`: `php` constraint `^8.2` → `^8.0`
- `phpunit/phpunit`: `^11.0` → `^9.6` (last line supporting 8.0)
- `phpunit.xml` adjusted to the PHPUnit 9 schema (`cacheResultFile`, `<coverage>`)
- All `readonly` properties / classes removed (8.1 / 8.2 features). Immutability is now expressed via PHPDoc and enforced by PHPStan:
  - **`@immutable`** on classes with only constructor state (`Data/*`, `Events/*`, `WebhookProcessor`, `Webhooks/Reactions/*`, `BaseAction`)
  - **Inline `/** @readonly */`** on individual promoted params in classes with mixed mutable state (`CheckoutBuilder`, `SubscriptionBuilder`)
  - Verified PHPStan flags mutations as `property.readOnlyByPhpDocAssignOutOfClass`

(Supersedes the earlier closed #14.)

### 2. OpenAPI sync follow-up

The upstream [vatly/vatly-api-php#13](https://github.com/vatly/vatly-api-php/pull/13) removes `merchantId` from `Vatly\API\Resources\Checkout`. The mock factories in `CheckoutBuilderTest` / `SubscriptionBuilderTest` were writing `$checkout->merchantId = 'merchant_test'`; these were unreachable in the actual test path but are now stale references and have been removed.

### 3. README audit

While verifying the package contents I found several stale claims that have been corrected:

- PHP version line and pin example
- **\"Typed response objects for all actions\"** — incorrect. Actions return raw `Vatly\API\Resources\*` objects; no response wrapper layer exists. Removed.
- **\"What's included\"** was missing: the `Vatly` facade, Builders, Webhook Reactions, Data DTOs. Added.
- Usage example rewritten to use the `Vatly` facade (the intended entry point) and to use the correct `products` payload shape (`[['id' => ..., 'quantity' => ...]]`)
- Framework-integrations note clarified: both packages have builders, Laravel's are Eloquent-aware variants

## Test plan

- [x] `composer test` — 92/92 passing
- [x] `composer analyse` — only pre-existing `instanceof.alwaysTrue` in `Webhooks/Reactions/CancelSubscriptionOnCanceled.php`
- [x] PHPStan confirmed to enforce both `@immutable` and inline `@readonly` (manual mutation test)
- [ ] CI to confirm tests pass under PHP 8.0, 8.1, 8.2, 8.3, 8.4 (depends on the workflow matrix)
