### PR TITLE
Reposition as shared driver internals + add WebhookProcessorFactory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,179 @@
+# Contributing & Driver Author Guide
+
+This package is the shared core that powers framework-specific Vatly drivers. Most readers want one of two things:
+
+- **Building a driver** for a framework that isn't covered yet (Symfony, WordPress, etc.) → start at [Building a driver](#building-a-driver).
+- **Contributing to this package itself** (bug fix, new contract, new reaction) → jump to [Working on this package](#working-on-this-package).
+
+If you're an application developer looking to use Vatly, you almost certainly want a driver, not this package directly. See the [README](README.md#looking-for-a-vatly-integration) for the list.
+
+## Architecture
+
+A driver is the framework-specific layer that fills in the abstractions this package defines. Concretely:
+
+| Concern | Lives in fluent | Lives in the driver |
+| --- | --- | --- |
+| Webhook signature, parsing, reactions, dispatch | ✅ | — |
+| Typed events (`OrderPaid`, `SubscriptionStarted`, …) | ✅ | — |
+| Action wrappers around the raw API SDK | ✅ | — |
+| Repository **contracts** (subscription, order, customer, webhook call) | ✅ | — |
+| Repository **implementations** (Eloquent / Doctrine / WP `$wpdb` / …) | — | ✅ |
+| `BillableInterface` implementation on a User/Tenant entity | — | ✅ |
+| Configuration source (env, `config()`, framework config) | — | ✅ |
+| Event dispatcher bridge | — | ✅ |
+| HTTP route for the webhook endpoint | — | ✅ |
+| DI / service container wiring | — | ✅ |
+
+The reference driver is [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — read its `VatlyServiceProvider` for a concrete wiring example.
+
+## Building a driver
+
+### 1. The contracts you must implement
+
+All under `Vatly\Fluent\Contracts\`:
+
+- **`BillableInterface`** — represents a customer entity (your User, Tenant, etc.). Methods: `getVatlyId()`, `setVatlyId()`, `hasVatlyId()`, `getVatlyEmail()`, `getVatlyName()`, `getKey()`, `save()`.
+- **`ConfigurationInterface`** — exposes API credentials and defaults. Methods: `getApiKey()`, `getApiUrl()`, `getApiVersion()`, `getWebhookSecret()`, `isTestmode()`, `getDefaultRedirectUrlSuccess()`, `getDefaultRedirectUrlCanceled()`, `getBillableModel()`.
+- **`SubscriptionRepositoryInterface`** — `findByVatlyId()`, `findByOwnerAndType()`, `findAllByOwner()`, `ownerHasActiveSubscription()`, `store(StoreSubscriptionData)`, `update(SubscriptionInterface, UpdateSubscriptionData)`.
+- **`CustomerRepositoryInterface`** — `findByVatlyId()`, `findByVatlyIdOrFail()`, `save(BillableInterface)`.
+- **`OrderRepositoryInterface`** — `findByVatlyId()`, `findAllByOwner()`, `store(StoreOrderData)`, `update(OrderInterface, UpdateOrderData)`.
+- **`WebhookCallRepositoryInterface`** — `record(…)` (audit log), `cleanUp(int $days)`.
+- **`EventDispatcherInterface`** — single method `dispatch(object $event)`. Bridge to your framework's event bus or PSR-14.
+
+Your driver also needs concrete `SubscriptionInterface` and `OrderInterface` implementations (typically your ORM models).
+
+### 2. The wiring sequence
+
+In your driver's bootstrap (`ServiceProvider`, bundle config, plugin init), wire in this order:
+
+1. Bind your `ConfigurationInterface` implementation.
+2. Construct a `Vatly\API\VatlyApiClient` and configure it from your `ConfigurationInterface`.
+3. Bind your repository implementations to the four repository contracts.
+4. Bind your event dispatcher implementation to `EventDispatcherInterface`.
+5. Build a `WebhookProcessor`. The easiest path is `WebhookProcessorFactory::create()`, which wires the standard reactions for you:
+
+```php
+use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
+
+$processor = WebhookProcessorFactory::create(
+    config: $config,
+    subscriptions: $subscriptionRepository,
+    orders: $orderRepository,
+    webhookCalls: $webhookCallRepository,
+    dispatcher: $eventDispatcher,
+    additionalReactions: [
+        // Optional custom reactions implementing WebhookReactionInterface
+    ],
+);
+```
+
+If you need to swap out the `SignatureVerifier` or `WebhookEventFactory`, construct `WebhookProcessor` directly:
+
+```php
+use Vatly\Fluent\Webhooks\WebhookProcessor;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+
+new WebhookProcessor(
+    signatureVerifier: $signatureVerifier,
+    eventFactory: $eventFactory,
+    repository: $webhookCallRepository,
+    dispatcher: $eventDispatcher,
+    webhookSecret: $config->getWebhookSecret() ?? '',
+    reactions: [
+        new SyncSubscriptionOnStarted($subscriptionRepository, $eventDispatcher),
+        new CancelSubscriptionOnCanceled($subscriptionRepository),
+        new StoreOrderOnPaid($orderRepository),
+    ],
+);
+```
+
+### 3. The webhook endpoint
+
+Expose a single POST route in your framework. In the handler:
+
+```php
+try {
+    $processor->handle(
+        payload: $request->getRawBody(),       // raw, not deserialized
+        signature: $request->getHeader('X-Vatly-Signature') ?? '',
+    );
+    return new Response(status: 201);
+} catch (InvalidWebhookSignatureException) {
+    return new Response(status: 403);
+}
+```
+
+Return `2xx` on success, `403` on signature mismatch. Anything else and Vatly will retry.
+
+### 4. Application-facing ergonomics
+
+Drivers typically add framework-idiomatic ergonomics on top:
+
+- **Trait / base class** so an application's User entity gets `$user->subscription('default')->cancel()`-style methods. (Laravel's `Billable` trait composes `Manages*` concerns.) This is intentionally **not** in fluent — each framework's idioms differ enough that a shared trait would be a poor fit.
+- **Builders** for checkouts/subscriptions that work in the framework's types. Fluent ships generic builders driven by `BillableInterface` — you may wrap or extend them.
+- **Audit/admin views, console commands, fakes** — purely driver-level.
+
+### 5. Listing your driver
+
+Once your driver is on Packagist and has tests + a README, open a PR against this repo's `README.md` adding it to the "Looking for a Vatly integration?" table.
+
+## Working on this package
+
+### Local setup
+
+```bash
+git clone https://github.com/Vatly/vatly-fluent-php.git
+cd vatly-fluent-php
+composer install
+composer test
+composer analyse
+```
+
+Tests are PHPUnit + Mockery, fully isolated — no framework or HTTP needed. The base `TestCase` extends `PHPUnit\Framework\TestCase` and uses `MockeryPHPUnitIntegration` for cleanup.
+
+### Design principles
+
+- **Zero framework imports.** No `use Illuminate\…` or `use Symfony\…` under `src/`. Drivers depend on us; we never depend on them.
+- **Stateless domain logic.** Reactions, builders, the processor — none of them hold state. State lives in the repository implementations the driver provides.
+- **Raw API resources.** Actions return `Vatly\API\Resources\*` directly. We deliberately don't add a response wrapper layer — that's a driver-level concern if needed at all.
+- **Immutable DTOs** for repository inputs (`StoreSubscriptionData`, `UpdateOrderData`, …).
+
+### PR process
+
+1. Branch off `main`.
+2. Add or update tests for the change.
+3. Run `composer test` and `composer analyse` locally.
+4. Open the PR. CI runs the same checks.
+
+## Planned consolidation (known follow-up)
+
+The Laravel driver currently carries some code that arguably belongs here:
+
+- **Duplicate builders** ([`vatly-laravel/src/Builders/`](https://github.com/Vatly/vatly-laravel/tree/main/src/Builders)) — Eloquent-flavoured `CheckoutBuilder` / `SubscriptionBuilder` that overlap with fluent's framework-agnostic versions. Open question whether the Eloquent/`Collection` signatures justify the duplication or whether fluent's builders can absorb the Laravel ergonomics behind the `BillableInterface` seam.
+- **`VatlyApiActions/*` wrapper layer** ([`vatly-laravel/src/VatlyApiActions/`](https://github.com/Vatly/vatly-laravel/tree/main/src/VatlyApiActions)) — Laravel-side actions that bypass fluent's actions and call the raw API client, returning local response DTOs. Fluent's stated design is "no response wrapper layer". Either fluent absorbs the response DTOs (and changes that stance) or the Laravel layer is dissolved and consumers use raw API resources. Decision pending.
+
+Both are breaking changes for Laravel consumers and will land in a dedicated alpha bump.
+
+### Coordinated release: adopt `WebhookProcessorFactory` in vatly-laravel
+
+`WebhookProcessorFactory` is new (additive). After the next fluent alpha release, [`vatly-laravel`](https://github.com/Vatly/vatly-laravel)'s `VatlyServiceProvider::registerWebhookProcessor()` should be migrated to:
+
+```php
+$this->app->singleton(WebhookProcessor::class, function () {
+    return WebhookProcessorFactory::create(
+        config: $this->app->make(ConfigurationInterface::class),
+        subscriptions: $this->app->make(SubscriptionRepositoryInterface::class),
+        orders: $this->app->make(OrderRepositoryInterface::class),
+        webhookCalls: $this->app->make(WebhookCallRepositoryInterface::class),
+        dispatcher: $this->app->make(EventDispatcherInterface::class),
+    );
+});
+```
+
+Track in a Laravel-side issue once the fluent release lands.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -6,39 +6,34 @@
 
 > **Alpha release -- under active development. Expect breaking changes.**
 
-Framework-agnostic fluent PHP SDK for [Vatly](https://vatly.com) billing. Wraps the [vatly-api-php](https://github.com/Vatly/vatly-api-php) client with expressive, action-based methods for managing subscriptions, checkouts, customers, and webhooks.
+Shared internals for [Vatly](https://vatly.com) framework drivers. This package is the framework-agnostic core that powers driver packages like [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — webhook processing, contracts, events, and DTOs that drivers reuse so they don't reimplement the same patterns.
 
-This package serves as the core logic layer, designed to be portable across PHP frameworks and as a reference for future language ports (JS, Python).
+## Looking for a Vatly integration?
 
-## Installation
+**Most users want a framework driver, not this package directly:**
 
-```bash
-composer require vatly/vatly-fluent-php
-```
+| Framework | Package |
+| --- | --- |
+| Laravel | [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) |
+| Symfony, WordPress, etc. | _Planned. Want to build one? See [CONTRIBUTING.md](CONTRIBUTING.md)._ |
+| No framework / raw API | [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) |
 
-This package follows semantic versioning. During alpha, pin to exact versions if you need stability:
+This package on its own doesn't persist anything, dispatch events, or read configuration — those concerns belong to a driver. You install it transitively through a driver.
 
-```bash
-composer require vatly/vatly-fluent-php:v0.4.0-alpha.1
-```
+## What's inside
 
-## Requirements
+Drivers wire these pieces into their framework's IoC container, ORM, event bus, and routing:
 
-- PHP 8.0+
-- A Vatly API key ([vatly.com](https://vatly.com))
+- **Contracts** ([src/Contracts](src/Contracts)): `BillableInterface`, `SubscriptionInterface`, `OrderInterface`, repository interfaces (`SubscriptionRepositoryInterface`, `CustomerRepositoryInterface`, `OrderRepositoryInterface`, `WebhookCallRepositoryInterface`), `EventDispatcherInterface`, `ConfigurationInterface`, `WebhookReactionInterface`.
+- **Webhook pipeline** ([src/Webhooks](src/Webhooks)): `WebhookProcessor` orchestrates signature verification → event parsing → audit logging → reactions → dispatch. Built-in reactions: `SyncSubscriptionOnStarted`, `StoreOrderOnPaid`, `CancelSubscriptionOnCanceled`.
+- **Events** ([src/Events](src/Events)): typed POPOs — `OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, `LocalSubscriptionCreated`, `WebhookReceived`, `UnsupportedWebhookReceived`.
+- **Actions** ([src/Actions](src/Actions)): thin wrappers around [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) — `CreateCheckout`, `CreateCustomer`, `GetCheckout`, `GetCustomer`, `GetSubscription`, `CreateSubscriptionBillingUpdateLink`, `CancelSubscription`, `SwapSubscriptionPlan`. Return raw `Vatly\API\Resources\*` objects.
+- **Builders** ([src/Builders](src/Builders)): `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`.
+- **Data DTOs** ([src/Data](src/Data)): immutable inputs for repository operations — `StoreOrderData`, `StoreSubscriptionData`, `UpdateOrderData`, `UpdateSubscriptionData`.
 
-## What's included
+## Direct usage (advanced)
 
-- **`Vatly` facade:** single entry point that lazy-instantiates actions and exposes the API client, signature verifier, and webhook event factory
-- **Actions:** CreateCheckout, CreateCustomer, GetCheckout, GetCustomer, GetSubscription, CreateSubscriptionBillingUpdateLink, CancelSubscription, SwapSubscriptionPlan
-- **Builders:** framework-agnostic `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`
-- **Webhook handling:** signature verification, event factory, typed event objects (`OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, etc.), and a `WebhookProcessor` that dispatches built-in reactions (sync subscription, store order, cancel subscription) plus your own
-- **Contracts:** `BillableInterface`, repository interfaces (`SubscriptionRepositoryInterface`, `OrderRepositoryInterface`, `CustomerRepositoryInterface`, `WebhookCallRepositoryInterface`), `EventDispatcherInterface`, `ConfigurationInterface` for framework integration
-- **Data DTOs:** immutable inputs for repository store/update operations (`StoreOrderData`, `StoreSubscriptionData`, `UpdateOrderData`, `UpdateSubscriptionData`)
-
-Actions return raw `Vatly\API\Resources\*` objects from the underlying [vatly-api-php](https://github.com/Vatly/vatly-api-php) client — there is no separate response wrapper layer.
-
-## Usage
+If you're not using a driver — for example a custom framework integration — you can wire this package up yourself. Start with the [Driver Author Guide](CONTRIBUTING.md), then use the `Vatly` entry point for read-only operations:
 
 ```php
 use Vatly\Fluent\Vatly;
@@ -46,26 +41,41 @@ use Vatly\Fluent\Vatly;
 $vatly = new Vatly('test_xxxxxxxxxxxx');
 
 $checkout = $vatly->createCheckout()->execute([
-    'products' => [
-        ['id' => 'subscription_plan_id', 'quantity' => 1],
-    ],
+    'products' => [['id' => 'plan_abc', 'quantity' => 1]],
     'customerId' => 'cust_xxx',
     'redirectUrlSuccess' => 'https://example.com/success',
     'redirectUrlCanceled' => 'https://example.com/canceled',
 ]);
 ```
 
-`$checkout` is a `Vatly\API\Resources\Checkout` — see [vatly-api-php](https://github.com/Vatly/vatly-api-php) for the full resource shape.
+For webhook handling, subscription sync, and anything stateful, you'll need to implement the repository contracts and wire a `WebhookProcessor` — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## For framework integrations
+## Requirements
 
-If you're using Laravel, see [vatly/vatly-laravel](https://github.com/Vatly/vatly-laravel). It provides Eloquent models, a `Billable` trait, Eloquent-aware repositories (implementations of the contracts above), Laravel-flavoured builders (driven by `Illuminate\Database\Eloquent\Model` and `Collection`), an event-bus bridge, and a webhook controller — all on top of this package.
+- PHP 8.0+
+- A Vatly API key ([vatly.com](https://vatly.com))
+
+## Installation
+
+```bash
+composer require vatly/vatly-fluent-php
+```
+
+Pin to an exact version during alpha:
+
+```bash
+composer require vatly/vatly-fluent-php:v0.4.0-alpha.3
+```
 
 ## Testing
 
 ```bash
 composer test
 ```
+
+## Contributing & building a driver
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contracts a driver implements, the wiring pattern, and the planned consolidation work.
 
 ## License
 

--- a/src/Webhooks/WebhookProcessor.php
+++ b/src/Webhooks/WebhookProcessor.php
@@ -66,4 +66,12 @@ class WebhookProcessor
 
         $this->dispatcher->dispatch($event);
     }
+
+    /**
+     * @return WebhookReactionInterface[]
+     */
+    public function getReactions(): array
+    {
+        return $this->reactions;
+    }
 }

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks;
+
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
+
+class WebhookProcessorFactory
+{
+    /**
+     * Build a WebhookProcessor wired with the standard reactions.
+     *
+     * Drivers call this from their bootstrap to avoid re-deriving the
+     * reaction registration list on each install.
+     *
+     * @param WebhookReactionInterface[] $additionalReactions
+     */
+    public static function create(
+        ConfigurationInterface $config,
+        SubscriptionRepositoryInterface $subscriptions,
+        OrderRepositoryInterface $orders,
+        WebhookCallRepositoryInterface $webhookCalls,
+        EventDispatcherInterface $dispatcher,
+        array $additionalReactions = [],
+    ): WebhookProcessor {
+        return new WebhookProcessor(
+            signatureVerifier: new SignatureVerifier(),
+            eventFactory: new WebhookEventFactory(),
+            repository: $webhookCalls,
+            dispatcher: $dispatcher,
+            webhookSecret: $config->getWebhookSecret() ?? '',
+            reactions: [
+                new SyncSubscriptionOnStarted($subscriptions, $dispatcher),
+                new CancelSubscriptionOnCanceled($subscriptions),
+                new StoreOrderOnPaid($orders),
+                ...$additionalReactions,
+            ],
+        );
+    }
+}

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks;
+
+use Mockery;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
+use Vatly\Fluent\Webhooks\WebhookProcessor;
+use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
+
+class WebhookProcessorFactoryTest extends TestCase
+{
+    public function test_it_builds_a_processor_with_the_standard_reactions(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+        );
+
+        $this->assertInstanceOf(WebhookProcessor::class, $processor);
+
+        $reactions = $processor->getReactions();
+
+        $this->assertCount(3, $reactions);
+        $this->assertInstanceOf(SyncSubscriptionOnStarted::class, $reactions[0]);
+        $this->assertInstanceOf(CancelSubscriptionOnCanceled::class, $reactions[1]);
+        $this->assertInstanceOf(StoreOrderOnPaid::class, $reactions[2]);
+    }
+
+    public function test_it_appends_additional_reactions_after_the_standard_ones(): void
+    {
+        $custom = Mockery::mock(WebhookReactionInterface::class);
+
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            additionalReactions: [$custom],
+        );
+
+        $reactions = $processor->getReactions();
+
+        $this->assertCount(4, $reactions);
+        $this->assertSame($custom, $reactions[3]);
+    }
+
+    public function test_it_tolerates_a_null_webhook_secret(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config(null),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+        );
+
+        $this->assertInstanceOf(WebhookProcessor::class, $processor);
+    }
+
+    private function config(?string $secret): ConfigurationInterface
+    {
+        $config = Mockery::mock(ConfigurationInterface::class);
+        $config->shouldReceive('getWebhookSecret')->andReturn($secret);
+
+        return $config;
+    }
+}


### PR DESCRIPTION
## Summary
- Repositions vatly-fluent-php as **shared driver internals**, not an end-user platform. README now leads with the driver table (vatly-laravel for Laravel; vatly-api-php for raw API; Symfony/WordPress on the roadmap).
- Adds **CONTRIBUTING.md** as the Driver Author Guide — the 7 contracts a driver implements, the wiring sequence, the webhook endpoint pattern, and documented follow-up consolidation work.
- Adds **`WebhookProcessorFactory::create()`** so drivers wire a fully-loaded `WebhookProcessor` in a single call instead of re-deriving the reaction list. Additive — no breaking change for existing consumers.
- Adds **`WebhookProcessor::getReactions()`** so drivers/tests can introspect the registered reactions without reflection.

## Why
Conversation about positioning concluded the fluent package isn't really a "platform" — it's the shared code that powers framework drivers. Docs and README should reflect that. The factory removes a chunk of boilerplate every new driver would otherwise repeat.

## Test plan
- [x] `composer test` → 95/95 pass (3 new tests for the factory)
- [x] `composer analyse` → no new errors (2 pre-existing PHPStan errors on `origin/main` are unrelated and remain unchanged)

## Follow-up (documented in CONTRIBUTING.md)
- After release, migrate `vatly-laravel`'s `VatlyServiceProvider::registerWebhookProcessor()` to call the factory.
- Larger consolidation: dissolve the Laravel-side duplicate `Builders/` and `VatlyApiActions/` layer (separate PR, planned via the `Vatly\Fluent\Billable` orchestrator restructure).
