### PR TITLE
feat: Vatly\Fluent\Billable orchestrator + reposition as shared driver internals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,179 @@
+# Contributing & Driver Author Guide
+
+This package is the shared core that powers framework-specific Vatly drivers. Most readers want one of two things:
+
+- **Building a driver** for a framework that isn't covered yet (Symfony, WordPress, etc.) → start at [Building a driver](#building-a-driver).
+- **Contributing to this package itself** (bug fix, new contract, new reaction) → jump to [Working on this package](#working-on-this-package).
+
+If you're an application developer looking to use Vatly, you almost certainly want a driver, not this package directly. See the [README](README.md#looking-for-a-vatly-integration) for the list.
+
+## Architecture
+
+A driver is the framework-specific layer that fills in the abstractions this package defines. Concretely:
+
+| Concern | Lives in fluent | Lives in the driver |
+| --- | --- | --- |
+| Webhook signature, parsing, reactions, dispatch | ✅ | — |
+| Typed events (`OrderPaid`, `SubscriptionStarted`, …) | ✅ | — |
+| Action wrappers around the raw API SDK | ✅ | — |
+| Repository **contracts** (subscription, order, customer, webhook call) | ✅ | — |
+| Repository **implementations** (Eloquent / Doctrine / WP `$wpdb` / …) | — | ✅ |
+| `BillableInterface` implementation on a User/Tenant entity | — | ✅ |
+| Configuration source (env, `config()`, framework config) | — | ✅ |
+| Event dispatcher bridge | — | ✅ |
+| HTTP route for the webhook endpoint | — | ✅ |
+| DI / service container wiring | — | ✅ |
+
+The reference driver is [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — read its `VatlyServiceProvider` for a concrete wiring example.
+
+## Building a driver
+
+### 1. The contracts you must implement
+
+All under `Vatly\Fluent\Contracts\`:
+
+- **`BillableInterface`** — represents a customer entity (your User, Tenant, etc.). Methods: `getVatlyId()`, `setVatlyId()`, `hasVatlyId()`, `getVatlyEmail()`, `getVatlyName()`, `getKey()`, `save()`.
+- **`ConfigurationInterface`** — exposes API credentials and defaults. Methods: `getApiKey()`, `getApiUrl()`, `getApiVersion()`, `getWebhookSecret()`, `isTestmode()`, `getDefaultRedirectUrlSuccess()`, `getDefaultRedirectUrlCanceled()`, `getBillableModel()`.
+- **`SubscriptionRepositoryInterface`** — `findByVatlyId()`, `findByOwnerAndType()`, `findAllByOwner()`, `ownerHasActiveSubscription()`, `store(StoreSubscriptionData)`, `update(SubscriptionInterface, UpdateSubscriptionData)`.
+- **`CustomerRepositoryInterface`** — `findByVatlyId()`, `findByVatlyIdOrFail()`, `save(BillableInterface)`.
+- **`OrderRepositoryInterface`** — `findByVatlyId()`, `findAllByOwner()`, `store(StoreOrderData)`, `update(OrderInterface, UpdateOrderData)`.
+- **`WebhookCallRepositoryInterface`** — `record(…)` (audit log), `cleanUp(int $days)`.
+- **`EventDispatcherInterface`** — single method `dispatch(object $event)`. Bridge to your framework's event bus or PSR-14.
+
+Your driver also needs concrete `SubscriptionInterface` and `OrderInterface` implementations (typically your ORM models).
+
+### 2. The wiring sequence
+
+In your driver's bootstrap (`ServiceProvider`, bundle config, plugin init), wire in this order:
+
+1. Bind your `ConfigurationInterface` implementation.
+2. Construct a `Vatly\API\VatlyApiClient` and configure it from your `ConfigurationInterface`.
+3. Bind your repository implementations to the four repository contracts.
+4. Bind your event dispatcher implementation to `EventDispatcherInterface`.
+5. Build a `WebhookProcessor`. The easiest path is `WebhookProcessorFactory::create()`, which wires the standard reactions for you:
+
+```php
+use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
+
+$processor = WebhookProcessorFactory::create(
+    config: $config,
+    subscriptions: $subscriptionRepository,
+    orders: $orderRepository,
+    webhookCalls: $webhookCallRepository,
+    dispatcher: $eventDispatcher,
+    additionalReactions: [
+        // Optional custom reactions implementing WebhookReactionInterface
+    ],
+);
+```
+
+If you need to swap out the `SignatureVerifier` or `WebhookEventFactory`, construct `WebhookProcessor` directly:
+
+```php
+use Vatly\Fluent\Webhooks\WebhookProcessor;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+
+new WebhookProcessor(
+    signatureVerifier: $signatureVerifier,
+    eventFactory: $eventFactory,
+    repository: $webhookCallRepository,
+    dispatcher: $eventDispatcher,
+    webhookSecret: $config->getWebhookSecret() ?? '',
+    reactions: [
+        new SyncSubscriptionOnStarted($subscriptionRepository, $eventDispatcher),
+        new CancelSubscriptionOnCanceled($subscriptionRepository),
+        new StoreOrderOnPaid($orderRepository),
+    ],
+);
+```
+
+### 3. The webhook endpoint
+
+Expose a single POST route in your framework. In the handler:
+
+```php
+try {
+    $processor->handle(
+        payload: $request->getRawBody(),       // raw, not deserialized
+        signature: $request->getHeader('X-Vatly-Signature') ?? '',
+    );
+    return new Response(status: 201);
+} catch (InvalidWebhookSignatureException) {
+    return new Response(status: 403);
+}
+```
+
+Return `2xx` on success, `403` on signature mismatch. Anything else and Vatly will retry.
+
+### 4. Application-facing ergonomics
+
+Drivers typically add framework-idiomatic ergonomics on top:
+
+- **Trait / base class** so an application's User entity gets `$user->subscription('default')->cancel()`-style methods. (Laravel's `Billable` trait composes `Manages*` concerns.) This is intentionally **not** in fluent — each framework's idioms differ enough that a shared trait would be a poor fit.
+- **Builders** for checkouts/subscriptions that work in the framework's types. Fluent ships generic builders driven by `BillableInterface` — you may wrap or extend them.
+- **Audit/admin views, console commands, fakes** — purely driver-level.
+
+### 5. Listing your driver
+
+Once your driver is on Packagist and has tests + a README, open a PR against this repo's `README.md` adding it to the "Looking for a Vatly integration?" table.
+
+## Working on this package
+
+### Local setup
+
+```bash
+git clone https://github.com/Vatly/vatly-fluent-php.git
+cd vatly-fluent-php
+composer install
+composer test
+composer analyse
+```
+
+Tests are PHPUnit + Mockery, fully isolated — no framework or HTTP needed. The base `TestCase` extends `PHPUnit\Framework\TestCase` and uses `MockeryPHPUnitIntegration` for cleanup.
+
+### Design principles
+
+- **Zero framework imports.** No `use Illuminate\…` or `use Symfony\…` under `src/`. Drivers depend on us; we never depend on them.
+- **Stateless domain logic.** Reactions, builders, the processor — none of them hold state. State lives in the repository implementations the driver provides.
+- **Raw API resources.** Actions return `Vatly\API\Resources\*` directly. We deliberately don't add a response wrapper layer — that's a driver-level concern if needed at all.
+- **Immutable DTOs** for repository inputs (`StoreSubscriptionData`, `UpdateOrderData`, …).
+
+### PR process
+
+1. Branch off `main`.
+2. Add or update tests for the change.
+3. Run `composer test` and `composer analyse` locally.
+4. Open the PR. CI runs the same checks.
+
+## Planned consolidation (known follow-up)
+
+The Laravel driver currently carries some code that arguably belongs here:
+
+- **Duplicate builders** ([`vatly-laravel/src/Builders/`](https://github.com/Vatly/vatly-laravel/tree/main/src/Builders)) — Eloquent-flavoured `CheckoutBuilder` / `SubscriptionBuilder` that overlap with fluent's framework-agnostic versions. Open question whether the Eloquent/`Collection` signatures justify the duplication or whether fluent's builders can absorb the Laravel ergonomics behind the `BillableInterface` seam.
+- **`VatlyApiActions/*` wrapper layer** ([`vatly-laravel/src/VatlyApiActions/`](https://github.com/Vatly/vatly-laravel/tree/main/src/VatlyApiActions)) — Laravel-side actions that bypass fluent's actions and call the raw API client, returning local response DTOs. Fluent's stated design is "no response wrapper layer". Either fluent absorbs the response DTOs (and changes that stance) or the Laravel layer is dissolved and consumers use raw API resources. Decision pending.
+
+Both are breaking changes for Laravel consumers and will land in a dedicated alpha bump.
+
+### Coordinated release: adopt `WebhookProcessorFactory` in vatly-laravel
+
+`WebhookProcessorFactory` is new (additive). After the next fluent alpha release, [`vatly-laravel`](https://github.com/Vatly/vatly-laravel)'s `VatlyServiceProvider::registerWebhookProcessor()` should be migrated to:
+
+```php
+$this->app->singleton(WebhookProcessor::class, function () {
+    return WebhookProcessorFactory::create(
+        config: $this->app->make(ConfigurationInterface::class),
+        subscriptions: $this->app->make(SubscriptionRepositoryInterface::class),
+        orders: $this->app->make(OrderRepositoryInterface::class),
+        webhookCalls: $this->app->make(WebhookCallRepositoryInterface::class),
+        dispatcher: $this->app->make(EventDispatcherInterface::class),
+    );
+});
+```
+
+Track in a Laravel-side issue once the fluent release lands.
+
+## License
+
+MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,156 +1,10 @@
-# Contributing & Driver Author Guide
+# Contributing
 
-This package is the shared core that powers framework-specific Vatly drivers. Most readers want one of two things:
+Thanks for considering a contribution to `vatly-fluent-php`. This guide is for changes **to this package itself** — bug fixes, new contracts, new reactions, doc improvements, etc.
 
-- **Building a driver** for a framework that isn't covered yet (Symfony, WordPress, etc.) → start at [Building a driver](#building-a-driver).
-- **Contributing to this package itself** (bug fix, new contract, new reaction) → jump to [Working on this package](#working-on-this-package).
+If you're looking to *build a driver* on top of fluent (Symfony, WordPress, …), the guide for that lives in the [README](README.md#building-a-driver), not here.
 
-If you're an application developer looking to use Vatly, you almost certainly want a driver, not this package directly. See the [README](README.md#looking-for-a-vatly-integration) for the list.
-
-## Architecture
-
-A driver is the framework-specific layer that fills in the abstractions this package defines. Concretely:
-
-| Concern | Lives in fluent | Lives in the driver |
-| --- | --- | --- |
-| Webhook signature, parsing, reactions, dispatch | ✅ | — |
-| Typed events (`OrderPaid`, `SubscriptionStarted`, …) | ✅ | — |
-| Action wrappers around the raw API SDK | ✅ | — |
-| Repository **contracts** (subscription, order, customer, webhook call) | ✅ | — |
-| Repository **implementations** (Eloquent / Doctrine / WP `$wpdb` / …) | — | ✅ |
-| `BillableInterface` implementation on a User/Tenant entity | — | ✅ |
-| Configuration source (env, `config()`, framework config) | — | ✅ |
-| Event dispatcher bridge | — | ✅ |
-| HTTP route for the webhook endpoint | — | ✅ |
-| DI / service container wiring | — | ✅ |
-
-The reference driver is [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — read its `VatlyServiceProvider` for a concrete wiring example.
-
-## Building a driver
-
-### 1. The contracts you must implement
-
-All under `Vatly\Fluent\Contracts\`:
-
-- **`BillableInterface`** — represents a customer entity (your User, Tenant, etc.). Methods: `getVatlyId()`, `setVatlyId()`, `hasVatlyId()`, `getVatlyEmail()`, `getVatlyName()`, `getKey()`, `save()`.
-- **`ConfigurationInterface`** — exposes API credentials and defaults. Methods: `getApiKey()`, `getApiUrl()`, `getApiVersion()`, `getWebhookSecret()`, `isTestmode()`, `getDefaultRedirectUrlSuccess()`, `getDefaultRedirectUrlCanceled()`, `getBillableModel()`.
-- **`SubscriptionRepositoryInterface`** — `findByVatlyId()`, `findByOwnerAndType()`, `findAllByOwner()`, `ownerHasActiveSubscription()`, `store(StoreSubscriptionData)`, `update(SubscriptionInterface, UpdateSubscriptionData)`.
-- **`CustomerRepositoryInterface`** — `findByVatlyId()`, `findByVatlyIdOrFail()`, `save(BillableInterface)`.
-- **`OrderRepositoryInterface`** — `findByVatlyId()`, `findAllByOwner()`, `store(StoreOrderData)`, `update(OrderInterface, UpdateOrderData)`.
-- **`WebhookCallRepositoryInterface`** — `record(…)` (audit log), `cleanUp(int $days)`.
-- **`EventDispatcherInterface`** — single method `dispatch(object $event)`. Bridge to your framework's event bus or PSR-14.
-
-Your driver also needs concrete `SubscriptionInterface` and `OrderInterface` implementations (typically your ORM models).
-
-### 2. The wiring sequence
-
-In your driver's bootstrap (`ServiceProvider`, bundle config, plugin init), wire in this order:
-
-1. Bind your `ConfigurationInterface` implementation.
-2. Construct a `Vatly\API\VatlyApiClient` and configure it from your `ConfigurationInterface`.
-3. Bind your repository implementations to the four repository contracts.
-4. Bind your event dispatcher implementation to `EventDispatcherInterface`.
-5. Build a `WebhookProcessor`. The easiest path is `WebhookProcessorFactory::create()`, which wires the standard reactions for you:
-
-```php
-use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
-
-$processor = WebhookProcessorFactory::create(
-    config: $config,
-    subscriptions: $subscriptionRepository,
-    orders: $orderRepository,
-    webhookCalls: $webhookCallRepository,
-    dispatcher: $eventDispatcher,
-    additionalReactions: [
-        // Optional custom reactions implementing WebhookReactionInterface
-    ],
-);
-```
-
-If you need to swap out the `SignatureVerifier` or `WebhookEventFactory`, construct `WebhookProcessor` directly:
-
-```php
-use Vatly\Fluent\Webhooks\WebhookProcessor;
-use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
-use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
-use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
-
-new WebhookProcessor(
-    signatureVerifier: $signatureVerifier,
-    eventFactory: $eventFactory,
-    repository: $webhookCallRepository,
-    dispatcher: $eventDispatcher,
-    webhookSecret: $config->getWebhookSecret() ?? '',
-    reactions: [
-        new SyncSubscriptionOnStarted($subscriptionRepository, $eventDispatcher),
-        new CancelSubscriptionOnCanceled($subscriptionRepository),
-        new StoreOrderOnPaid($orderRepository),
-    ],
-);
-```
-
-6. Register a `BillableFactory` singleton with the shared dependencies. This is what your `$entity->vatlyBillable()` accessor calls to construct a per-owner `Vatly\Fluent\Billable`:
-
-```php
-use Vatly\Fluent\BillableFactory;
-
-$factory = new BillableFactory(
-    subscriptions: $subscriptionRepository,
-    customers: $customerRepository,
-    orders: $orderRepository,
-    config: $config,
-    createCheckoutAction: new CreateCheckout($apiClient),
-    createCustomerAction: new CreateCustomer($apiClient),
-    getCustomerAction: new GetCustomer($apiClient),
-    getSubscriptionAction: new GetSubscription($apiClient),
-    swapSubscriptionPlanAction: new SwapSubscriptionPlan($apiClient),
-    cancelSubscriptionAction: new CancelSubscription($apiClient),
-    createBillingUpdateLinkAction: new CreateSubscriptionBillingUpdateLink($apiClient),
-);
-```
-
-In your User/Tenant trait or base class, expose it:
-
-```php
-public function vatlyBillable(): \Vatly\Fluent\Billable
-{
-    return $container->get(BillableFactory::class)->forOwner($this);
-}
-```
-
-### 3. The webhook endpoint
-
-Expose a single POST route in your framework. In the handler:
-
-```php
-try {
-    $processor->handle(
-        payload: $request->getRawBody(),       // raw, not deserialized
-        signature: $request->getHeader('X-Vatly-Signature') ?? '',
-    );
-    return new Response(status: 201);
-} catch (InvalidWebhookSignatureException) {
-    return new Response(status: 403);
-}
-```
-
-Return `2xx` on success, `403` on signature mismatch. Anything else and Vatly will retry.
-
-### 4. Application-facing ergonomics
-
-The canonical per-owner API surface lives in fluent on `Vatly\Fluent\Billable` — `subscribe()`, `checkout()`, `subscribed()`, `subscription()`, `createAsVatlyCustomer()`, etc. Drivers expose that surface through their framework idioms:
-
-- **A trait, base class, or accessor** so the application's User/Tenant entity gets a `vatlyBillable()` method returning a `Vatly\Fluent\Billable`. Optionally add Cashier-style proxy methods (`$user->subscribe()`, `$user->subscribed()`) that delegate to `vatlyBillable()->X()` — see [vatly-laravel's `Billable` trait](https://github.com/Vatly/vatly-laravel/blob/main/src/Billable.php) for the reference example.
-- **Eloquent/Doctrine/etc. relations** for collection-style access (`$user->subscriptions`) that fluent can't provide — those stay driver-side.
-- **Audit/admin views, console commands, fakes** — purely driver-level.
-
-### 5. Listing your driver
-
-Once your driver is on Packagist and has tests + a README, open a PR against this repo's `README.md` adding it to the "Looking for a Vatly integration?" table.
-
-## Working on this package
-
-### Local setup
+## Local setup
 
 ```bash
 git clone https://github.com/Vatly/vatly-fluent-php.git
@@ -162,21 +16,31 @@ composer analyse
 
 Tests are PHPUnit + Mockery, fully isolated — no framework or HTTP needed. The base `TestCase` extends `PHPUnit\Framework\TestCase` and uses `MockeryPHPUnitIntegration` for cleanup.
 
-### Design principles
+## Design principles
 
-- **Zero framework imports.** No `use Illuminate\…` or `use Symfony\…` under `src/`. Drivers depend on us; we never depend on them.
-- **Stateless domain logic.** Reactions, builders, the processor — none of them hold state. State lives in the repository implementations the driver provides.
-- **Raw API resources.** Actions return `Vatly\API\Resources\*` directly. We deliberately don't add a response wrapper layer — that's a driver-level concern if needed at all.
-- **Immutable DTOs** for repository inputs (`StoreSubscriptionData`, `UpdateOrderData`, …).
+These are the constraints to preserve when changing code under `src/`:
 
-### PR process
+- **Zero framework imports.** No `use Illuminate\…` or `use Symfony\…` under `src/`. Drivers depend on us; we never depend on them. The webhook pipeline, the orchestrator, the reactions, and the actions are all built against framework-agnostic contracts.
+- **Stateless domain logic.** Reactions, builders, the processor — none of them hold persistent state. State lives in the repository implementations the driver provides.
+- **Raw API resources.** Actions return `Vatly\API\Resources\*` directly. We deliberately don't add a response-wrapper layer.
+- **Immutable DTOs** for repository inputs (`StoreSubscriptionData`, `UpdateOrderData`, …) and for typed events.
+- **Webhook events carry their own data.** Don't synthesise timestamps in reactions — pull them from the event, which pulled them from Vatly.
+
+## PR process
 
 1. Branch off `main`.
 2. Add or update tests for the change.
-3. Run `composer test` and `composer analyse` locally.
-4. Open the PR. CI runs the same checks.
+3. Run `composer test` and `composer analyse` locally — both must be green.
+4. Open the PR. CI runs the same checks across PHP 8.0 – 8.4.
 
+## Listing your driver
+
+If you've built a Vatly driver for a framework not yet on the driver table, please open a PR adding it to the [Looking for a Vatly integration?](README.md#looking-for-a-vatly-integration) section. To be listed, a driver should:
+
+- Be published on Packagist
+- Have a test suite that runs in CI
+- Have a README that gets a new user from `composer require` to a working webhook + first subscription, in the style of [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel)
 
 ## License
 
-MIT
+By contributing, you agree your contributions are released under the [MIT license](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,35 @@ new WebhookProcessor(
 );
 ```
 
+6. Register a `BillableFactory` singleton with the shared dependencies. This is what your `$entity->vatlyBillable()` accessor calls to construct a per-owner `Vatly\Fluent\Billable`:
+
+```php
+use Vatly\Fluent\BillableFactory;
+
+$factory = new BillableFactory(
+    subscriptions: $subscriptionRepository,
+    customers: $customerRepository,
+    orders: $orderRepository,
+    config: $config,
+    createCheckoutAction: new CreateCheckout($apiClient),
+    createCustomerAction: new CreateCustomer($apiClient),
+    getCustomerAction: new GetCustomer($apiClient),
+    getSubscriptionAction: new GetSubscription($apiClient),
+    swapSubscriptionPlanAction: new SwapSubscriptionPlan($apiClient),
+    cancelSubscriptionAction: new CancelSubscription($apiClient),
+    createBillingUpdateLinkAction: new CreateSubscriptionBillingUpdateLink($apiClient),
+);
+```
+
+In your User/Tenant trait or base class, expose it:
+
+```php
+public function vatlyBillable(): \Vatly\Fluent\Billable
+{
+    return $container->get(BillableFactory::class)->forOwner($this);
+}
+```
+
 ### 3. The webhook endpoint
 
 Expose a single POST route in your framework. In the handler:
@@ -109,10 +138,10 @@ Return `2xx` on success, `403` on signature mismatch. Anything else and Vatly wi
 
 ### 4. Application-facing ergonomics
 
-Drivers typically add framework-idiomatic ergonomics on top:
+The canonical per-owner API surface lives in fluent on `Vatly\Fluent\Billable` — `subscribe()`, `checkout()`, `subscribed()`, `subscription()`, `createAsVatlyCustomer()`, etc. Drivers expose that surface through their framework idioms:
 
-- **Trait / base class** so an application's User entity gets `$user->subscription('default')->cancel()`-style methods. (Laravel's `Billable` trait composes `Manages*` concerns.) This is intentionally **not** in fluent — each framework's idioms differ enough that a shared trait would be a poor fit.
-- **Builders** for checkouts/subscriptions that work in the framework's types. Fluent ships generic builders driven by `BillableInterface` — you may wrap or extend them.
+- **A trait, base class, or accessor** so the application's User/Tenant entity gets a `vatlyBillable()` method returning a `Vatly\Fluent\Billable`. Optionally add Cashier-style proxy methods (`$user->subscribe()`, `$user->subscribed()`) that delegate to `vatlyBillable()->X()` — see [vatly-laravel's `Billable` trait](https://github.com/Vatly/vatly-laravel/blob/main/src/Billable.php) for the reference example.
+- **Eloquent/Doctrine/etc. relations** for collection-style access (`$user->subscriptions`) that fluent can't provide — those stay driver-side.
 - **Audit/admin views, console commands, fakes** — purely driver-level.
 
 ### 5. Listing your driver
@@ -147,32 +176,6 @@ Tests are PHPUnit + Mockery, fully isolated — no framework or HTTP needed. The
 3. Run `composer test` and `composer analyse` locally.
 4. Open the PR. CI runs the same checks.
 
-## Planned consolidation (known follow-up)
-
-The Laravel driver currently carries some code that arguably belongs here:
-
-- **Duplicate builders** ([`vatly-laravel/src/Builders/`](https://github.com/Vatly/vatly-laravel/tree/main/src/Builders)) — Eloquent-flavoured `CheckoutBuilder` / `SubscriptionBuilder` that overlap with fluent's framework-agnostic versions. Open question whether the Eloquent/`Collection` signatures justify the duplication or whether fluent's builders can absorb the Laravel ergonomics behind the `BillableInterface` seam.
-- **`VatlyApiActions/*` wrapper layer** ([`vatly-laravel/src/VatlyApiActions/`](https://github.com/Vatly/vatly-laravel/tree/main/src/VatlyApiActions)) — Laravel-side actions that bypass fluent's actions and call the raw API client, returning local response DTOs. Fluent's stated design is "no response wrapper layer". Either fluent absorbs the response DTOs (and changes that stance) or the Laravel layer is dissolved and consumers use raw API resources. Decision pending.
-
-Both are breaking changes for Laravel consumers and will land in a dedicated alpha bump.
-
-### Coordinated release: adopt `WebhookProcessorFactory` in vatly-laravel
-
-`WebhookProcessorFactory` is new (additive). After the next fluent alpha release, [`vatly-laravel`](https://github.com/Vatly/vatly-laravel)'s `VatlyServiceProvider::registerWebhookProcessor()` should be migrated to:
-
-```php
-$this->app->singleton(WebhookProcessor::class, function () {
-    return WebhookProcessorFactory::create(
-        config: $this->app->make(ConfigurationInterface::class),
-        subscriptions: $this->app->make(SubscriptionRepositoryInterface::class),
-        orders: $this->app->make(OrderRepositoryInterface::class),
-        webhookCalls: $this->app->make(WebhookCallRepositoryInterface::class),
-        dispatcher: $this->app->make(EventDispatcherInterface::class),
-    );
-});
-```
-
-Track in a Laravel-side issue once the fluent release lands.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,39 +6,34 @@
 
 > **Alpha release -- under active development. Expect breaking changes.**
 
-Framework-agnostic fluent PHP SDK for [Vatly](https://vatly.com) billing. Wraps the [vatly-api-php](https://github.com/Vatly/vatly-api-php) client with expressive, action-based methods for managing subscriptions, checkouts, customers, and webhooks.
+Shared internals for [Vatly](https://vatly.com) framework drivers. This package is the framework-agnostic core that powers driver packages like [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — webhook processing, contracts, events, and DTOs that drivers reuse so they don't reimplement the same patterns.
 
-This package serves as the core logic layer, designed to be portable across PHP frameworks and as a reference for future language ports (JS, Python).
+## Looking for a Vatly integration?
 
-## Installation
+**Most users want a framework driver, not this package directly:**
 
-```bash
-composer require vatly/vatly-fluent-php
-```
+| Framework | Package |
+| --- | --- |
+| Laravel | [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) |
+| Symfony, WordPress, etc. | _Planned. Want to build one? See [CONTRIBUTING.md](CONTRIBUTING.md)._ |
+| No framework / raw API | [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) |
 
-This package follows semantic versioning. During alpha, pin to exact versions if you need stability:
+This package on its own doesn't persist anything, dispatch events, or read configuration — those concerns belong to a driver. You install it transitively through a driver.
 
-```bash
-composer require vatly/vatly-fluent-php:v0.4.0-alpha.1
-```
+## What's inside
 
-## Requirements
+Drivers wire these pieces into their framework's IoC container, ORM, event bus, and routing:
 
-- PHP 8.0+
-- A Vatly API key ([vatly.com](https://vatly.com))
+- **Contracts** ([src/Contracts](src/Contracts)): `BillableInterface`, `SubscriptionInterface`, `OrderInterface`, repository interfaces (`SubscriptionRepositoryInterface`, `CustomerRepositoryInterface`, `OrderRepositoryInterface`, `WebhookCallRepositoryInterface`), `EventDispatcherInterface`, `ConfigurationInterface`, `WebhookReactionInterface`.
+- **Webhook pipeline** ([src/Webhooks](src/Webhooks)): `WebhookProcessor` orchestrates signature verification → event parsing → audit logging → reactions → dispatch. Built-in reactions: `SyncSubscriptionOnStarted`, `StoreOrderOnPaid`, `CancelSubscriptionOnCanceled`.
+- **Events** ([src/Events](src/Events)): typed POPOs — `OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, `LocalSubscriptionCreated`, `WebhookReceived`, `UnsupportedWebhookReceived`.
+- **Actions** ([src/Actions](src/Actions)): thin wrappers around [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) — `CreateCheckout`, `CreateCustomer`, `GetCheckout`, `GetCustomer`, `GetSubscription`, `CreateSubscriptionBillingUpdateLink`, `CancelSubscription`, `SwapSubscriptionPlan`. Return raw `Vatly\API\Resources\*` objects.
+- **Builders** ([src/Builders](src/Builders)): `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`.
+- **Data DTOs** ([src/Data](src/Data)): immutable inputs for repository operations — `StoreOrderData`, `StoreSubscriptionData`, `UpdateOrderData`, `UpdateSubscriptionData`.
 
-## What's included
+## Direct usage (advanced)
 
-- **`Vatly` facade:** single entry point that lazy-instantiates actions and exposes the API client, signature verifier, and webhook event factory
-- **Actions:** CreateCheckout, CreateCustomer, GetCheckout, GetCustomer, GetSubscription, CreateSubscriptionBillingUpdateLink, CancelSubscription, SwapSubscriptionPlan
-- **Builders:** framework-agnostic `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`
-- **Webhook handling:** signature verification, event factory, typed event objects (`OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, etc.), and a `WebhookProcessor` that dispatches built-in reactions (sync subscription, store order, cancel subscription) plus your own
-- **Contracts:** `BillableInterface`, repository interfaces (`SubscriptionRepositoryInterface`, `OrderRepositoryInterface`, `CustomerRepositoryInterface`, `WebhookCallRepositoryInterface`), `EventDispatcherInterface`, `ConfigurationInterface` for framework integration
-- **Data DTOs:** immutable inputs for repository store/update operations (`StoreOrderData`, `StoreSubscriptionData`, `UpdateOrderData`, `UpdateSubscriptionData`)
-
-Actions return raw `Vatly\API\Resources\*` objects from the underlying [vatly-api-php](https://github.com/Vatly/vatly-api-php) client — there is no separate response wrapper layer.
-
-## Usage
+If you're not using a driver — for example a custom framework integration — you can wire this package up yourself. Start with the [Driver Author Guide](CONTRIBUTING.md), then use the `Vatly` entry point for read-only operations:
 
 ```php
 use Vatly\Fluent\Vatly;
@@ -46,26 +41,41 @@ use Vatly\Fluent\Vatly;
 $vatly = new Vatly('test_xxxxxxxxxxxx');
 
 $checkout = $vatly->createCheckout()->execute([
-    'products' => [
-        ['id' => 'subscription_plan_id', 'quantity' => 1],
-    ],
+    'products' => [['id' => 'plan_abc', 'quantity' => 1]],
     'customerId' => 'cust_xxx',
     'redirectUrlSuccess' => 'https://example.com/success',
     'redirectUrlCanceled' => 'https://example.com/canceled',
 ]);
 ```
 
-`$checkout` is a `Vatly\API\Resources\Checkout` — see [vatly-api-php](https://github.com/Vatly/vatly-api-php) for the full resource shape.
+For webhook handling, subscription sync, and anything stateful, you'll need to implement the repository contracts and wire a `WebhookProcessor` — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## For framework integrations
+## Requirements
 
-If you're using Laravel, see [vatly/vatly-laravel](https://github.com/Vatly/vatly-laravel). It provides Eloquent models, a `Billable` trait, Eloquent-aware repositories (implementations of the contracts above), Laravel-flavoured builders (driven by `Illuminate\Database\Eloquent\Model` and `Collection`), an event-bus bridge, and a webhook controller — all on top of this package.
+- PHP 8.0+
+- A Vatly API key ([vatly.com](https://vatly.com))
+
+## Installation
+
+```bash
+composer require vatly/vatly-fluent-php
+```
+
+Pin to an exact version during alpha:
+
+```bash
+composer require vatly/vatly-fluent-php:v0.4.0-alpha.3
+```
 
 ## Testing
 
 ```bash
 composer test
 ```
+
+## Contributing & building a driver
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contracts a driver implements, the wiring pattern, and the planned consolidation work.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **Alpha release -- under active development. Expect breaking changes.**
 
-Shared internals for [Vatly](https://vatly.com) framework drivers. This package is the framework-agnostic core that powers driver packages like [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — webhook processing, contracts, events, and DTOs that drivers reuse so they don't reimplement the same patterns.
+Shared internals for [Vatly](https://vatly.com) framework drivers. This package is the framework-agnostic core that powers driver packages like [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — webhook processing, contracts, events, DTOs, and the per-owner orchestrator (`Vatly\Fluent\Billable`) that drivers reuse so they don't reimplement the same patterns.
 
 ## Looking for a Vatly integration?
 
@@ -15,47 +15,14 @@ Shared internals for [Vatly](https://vatly.com) framework drivers. This package 
 | Framework | Package |
 | --- | --- |
 | Laravel | [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) |
-| Symfony, WordPress, etc. | _Planned. Want to build one? See [CONTRIBUTING.md](CONTRIBUTING.md)._ |
+| Symfony, WordPress, etc. | _Planned. Want to build one? See [Building a driver](#building-a-driver) below._ |
 | No framework / raw API | [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) |
 
 This package on its own doesn't persist anything, dispatch events, or read configuration — those concerns belong to a driver. You install it transitively through a driver.
 
-## What's inside
-
-Drivers wire these pieces into their framework's IoC container, ORM, event bus, and routing:
-
-- **Contracts** ([src/Contracts](src/Contracts)): `BillableInterface`, `SubscriptionInterface`, `OrderInterface`, repository interfaces (`SubscriptionRepositoryInterface`, `CustomerRepositoryInterface`, `OrderRepositoryInterface`, `WebhookCallRepositoryInterface`), `EventDispatcherInterface`, `ConfigurationInterface`, `WebhookReactionInterface`.
-- **Webhook pipeline** ([src/Webhooks](src/Webhooks)): `WebhookProcessor` orchestrates signature verification → event parsing → audit logging → reactions → dispatch. Built-in reactions: `SyncSubscriptionOnStarted`, `StoreOrderOnPaid`, `CancelSubscriptionOnCanceled`.
-- **Events** ([src/Events](src/Events)): typed POPOs — `OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, `LocalSubscriptionCreated`, `WebhookReceived`, `UnsupportedWebhookReceived`.
-- **Actions** ([src/Actions](src/Actions)): thin wrappers around [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) — `CreateCheckout`, `CreateCustomer`, `GetCheckout`, `GetCustomer`, `GetSubscription`, `CreateSubscriptionBillingUpdateLink`, `CancelSubscription`, `SwapSubscriptionPlan`. Return raw `Vatly\API\Resources\*` objects.
-- **Builders** ([src/Builders](src/Builders)): `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`.
-- **Data DTOs** ([src/Data](src/Data)): immutable inputs for repository operations — `StoreOrderData`, `StoreSubscriptionData`, `UpdateOrderData`, `UpdateSubscriptionData`.
-
-## Direct usage (advanced)
-
-If you're not using a driver — for example a custom framework integration — you can wire this package up yourself. Start with the [Driver Author Guide](CONTRIBUTING.md), then use the `Vatly` entry point for read-only operations:
-
-```php
-use Vatly\Fluent\Vatly;
-
-$vatly = new Vatly('test_xxxxxxxxxxxx');
-
-$checkout = $vatly->createCheckout()->execute([
-    'products' => [['id' => 'plan_abc', 'quantity' => 1]],
-    'customerId' => 'cust_xxx',
-    'redirectUrlSuccess' => 'https://example.com/success',
-    'redirectUrlCanceled' => 'https://example.com/canceled',
-]);
-```
-
-For webhook handling, subscription sync, and anything stateful, you'll need to implement the repository contracts and wire a `WebhookProcessor` — see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Requirements
-
-- PHP 8.0+
-- A Vatly API key ([vatly.com](https://vatly.com))
-
 ## Installation
+
+Requires PHP 8.0+ and a Vatly API key ([vatly.com](https://vatly.com)).
 
 ```bash
 composer require vatly/vatly-fluent-php
@@ -64,8 +31,135 @@ composer require vatly/vatly-fluent-php
 Pin to an exact version during alpha:
 
 ```bash
-composer require vatly/vatly-fluent-php:v0.4.0-alpha.3
+composer require vatly/vatly-fluent-php:v0.5.0-alpha.1
 ```
+
+## What's inside
+
+- **Orchestrator** ([src/Billable.php](src/Billable.php), [src/BillableFactory.php](src/BillableFactory.php), [src/SubscriptionHandle.php](src/SubscriptionHandle.php)): the canonical per-owner API surface — `subscribe()`, `checkout()`, `subscribed()`, `subscription()`, `createAsVatlyCustomer()`, etc. Drivers expose this through a framework-idiomatic accessor.
+- **Contracts** ([src/Contracts](src/Contracts)): `BillableInterface`, `SubscriptionInterface`, `OrderInterface`, repository interfaces (subscription / customer / order / webhook call), `EventDispatcherInterface`, `ConfigurationInterface`, `WebhookReactionInterface`.
+- **Webhook pipeline** ([src/Webhooks](src/Webhooks)): `WebhookProcessor` orchestrates signature verification → event parsing → audit logging → reactions → dispatch. Built-in reactions: `SyncSubscriptionOnStarted`, `StoreOrderOnPaid`, `CancelSubscriptionOnCanceled`. Wire it in one call with `WebhookProcessorFactory::create()`.
+- **Events** ([src/Events](src/Events)): typed POPOs — `OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, `LocalSubscriptionCreated`, `WebhookReceived`, `UnsupportedWebhookReceived`.
+- **Actions** ([src/Actions](src/Actions)): thin wrappers around [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) returning raw `Vatly\API\Resources\*` objects.
+- **Builders** ([src/Builders](src/Builders)): `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`.
+- **Data DTOs** ([src/Data](src/Data)): immutable inputs for repository operations.
+
+## Building a driver
+
+A driver is the framework-specific layer that fills in the abstractions defined here. The reference driver is [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — its `VatlyServiceProvider` and `Billable` trait are the working examples to crib from.
+
+### Architecture
+
+| Concern | Lives in fluent | Lives in the driver |
+| --- | --- | --- |
+| Webhook signature, parsing, reactions, dispatch | ✅ | — |
+| Typed events (`OrderPaid`, `SubscriptionStarted`, …) | ✅ | — |
+| Action wrappers around the raw API SDK | ✅ | — |
+| Per-owner orchestrator (`Vatly\Fluent\Billable`) | ✅ | — |
+| Repository **contracts** | ✅ | — |
+| Repository **implementations** (Eloquent / Doctrine / `$wpdb` / …) | — | ✅ |
+| `BillableInterface` implementation on a User/Tenant entity | — | ✅ |
+| Configuration source (env, framework config) | — | ✅ |
+| Event dispatcher bridge | — | ✅ |
+| HTTP route for the webhook endpoint | — | ✅ |
+| DI / service-container wiring | — | ✅ |
+| `vatlyBillable()` accessor on the host entity | — | ✅ |
+
+### 1. Contracts to implement
+
+All under `Vatly\Fluent\Contracts\`:
+
+- **`BillableInterface`** — represents a customer entity (User, Tenant, etc.). Methods: `getVatlyId()`, `setVatlyId()`, `hasVatlyId()`, `getVatlyEmail()`, `getVatlyName()`, `getKey()`, `save()`.
+- **`ConfigurationInterface`** — `getApiKey()`, `getApiUrl()`, `getApiVersion()`, `getWebhookSecret()`, `isTestmode()`, `getDefaultRedirectUrlSuccess()`, `getDefaultRedirectUrlCanceled()`, `getBillableModel()`.
+- **`SubscriptionRepositoryInterface`** — `findByVatlyId()`, `findByOwnerAndType()`, `findAllByOwner()`, `ownerHasActiveSubscription()`, `store(StoreSubscriptionData)`, `update(SubscriptionInterface, UpdateSubscriptionData)`.
+- **`CustomerRepositoryInterface`** — `findByVatlyId()`, `findByVatlyIdOrFail()`, `save(BillableInterface)`.
+- **`OrderRepositoryInterface`** — `findByVatlyId()`, `findAllByOwner()`, `store(StoreOrderData)`, `update(OrderInterface, UpdateOrderData)`.
+- **`WebhookCallRepositoryInterface`** — `record(…)` (audit log), `cleanUp(int $days)`.
+- **`EventDispatcherInterface`** — single method `dispatch(object $event)`. Bridge to your framework's event bus or PSR-14.
+
+Your driver also needs concrete `SubscriptionInterface` and `OrderInterface` implementations (typically your ORM models).
+
+### 2. Wiring sequence
+
+In your driver's bootstrap (`ServiceProvider`, bundle config, plugin init), wire in this order:
+
+1. Bind your `ConfigurationInterface` implementation.
+2. Construct a `Vatly\API\VatlyApiClient` and configure it from your `ConfigurationInterface`.
+3. Bind your repository implementations to the four repository contracts.
+4. Bind your event dispatcher implementation to `EventDispatcherInterface`.
+5. Build a `WebhookProcessor` via the factory:
+
+```php
+use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
+
+$processor = WebhookProcessorFactory::create(
+    config: $config,
+    subscriptions: $subscriptionRepository,
+    orders: $orderRepository,
+    webhookCalls: $webhookCallRepository,
+    dispatcher: $eventDispatcher,
+    additionalReactions: [
+        // Optional custom reactions implementing WebhookReactionInterface
+    ],
+);
+```
+
+If you need to swap out the `SignatureVerifier` or `WebhookEventFactory`, construct `WebhookProcessor` directly with all the reactions instead.
+
+6. Register a `BillableFactory` singleton with the shared dependencies:
+
+```php
+use Vatly\Fluent\BillableFactory;
+
+$factory = new BillableFactory(
+    subscriptions: $subscriptionRepository,
+    customers: $customerRepository,
+    orders: $orderRepository,
+    config: $config,
+    createCheckoutAction: new CreateCheckout($apiClient),
+    createCustomerAction: new CreateCustomer($apiClient),
+    getCustomerAction: new GetCustomer($apiClient),
+    getSubscriptionAction: new GetSubscription($apiClient),
+    swapSubscriptionPlanAction: new SwapSubscriptionPlan($apiClient),
+    cancelSubscriptionAction: new CancelSubscription($apiClient),
+    createBillingUpdateLinkAction: new CreateSubscriptionBillingUpdateLink($apiClient),
+);
+```
+
+7. In your User/Tenant trait or base class, expose the orchestrator:
+
+```php
+public function vatlyBillable(): \Vatly\Fluent\Billable
+{
+    return $container->get(BillableFactory::class)->forOwner($this);
+}
+```
+
+### 3. The webhook endpoint
+
+Expose a single POST route in your framework. In the handler:
+
+```php
+try {
+    $processor->handle(
+        payload: $request->getRawBody(),       // raw, not deserialized
+        signature: $request->getHeader('X-Vatly-Signature') ?? '',
+    );
+    return new Response(status: 201);
+} catch (InvalidWebhookSignatureException) {
+    return new Response(status: 403);
+}
+```
+
+Return `2xx` on success, `403` on signature mismatch. Anything else and Vatly will retry.
+
+### 4. Application-facing ergonomics
+
+The canonical per-owner API surface lives on `Vatly\Fluent\Billable` (returned by `vatlyBillable()`). Drivers typically expose that surface through framework idioms:
+
+- **Cashier-style proxy methods** on the entity trait — `$user->subscribe()`, `$user->subscribed('default')`, `$user->subscription('default')`, `$user->checkout()` — that delegate to `vatlyBillable()->X()`. See [vatly-laravel's `Billable` trait](https://github.com/Vatly/vatly-laravel/blob/main/src/Billable.php) for the reference.
+- **ORM-native relations** for collection-style access (`$user->subscriptions`) that fluent can't provide.
+- **Audit/admin views, console commands, fakes** — purely driver-level.
 
 ## Testing
 
@@ -73,9 +167,9 @@ composer require vatly/vatly-fluent-php:v0.4.0-alpha.3
 composer test
 ```
 
-## Contributing & building a driver
+## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the contracts a driver implements, the wiring pattern, and the planned consolidation work.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, design principles, and the PR process. If you've built a Vatly driver for a framework not yet covered, that's also where to PR yourself onto the driver table above.
 
 ## License
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -25,11 +25,10 @@ use Vatly\Fluent\Exceptions\CustomerAlreadyCreatedException;
 use Vatly\Fluent\Exceptions\InvalidCustomerException;
 
 /**
- * The per-owner Vatly orchestrator.
+ * The per-owner Vatly orchestrator — the canonical API surface.
  *
- * This is the canonical surface every driver exposes — Laravel, Symfony,
- * WordPress, etc. each provide a thin accessor (e.g. `$user->vatlyBillable()`)
- * that returns one of these.
+ * Drivers expose this through a framework-idiomatic accessor on the host
+ * entity (e.g. `$user->vatlyBillable()`) that returns one of these.
  */
 class Billable
 {
@@ -144,11 +143,6 @@ class Billable
         );
     }
 
-    public function newCheckout(): CheckoutBuilder
-    {
-        return $this->checkout();
-    }
-
     // --- Subscriptions ---
 
     public function subscribe(): SubscriptionBuilder
@@ -158,14 +152,6 @@ class Billable
             owner: $this->owner,
             checkoutBuilder: $this->checkout(),
         );
-    }
-
-    /**
-     * Cashier-style alias of subscribe().
-     */
-    public function newSubscription(): SubscriptionBuilder
-    {
-        return $this->subscribe();
     }
 
     public function subscribed(string $type = 'default'): bool

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent;
+
+use Vatly\API\Resources\Customer;
+use Vatly\Fluent\Actions\CancelSubscription;
+use Vatly\Fluent\Actions\CreateCheckout;
+use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\SwapSubscriptionPlan;
+use Vatly\Fluent\Builders\CheckoutBuilder;
+use Vatly\Fluent\Builders\SubscriptionBuilder;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Exceptions\CustomerAlreadyCreatedException;
+use Vatly\Fluent\Exceptions\InvalidCustomerException;
+
+/**
+ * The per-owner Vatly orchestrator.
+ *
+ * This is the canonical surface every driver exposes — Laravel, Symfony,
+ * WordPress, etc. each provide a thin accessor (e.g. `$user->vatlyBillable()`)
+ * that returns one of these.
+ */
+class Billable
+{
+    public function __construct(
+        private readonly BillableInterface $owner,
+        private readonly SubscriptionRepositoryInterface $subscriptions,
+        private readonly CustomerRepositoryInterface $customers,
+        private readonly OrderRepositoryInterface $orders,
+        private readonly ConfigurationInterface $config,
+        private readonly CreateCheckout $createCheckoutAction,
+        private readonly CreateCustomer $createCustomerAction,
+        private readonly GetCustomer $getCustomerAction,
+        private readonly GetSubscription $getSubscriptionAction,
+        private readonly SwapSubscriptionPlan $swapSubscriptionPlanAction,
+        private readonly CancelSubscription $cancelSubscriptionAction,
+        private readonly CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+    ) {
+        //
+    }
+
+    public function owner(): BillableInterface
+    {
+        return $this->owner;
+    }
+
+    // --- Customer ---
+
+    /**
+     * Create the corresponding Vatly customer for this owner. Persists the
+     * resulting customer ID on the owner via CustomerRepository::save().
+     *
+     * @param array<string, mixed> $options Additional Vatly customer payload (email/name overrides etc.).
+     *
+     * @throws CustomerAlreadyCreatedException
+     */
+    public function createAsVatlyCustomer(array $options = []): Customer
+    {
+        if ($this->owner->hasVatlyId()) {
+            throw CustomerAlreadyCreatedException::exists($this->owner);
+        }
+
+        if (! array_key_exists('email', $options) && $email = $this->owner->getVatlyEmail()) {
+            $options['email'] = $email;
+        }
+
+        if (! array_key_exists('name', $options) && $name = $this->owner->getVatlyName()) {
+            $options['name'] = $name;
+        }
+
+        $customer = $this->createCustomerAction->execute($options);
+
+        $this->owner->setVatlyId($customer->id);
+        $this->customers->save($this->owner);
+
+        return $customer;
+    }
+
+    /**
+     * Fetch this owner's current Vatly customer.
+     *
+     * @throws InvalidCustomerException When no Vatly customer ID is set.
+     */
+    public function asVatlyCustomer(): Customer
+    {
+        $this->assertCustomerExists();
+
+        return $this->getCustomerAction->execute((string) $this->owner->getVatlyId());
+    }
+
+    /**
+     * Return the existing Vatly customer if one is linked, otherwise create one.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function createOrGetVatlyCustomer(array $options = []): Customer
+    {
+        if ($this->owner->hasVatlyId()) {
+            return $this->asVatlyCustomer();
+        }
+
+        return $this->createAsVatlyCustomer($options);
+    }
+
+    /**
+     * Ensure a Vatly customer exists for this owner. No-op if already linked.
+     *
+     * @param array<string, mixed> $createOptions
+     */
+    public function ensureHasVatlyCustomer(array $createOptions = []): void
+    {
+        if ($this->owner->hasVatlyId()) {
+            return;
+        }
+
+        $this->createAsVatlyCustomer($createOptions);
+    }
+
+    public function assertCustomerExists(): void
+    {
+        if (! $this->owner->hasVatlyId()) {
+            throw InvalidCustomerException::notYetCreated($this->owner);
+        }
+    }
+
+    // --- Checkouts ---
+
+    public function checkout(): CheckoutBuilder
+    {
+        return new CheckoutBuilder(
+            owner: $this->owner,
+            createCheckout: $this->createCheckoutAction,
+        );
+    }
+
+    public function newCheckout(): CheckoutBuilder
+    {
+        return $this->checkout();
+    }
+
+    // --- Subscriptions ---
+
+    public function subscribe(): SubscriptionBuilder
+    {
+        return new SubscriptionBuilder(
+            config: $this->config,
+            owner: $this->owner,
+            checkoutBuilder: $this->checkout(),
+        );
+    }
+
+    /**
+     * Cashier-style alias of subscribe().
+     */
+    public function newSubscription(): SubscriptionBuilder
+    {
+        return $this->subscribe();
+    }
+
+    public function subscribed(string $type = 'default'): bool
+    {
+        return $this->subscriptions->ownerHasActiveSubscription($this->owner, $type);
+    }
+
+    public function subscription(string $type = 'default'): ?SubscriptionHandle
+    {
+        $subscription = $this->subscriptions->findByOwnerAndType($this->owner, $type);
+
+        if ($subscription === null) {
+            return null;
+        }
+
+        return $this->handleFor($subscription);
+    }
+
+    /**
+     * Build a SubscriptionHandle wrapping the given subscription.
+     */
+    public function handleFor(SubscriptionInterface $subscription): SubscriptionHandle
+    {
+        return new SubscriptionHandle(
+            subscription: $subscription,
+            subscriptions: $this->subscriptions,
+            swapAction: $this->swapSubscriptionPlanAction,
+            cancelAction: $this->cancelSubscriptionAction,
+            getSubscriptionAction: $this->getSubscriptionAction,
+            createBillingUpdateLinkAction: $this->createBillingUpdateLinkAction,
+        );
+    }
+
+    // --- Orders ---
+
+    /**
+     * @return OrderInterface[]
+     */
+    public function orders(): array
+    {
+        return $this->orders->findAllByOwner($this->owner);
+    }
+}

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -112,7 +112,7 @@ class Billable
         return $this->createAsVatlyCustomer($options);
     }
 
-    public function assertCustomerExists(): void
+    private function assertCustomerExists(): void
     {
         if (! $this->owner->hasVatlyId()) {
             throw InvalidCustomerException::notYetCreated($this->owner);
@@ -156,10 +156,7 @@ class Billable
         return $this->handleFor($subscription);
     }
 
-    /**
-     * Build a SubscriptionHandle wrapping the given subscription.
-     */
-    public function handleFor(SubscriptionInterface $subscription): SubscriptionHandle
+    private function handleFor(SubscriptionInterface $subscription): SubscriptionHandle
     {
         return new SubscriptionHandle(
             subscription: $subscription,

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -34,18 +34,18 @@ use Vatly\Fluent\Exceptions\InvalidCustomerException;
 class Billable
 {
     public function __construct(
-        private readonly BillableInterface $owner,
-        private readonly SubscriptionRepositoryInterface $subscriptions,
-        private readonly CustomerRepositoryInterface $customers,
-        private readonly OrderRepositoryInterface $orders,
-        private readonly ConfigurationInterface $config,
-        private readonly CreateCheckout $createCheckoutAction,
-        private readonly CreateCustomer $createCustomerAction,
-        private readonly GetCustomer $getCustomerAction,
-        private readonly GetSubscription $getSubscriptionAction,
-        private readonly SwapSubscriptionPlan $swapSubscriptionPlanAction,
-        private readonly CancelSubscription $cancelSubscriptionAction,
-        private readonly CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+        private BillableInterface $owner,
+        private SubscriptionRepositoryInterface $subscriptions,
+        private CustomerRepositoryInterface $customers,
+        private OrderRepositoryInterface $orders,
+        private ConfigurationInterface $config,
+        private CreateCheckout $createCheckoutAction,
+        private CreateCustomer $createCustomerAction,
+        private GetCustomer $getCustomerAction,
+        private GetSubscription $getSubscriptionAction,
+        private SwapSubscriptionPlan $swapSubscriptionPlanAction,
+        private CancelSubscription $cancelSubscriptionAction,
+        private CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
     ) {
         //
     }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -112,20 +112,6 @@ class Billable
         return $this->createAsVatlyCustomer($options);
     }
 
-    /**
-     * Ensure a Vatly customer exists for this owner. No-op if already linked.
-     *
-     * @param array<string, mixed> $createOptions
-     */
-    public function ensureHasVatlyCustomer(array $createOptions = []): void
-    {
-        if ($this->owner->hasVatlyId()) {
-            return;
-        }
-
-        $this->createAsVatlyCustomer($createOptions);
-    }
-
     public function assertCustomerExists(): void
     {
         if (! $this->owner->hasVatlyId()) {

--- a/src/BillableFactory.php
+++ b/src/BillableFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent;
+
+use Vatly\Fluent\Actions\CancelSubscription;
+use Vatly\Fluent\Actions\CreateCheckout;
+use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\SwapSubscriptionPlan;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+
+/**
+ * Builds a Vatly\Fluent\Billable orchestrator bound to a specific owner.
+ *
+ * Drivers register this as a singleton in their DI container with all the
+ * shared dependencies (repos, actions, config) and call ->forOwner($entity)
+ * inside the per-owner accessor trait/method.
+ */
+class BillableFactory
+{
+    public function __construct(
+        private readonly SubscriptionRepositoryInterface $subscriptions,
+        private readonly CustomerRepositoryInterface $customers,
+        private readonly OrderRepositoryInterface $orders,
+        private readonly ConfigurationInterface $config,
+        private readonly CreateCheckout $createCheckoutAction,
+        private readonly CreateCustomer $createCustomerAction,
+        private readonly GetCustomer $getCustomerAction,
+        private readonly GetSubscription $getSubscriptionAction,
+        private readonly SwapSubscriptionPlan $swapSubscriptionPlanAction,
+        private readonly CancelSubscription $cancelSubscriptionAction,
+        private readonly CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+    ) {
+        //
+    }
+
+    public function forOwner(BillableInterface $owner): Billable
+    {
+        return new Billable(
+            owner: $owner,
+            subscriptions: $this->subscriptions,
+            customers: $this->customers,
+            orders: $this->orders,
+            config: $this->config,
+            createCheckoutAction: $this->createCheckoutAction,
+            createCustomerAction: $this->createCustomerAction,
+            getCustomerAction: $this->getCustomerAction,
+            getSubscriptionAction: $this->getSubscriptionAction,
+            swapSubscriptionPlanAction: $this->swapSubscriptionPlanAction,
+            cancelSubscriptionAction: $this->cancelSubscriptionAction,
+            createBillingUpdateLinkAction: $this->createBillingUpdateLinkAction,
+        );
+    }
+}

--- a/src/BillableFactory.php
+++ b/src/BillableFactory.php
@@ -27,17 +27,17 @@ use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 class BillableFactory
 {
     public function __construct(
-        private readonly SubscriptionRepositoryInterface $subscriptions,
-        private readonly CustomerRepositoryInterface $customers,
-        private readonly OrderRepositoryInterface $orders,
-        private readonly ConfigurationInterface $config,
-        private readonly CreateCheckout $createCheckoutAction,
-        private readonly CreateCustomer $createCustomerAction,
-        private readonly GetCustomer $getCustomerAction,
-        private readonly GetSubscription $getSubscriptionAction,
-        private readonly SwapSubscriptionPlan $swapSubscriptionPlanAction,
-        private readonly CancelSubscription $cancelSubscriptionAction,
-        private readonly CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+        private SubscriptionRepositoryInterface $subscriptions,
+        private CustomerRepositoryInterface $customers,
+        private OrderRepositoryInterface $orders,
+        private ConfigurationInterface $config,
+        private CreateCheckout $createCheckoutAction,
+        private CreateCustomer $createCustomerAction,
+        private GetCustomer $getCustomerAction,
+        private GetSubscription $getSubscriptionAction,
+        private SwapSubscriptionPlan $swapSubscriptionPlanAction,
+        private CancelSubscription $cancelSubscriptionAction,
+        private CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
     ) {
         //
     }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -18,5 +18,6 @@ class UpdateSubscriptionData
         public ?string $name = null,
         public ?int $quantity = null,
         public ?DateTimeInterface $endsAt = null,
+        public ?string $type = null,
     ) {}
 }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -18,6 +18,5 @@ class UpdateSubscriptionData
         public ?string $name = null,
         public ?int $quantity = null,
         public ?DateTimeInterface $endsAt = null,
-        public ?string $type = null,
     ) {}
 }

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use DateTimeImmutable;
+use DateTimeInterface;
+
 /**
  * Event representing a subscription being canceled immediately at Vatly.
  *
@@ -16,6 +19,7 @@ class SubscriptionCanceledImmediately
     public function __construct(
         public string $customerId,
         public string $subscriptionId,
+        public DateTimeInterface $endsAt,
     ) {
         //
     }
@@ -25,6 +29,7 @@ class SubscriptionCanceledImmediately
         return new self(
             customerId: $webhook->object['data']['customerId'],
             subscriptionId: $webhook->resourceId,
+            endsAt: new DateTimeImmutable($webhook->raisedAt),
         );
     }
 }

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -118,7 +118,7 @@ class SubscriptionHandle
      * @param array<string, mixed> $options Extra parameters passed to the Vatly API
      *                                      (e.g. applyImmediately, invoiceImmediately).
      */
-    public function swap(string $type, string $planId, array $options = []): self
+    public function swap(string $planId, array $options = []): self
     {
         $response = $this->swapAction->execute(
             $this->subscription->getVatlyId(),
@@ -131,7 +131,6 @@ class SubscriptionHandle
             new UpdateSubscriptionData(
                 planId: $response->subscriptionPlanId,
                 quantity: $response->quantity,
-                type: $type,
             ),
         );
 
@@ -147,12 +146,12 @@ class SubscriptionHandle
      *
      * @param array<string, mixed> $options
      */
-    public function swapAndInvoice(string $type, string $planId, array $options = []): self
+    public function swapAndInvoice(string $planId, array $options = []): self
     {
         $options['applyImmediately'] = true;
         $options['invoiceImmediately'] = true;
 
-        return $this->swap($type, $planId, $options);
+        return $this->swap($planId, $options);
     }
 
     /**

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent;
+
+use DateTimeInterface;
+use Vatly\API\Types\Link;
+use Vatly\Fluent\Actions\CancelSubscription;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\SwapSubscriptionPlan;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Exceptions\FeatureUnavailableException;
+
+/**
+ * Framework-agnostic operations on a subscription.
+ *
+ * Wraps a SubscriptionInterface (the persistent state, owned by the driver)
+ * with the actions that operate on it. Drivers expose this via
+ * Billable::subscription().
+ */
+class SubscriptionHandle
+{
+    public function __construct(
+        private SubscriptionInterface $subscription,
+        private readonly SubscriptionRepositoryInterface $subscriptions,
+        private readonly SwapSubscriptionPlan $swapAction,
+        private readonly CancelSubscription $cancelAction,
+        private readonly GetSubscription $getSubscriptionAction,
+        private readonly CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+    ) {
+        //
+    }
+
+    /**
+     * The underlying persistent subscription record.
+     */
+    public function model(): SubscriptionInterface
+    {
+        return $this->subscription;
+    }
+
+    // --- State accessors (delegate to SubscriptionInterface) ---
+
+    public function getVatlyId(): string
+    {
+        return $this->subscription->getVatlyId();
+    }
+
+    public function getType(): string
+    {
+        return $this->subscription->getType();
+    }
+
+    public function getPlanId(): string
+    {
+        return $this->subscription->getPlanId();
+    }
+
+    public function getName(): string
+    {
+        return $this->subscription->getName();
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->subscription->getQuantity();
+    }
+
+    public function getEndsAt(): ?DateTimeInterface
+    {
+        return $this->subscription->getEndsAt();
+    }
+
+    public function getOwner(): BillableInterface
+    {
+        return $this->subscription->getOwner();
+    }
+
+    public function isCancelled(): bool
+    {
+        return $this->subscription->isCancelled();
+    }
+
+    public function cancelled(): bool
+    {
+        return $this->subscription->isCancelled();
+    }
+
+    public function isOnGracePeriod(): bool
+    {
+        return $this->subscription->isOnGracePeriod();
+    }
+
+    public function onGracePeriod(): bool
+    {
+        return $this->subscription->isOnGracePeriod();
+    }
+
+    public function isActive(): bool
+    {
+        return $this->subscription->isActive();
+    }
+
+    public function active(): bool
+    {
+        return $this->subscription->isActive();
+    }
+
+    // --- Operations ---
+
+    /**
+     * Swap the subscription to a different plan.
+     *
+     * @param array<string, mixed> $options Extra parameters passed to the Vatly API
+     *                                      (e.g. applyImmediately, invoiceImmediately).
+     */
+    public function swap(string $type, string $planId, array $options = []): self
+    {
+        $response = $this->swapAction->execute(
+            $this->subscription->getVatlyId(),
+            $planId,
+            $options,
+        );
+
+        $updated = $this->subscriptions->update(
+            $this->subscription,
+            new UpdateSubscriptionData(
+                planId: $response->subscriptionPlanId,
+                quantity: $response->quantity,
+                type: $type,
+            ),
+        );
+
+        $this->subscription = $updated;
+
+        return $this;
+    }
+
+    /**
+     * Swap to a new plan and invoice immediately.
+     *
+     * Applies the plan change right away and creates an invoice for prorated charges.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function swapAndInvoice(string $type, string $planId, array $options = []): self
+    {
+        $options['applyImmediately'] = true;
+        $options['invoiceImmediately'] = true;
+
+        return $this->swap($type, $planId, $options);
+    }
+
+    /**
+     * Resume a cancelled subscription.
+     *
+     * @throws FeatureUnavailableException Vatly's API does not currently support resuming.
+     */
+    public function resume(): self
+    {
+        throw FeatureUnavailableException::notImplementedOnApi();
+    }
+
+    /**
+     * Create a signed URL where the customer can update billing details
+     * (billing address, VAT number, company name) via a hosted flow.
+     *
+     * Each call returns a fresh time-bounded link.
+     *
+     * @param array<string, mixed> $prefillData Optional pre-fill data.
+     */
+    public function createBillingUpdateLink(array $prefillData = []): string
+    {
+        $link = $this->createBillingUpdateLinkAction->execute(
+            $this->subscription->getVatlyId(),
+            $prefillData,
+        );
+
+        assert($link instanceof Link);
+
+        return $link->href;
+    }
+
+    /**
+     * Cancel the subscription at Vatly.
+     *
+     * The webhook reaction is responsible for updating the local end date
+     * once Vatly confirms (immediate vs. grace period).
+     */
+    public function cancel(): void
+    {
+        $this->cancelAction->execute($this->subscription->getVatlyId());
+    }
+
+    /**
+     * Refresh the local subscription record from Vatly.
+     */
+    public function sync(): self
+    {
+        $response = $this->getSubscriptionAction->execute($this->subscription->getVatlyId());
+
+        $endsAt = $this->resolveEndsAt($response);
+
+        $updated = $this->subscriptions->update(
+            $this->subscription,
+            new UpdateSubscriptionData(
+                planId: $response->subscriptionPlanId,
+                name: $response->name,
+                quantity: $response->quantity,
+                endsAt: $endsAt,
+            ),
+        );
+
+        $this->subscription = $updated;
+
+        return $this;
+    }
+
+    private function resolveEndsAt(\Vatly\API\Resources\Subscription $response): ?DateTimeInterface
+    {
+        if ($response->endedAt !== null) {
+            return new \DateTimeImmutable($response->endedAt);
+        }
+
+        if ($response->cancelledAt !== null && $this->subscription->getEndsAt() === null) {
+            return new \DateTimeImmutable($response->cancelledAt);
+        }
+
+        return $this->subscription->getEndsAt();
+    }
+}

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Vatly\Fluent;
 
 use DateTimeInterface;
-use Vatly\API\Types\Link;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
 use Vatly\Fluent\Actions\GetSubscription;
@@ -27,11 +26,11 @@ class SubscriptionHandle
 {
     public function __construct(
         private SubscriptionInterface $subscription,
-        private readonly SubscriptionRepositoryInterface $subscriptions,
-        private readonly SwapSubscriptionPlan $swapAction,
-        private readonly CancelSubscription $cancelAction,
-        private readonly GetSubscription $getSubscriptionAction,
-        private readonly CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+        private SubscriptionRepositoryInterface $subscriptions,
+        private SwapSubscriptionPlan $swapAction,
+        private CancelSubscription $cancelAction,
+        private GetSubscription $getSubscriptionAction,
+        private CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
     ) {
         //
     }
@@ -180,8 +179,6 @@ class SubscriptionHandle
             $this->subscription->getVatlyId(),
             $prefillData,
         );
-
-        assert($link instanceof Link);
 
         return $link->href;
     }

--- a/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
+++ b/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks\Reactions;
 
-use DateTimeImmutable;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
@@ -28,24 +27,19 @@ class CancelSubscriptionOnCanceled implements WebhookReactionInterface
 
     public function handle(object $event): void
     {
-        $subscriptionId = match (true) {
-            $event instanceof SubscriptionCanceledImmediately => $event->subscriptionId,
-            $event instanceof SubscriptionCanceledWithGracePeriod => $event->subscriptionId,
-            default => throw new \InvalidArgumentException('Unsupported event type'),
-        };
+        if (! $event instanceof SubscriptionCanceledImmediately
+            && ! $event instanceof SubscriptionCanceledWithGracePeriod) {
+            return;
+        }
 
-        $subscription = $this->subscriptions->findByVatlyId($subscriptionId);
+        $subscription = $this->subscriptions->findByVatlyId($event->subscriptionId);
 
         if ($subscription === null) {
             return;
         }
 
-        $endsAt = $event instanceof SubscriptionCanceledImmediately
-            ? new DateTimeImmutable()
-            : $event->endsAt;
-
         $this->subscriptions->update($subscription, new UpdateSubscriptionData(
-            endsAt: $endsAt,
+            endsAt: $event->endsAt,
         ));
     }
 }

--- a/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
+++ b/src/Webhooks/Reactions/CancelSubscriptionOnCanceled.php
@@ -40,11 +40,9 @@ class CancelSubscriptionOnCanceled implements WebhookReactionInterface
             return;
         }
 
-        $endsAt = match (true) {
-            $event instanceof SubscriptionCanceledImmediately => new DateTimeImmutable(),
-            $event instanceof SubscriptionCanceledWithGracePeriod => $event->endsAt,
-            default => throw new \InvalidArgumentException('Unsupported event type'),
-        };
+        $endsAt = $event instanceof SubscriptionCanceledImmediately
+            ? new DateTimeImmutable()
+            : $event->endsAt;
 
         $this->subscriptions->update($subscription, new UpdateSubscriptionData(
             endsAt: $endsAt,

--- a/src/Webhooks/WebhookProcessor.php
+++ b/src/Webhooks/WebhookProcessor.php
@@ -66,4 +66,12 @@ class WebhookProcessor
 
         $this->dispatcher->dispatch($event);
     }
+
+    /**
+     * @return WebhookReactionInterface[]
+     */
+    public function getReactions(): array
+    {
+        return $this->reactions;
+    }
 }

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks;
+
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
+
+class WebhookProcessorFactory
+{
+    /**
+     * Build a WebhookProcessor wired with the standard reactions.
+     *
+     * Drivers call this from their bootstrap to avoid re-deriving the
+     * reaction registration list on each install.
+     *
+     * @param WebhookReactionInterface[] $additionalReactions
+     */
+    public static function create(
+        ConfigurationInterface $config,
+        SubscriptionRepositoryInterface $subscriptions,
+        OrderRepositoryInterface $orders,
+        WebhookCallRepositoryInterface $webhookCalls,
+        EventDispatcherInterface $dispatcher,
+        array $additionalReactions = [],
+    ): WebhookProcessor {
+        return new WebhookProcessor(
+            signatureVerifier: new SignatureVerifier(),
+            eventFactory: new WebhookEventFactory(),
+            repository: $webhookCalls,
+            dispatcher: $dispatcher,
+            webhookSecret: $config->getWebhookSecret() ?? '',
+            reactions: [
+                new SyncSubscriptionOnStarted($subscriptions, $dispatcher),
+                new CancelSubscriptionOnCanceled($subscriptions),
+                new StoreOrderOnPaid($orders),
+                ...$additionalReactions,
+            ],
+        );
+    }
+}

--- a/tests/BillableFactoryTest.php
+++ b/tests/BillableFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests;
+
+use Mockery;
+use Vatly\Fluent\Actions\CancelSubscription;
+use Vatly\Fluent\Actions\CreateCheckout;
+use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\SwapSubscriptionPlan;
+use Vatly\Fluent\Billable;
+use Vatly\Fluent\BillableFactory;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+
+class BillableFactoryTest extends TestCase
+{
+    public function test_for_owner_returns_a_billable_bound_to_the_given_owner(): void
+    {
+        $owner = Mockery::mock(BillableInterface::class);
+
+        $factory = new BillableFactory(
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            customers: Mockery::mock(CustomerRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            config: Mockery::mock(ConfigurationInterface::class),
+            createCheckoutAction: Mockery::mock(CreateCheckout::class),
+            createCustomerAction: Mockery::mock(CreateCustomer::class),
+            getCustomerAction: Mockery::mock(GetCustomer::class),
+            getSubscriptionAction: Mockery::mock(GetSubscription::class),
+            swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
+            cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
+            createBillingUpdateLinkAction: Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+        );
+
+        $billable = $factory->forOwner($owner);
+
+        $this->assertInstanceOf(Billable::class, $billable);
+        $this->assertSame($owner, $billable->owner());
+    }
+
+    public function test_for_owner_returns_a_fresh_billable_each_call(): void
+    {
+        $factory = new BillableFactory(
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            customers: Mockery::mock(CustomerRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            config: Mockery::mock(ConfigurationInterface::class),
+            createCheckoutAction: Mockery::mock(CreateCheckout::class),
+            createCustomerAction: Mockery::mock(CreateCustomer::class),
+            getCustomerAction: Mockery::mock(GetCustomer::class),
+            getSubscriptionAction: Mockery::mock(GetSubscription::class),
+            swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
+            cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
+            createBillingUpdateLinkAction: Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+        );
+
+        $ownerA = Mockery::mock(BillableInterface::class);
+        $ownerB = Mockery::mock(BillableInterface::class);
+
+        $billableA = $factory->forOwner($ownerA);
+        $billableB = $factory->forOwner($ownerB);
+
+        $this->assertNotSame($billableA, $billableB);
+        $this->assertSame($ownerA, $billableA->owner());
+        $this->assertSame($ownerB, $billableB->owner());
+    }
+}

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -35,7 +35,6 @@ class BillableTest extends TestCase
         $billable = $this->buildBillable();
 
         $this->assertInstanceOf(CheckoutBuilder::class, $billable->checkout());
-        $this->assertInstanceOf(CheckoutBuilder::class, $billable->newCheckout());
     }
 
     public function test_subscribe_returns_a_subscription_builder(): void
@@ -47,7 +46,6 @@ class BillableTest extends TestCase
         $billable = $this->buildBillable(config: $config);
 
         $this->assertInstanceOf(SubscriptionBuilder::class, $billable->subscribe());
-        $this->assertInstanceOf(SubscriptionBuilder::class, $billable->newSubscription());
     }
 
     public function test_subscribed_delegates_to_the_repository(): void

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests;
+
+use Mockery;
+use ReflectionClass;
+use Vatly\API\Resources\Customer;
+use Vatly\Fluent\Actions\CancelSubscription;
+use Vatly\Fluent\Actions\CreateCheckout;
+use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\SwapSubscriptionPlan;
+use Vatly\Fluent\Billable;
+use Vatly\Fluent\Builders\CheckoutBuilder;
+use Vatly\Fluent\Builders\SubscriptionBuilder;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Exceptions\CustomerAlreadyCreatedException;
+use Vatly\Fluent\Exceptions\InvalidCustomerException;
+use Vatly\Fluent\SubscriptionHandle;
+
+class BillableTest extends TestCase
+{
+    public function test_checkout_returns_a_builder_bound_to_the_owner(): void
+    {
+        $billable = $this->buildBillable();
+
+        $this->assertInstanceOf(CheckoutBuilder::class, $billable->checkout());
+        $this->assertInstanceOf(CheckoutBuilder::class, $billable->newCheckout());
+    }
+
+    public function test_subscribe_returns_a_subscription_builder(): void
+    {
+        $config = Mockery::mock(ConfigurationInterface::class);
+        $config->shouldReceive('getDefaultRedirectUrlSuccess')->andReturn('https://app/done');
+        $config->shouldReceive('getDefaultRedirectUrlCanceled')->andReturn('https://app/back');
+
+        $billable = $this->buildBillable(config: $config);
+
+        $this->assertInstanceOf(SubscriptionBuilder::class, $billable->subscribe());
+        $this->assertInstanceOf(SubscriptionBuilder::class, $billable->newSubscription());
+    }
+
+    public function test_subscribed_delegates_to_the_repository(): void
+    {
+        $owner = $this->stubOwner();
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('ownerHasActiveSubscription')
+            ->with($owner, 'default')
+            ->andReturn(true);
+
+        $billable = $this->buildBillable(owner: $owner, subscriptions: $subscriptions);
+
+        $this->assertTrue($billable->subscribed('default'));
+    }
+
+    public function test_subscription_returns_null_when_none_exists(): void
+    {
+        $owner = $this->stubOwner();
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('findByOwnerAndType')
+            ->with($owner, 'default')
+            ->andReturn(null);
+
+        $billable = $this->buildBillable(owner: $owner, subscriptions: $subscriptions);
+
+        $this->assertNull($billable->subscription('default'));
+    }
+
+    public function test_subscription_returns_a_handle_when_present(): void
+    {
+        $owner = $this->stubOwner();
+        $found = Mockery::mock(SubscriptionInterface::class);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('findByOwnerAndType')
+            ->with($owner, 'default')
+            ->andReturn($found);
+
+        $billable = $this->buildBillable(owner: $owner, subscriptions: $subscriptions);
+
+        $handle = $billable->subscription('default');
+
+        $this->assertInstanceOf(SubscriptionHandle::class, $handle);
+        $this->assertSame($found, $handle->model());
+    }
+
+    public function test_orders_delegates_to_the_repository(): void
+    {
+        $owner = $this->stubOwner();
+        $orderA = Mockery::mock(OrderInterface::class);
+        $orderB = Mockery::mock(OrderInterface::class);
+
+        $orders = Mockery::mock(OrderRepositoryInterface::class);
+        $orders->shouldReceive('findAllByOwner')->with($owner)->andReturn([$orderA, $orderB]);
+
+        $billable = $this->buildBillable(owner: $owner, orders: $orders);
+
+        $this->assertSame([$orderA, $orderB], $billable->orders());
+    }
+
+    public function test_create_as_vatly_customer_creates_persists_and_returns_the_customer(): void
+    {
+        $owner = Mockery::mock(BillableInterface::class);
+        $owner->shouldReceive('hasVatlyId')->andReturn(false);
+        $owner->shouldReceive('getVatlyEmail')->andReturn('sander@example.test');
+        $owner->shouldReceive('getVatlyName')->andReturn('Sander');
+        $owner->shouldReceive('setVatlyId')->once()->with('customer_xyz');
+
+        $customer = $this->makeCustomer(['id' => 'customer_xyz']);
+
+        $action = Mockery::mock(CreateCustomer::class);
+        $action->shouldReceive('execute')
+            ->once()
+            ->with(['email' => 'sander@example.test', 'name' => 'Sander'])
+            ->andReturn($customer);
+
+        $customers = Mockery::mock(CustomerRepositoryInterface::class);
+        $customers->shouldReceive('save')->once()->with($owner);
+
+        $billable = $this->buildBillable(
+            owner: $owner,
+            customers: $customers,
+            createCustomerAction: $action,
+        );
+
+        $result = $billable->createAsVatlyCustomer();
+
+        $this->assertSame('customer_xyz', $result->id);
+    }
+
+    public function test_create_as_vatly_customer_throws_when_already_linked(): void
+    {
+        $owner = $this->stubOwner(hasVatlyId: true);
+        $owner->shouldReceive('getVatlyId')->andReturn('customer_xyz');
+
+        $billable = $this->buildBillable(owner: $owner);
+
+        $this->expectException(CustomerAlreadyCreatedException::class);
+
+        $billable->createAsVatlyCustomer();
+    }
+
+    public function test_as_vatly_customer_fetches_via_get_customer_action(): void
+    {
+        $owner = Mockery::mock(BillableInterface::class);
+        $owner->shouldReceive('hasVatlyId')->andReturn(true);
+        $owner->shouldReceive('getVatlyId')->andReturn('customer_xyz');
+
+        $customer = $this->makeCustomer(['id' => 'customer_xyz']);
+
+        $action = Mockery::mock(GetCustomer::class);
+        $action->shouldReceive('execute')->with('customer_xyz')->andReturn($customer);
+
+        $billable = $this->buildBillable(owner: $owner, getCustomerAction: $action);
+
+        $this->assertSame($customer, $billable->asVatlyCustomer());
+    }
+
+    public function test_as_vatly_customer_throws_when_no_vatly_id(): void
+    {
+        $owner = $this->stubOwner(hasVatlyId: false);
+
+        $billable = $this->buildBillable(owner: $owner);
+
+        $this->expectException(InvalidCustomerException::class);
+
+        $billable->asVatlyCustomer();
+    }
+
+    public function test_ensure_has_vatly_customer_is_a_noop_when_already_linked(): void
+    {
+        $owner = $this->stubOwner(hasVatlyId: true);
+
+        $customers = Mockery::mock(CustomerRepositoryInterface::class);
+        $customers->shouldNotReceive('save');
+
+        $action = Mockery::mock(CreateCustomer::class);
+        $action->shouldNotReceive('execute');
+
+        $billable = $this->buildBillable(
+            owner: $owner,
+            customers: $customers,
+            createCustomerAction: $action,
+        );
+
+        $billable->ensureHasVatlyCustomer();
+    }
+
+    private function stubOwner(bool $hasVatlyId = false): BillableInterface
+    {
+        $owner = Mockery::mock(BillableInterface::class);
+        $owner->shouldReceive('hasVatlyId')->andReturn($hasVatlyId);
+
+        return $owner;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function makeCustomer(array $fields): Customer
+    {
+        /** @var Customer $resource */
+        $resource = (new ReflectionClass(Customer::class))->newInstanceWithoutConstructor();
+
+        foreach ($fields as $key => $value) {
+            $resource->{$key} = $value;
+        }
+
+        return $resource;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function buildBillable(
+        ?BillableInterface $owner = null,
+        ?SubscriptionRepositoryInterface $subscriptions = null,
+        ?CustomerRepositoryInterface $customers = null,
+        ?OrderRepositoryInterface $orders = null,
+        ?ConfigurationInterface $config = null,
+        ?CreateCheckout $createCheckoutAction = null,
+        ?CreateCustomer $createCustomerAction = null,
+        ?GetCustomer $getCustomerAction = null,
+        ?GetSubscription $getSubscriptionAction = null,
+        ?SwapSubscriptionPlan $swapSubscriptionPlanAction = null,
+        ?CancelSubscription $cancelSubscriptionAction = null,
+        ?CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction = null,
+    ): Billable {
+        return new Billable(
+            owner: $owner ?? $this->stubOwner(),
+            subscriptions: $subscriptions ?? Mockery::mock(SubscriptionRepositoryInterface::class),
+            customers: $customers ?? Mockery::mock(CustomerRepositoryInterface::class),
+            orders: $orders ?? Mockery::mock(OrderRepositoryInterface::class),
+            config: $config ?? Mockery::mock(ConfigurationInterface::class),
+            createCheckoutAction: $createCheckoutAction ?? Mockery::mock(CreateCheckout::class),
+            createCustomerAction: $createCustomerAction ?? Mockery::mock(CreateCustomer::class),
+            getCustomerAction: $getCustomerAction ?? Mockery::mock(GetCustomer::class),
+            getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
+            swapSubscriptionPlanAction: $swapSubscriptionPlanAction ?? Mockery::mock(SwapSubscriptionPlan::class),
+            cancelSubscriptionAction: $cancelSubscriptionAction ?? Mockery::mock(CancelSubscription::class),
+            createBillingUpdateLinkAction: $createBillingUpdateLinkAction
+                ?? Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+        );
+    }
+}

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -177,23 +177,27 @@ class BillableTest extends TestCase
         $billable->asVatlyCustomer();
     }
 
-    public function test_ensure_has_vatly_customer_is_a_noop_when_already_linked(): void
+    public function test_create_or_get_returns_existing_without_creating_when_already_linked(): void
     {
-        $owner = $this->stubOwner(hasVatlyId: true);
+        $owner = Mockery::mock(BillableInterface::class);
+        $owner->shouldReceive('hasVatlyId')->andReturn(true);
+        $owner->shouldReceive('getVatlyId')->andReturn('customer_xyz');
 
-        $customers = Mockery::mock(CustomerRepositoryInterface::class);
-        $customers->shouldNotReceive('save');
+        $customer = $this->makeCustomer(['id' => 'customer_xyz']);
 
-        $action = Mockery::mock(CreateCustomer::class);
-        $action->shouldNotReceive('execute');
+        $getCustomer = Mockery::mock(GetCustomer::class);
+        $getCustomer->shouldReceive('execute')->with('customer_xyz')->andReturn($customer);
+
+        $createCustomer = Mockery::mock(CreateCustomer::class);
+        $createCustomer->shouldNotReceive('execute');
 
         $billable = $this->buildBillable(
             owner: $owner,
-            customers: $customers,
-            createCustomerAction: $action,
+            getCustomerAction: $getCustomer,
+            createCustomerAction: $createCustomer,
         );
 
-        $billable->ensureHasVatlyCustomer();
+        $this->assertSame($customer, $billable->createOrGetVatlyCustomer());
     }
 
     private function stubOwner(bool $hasVatlyId = false): BillableInterface

--- a/tests/Events/SubscriptionCanceledTest.php
+++ b/tests/Events/SubscriptionCanceledTest.php
@@ -20,13 +20,17 @@ class SubscriptionCanceledTest extends TestCase
 
     public function test_immediately_can_be_instantiated_with_properties(): void
     {
+        $endsAt = new DateTimeImmutable('2024-01-15T10:00:00Z');
+
         $event = new SubscriptionCanceledImmediately(
             customerId: 'cus_123',
             subscriptionId: 'sub_456',
+            endsAt: $endsAt,
         );
 
         $this->assertSame('cus_123', $event->customerId);
         $this->assertSame('sub_456', $event->subscriptionId);
+        $this->assertSame($endsAt, $event->endsAt);
     }
 
     public function test_immediately_creates_from_webhook(): void
@@ -44,6 +48,10 @@ class SubscriptionCanceledTest extends TestCase
 
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('sub_123', $event->subscriptionId);
+        $this->assertEquals(
+            new DateTimeImmutable('2024-01-15T10:00:00Z'),
+            $event->endsAt,
+        );
     }
 
     public function test_with_grace_period_has_correct_vatly_event_name_constant(): void

--- a/tests/SubscriptionHandleTest.php
+++ b/tests/SubscriptionHandleTest.php
@@ -66,8 +66,7 @@ class SubscriptionHandleTest extends TestCase
             ->once()
             ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
                 return $data->planId === 'plan_premium'
-                    && $data->quantity === 2
-                    && $data->type === 'team';
+                    && $data->quantity === 2;
             }))
             ->andReturn($updatedSubscription);
 
@@ -77,7 +76,7 @@ class SubscriptionHandleTest extends TestCase
             swapAction: $swapAction,
         );
 
-        $returned = $handle->swap('team', 'plan_premium');
+        $returned = $handle->swap('plan_premium');
 
         $this->assertSame($handle, $returned);
         $this->assertSame($updatedSubscription, $handle->model());
@@ -109,7 +108,7 @@ class SubscriptionHandleTest extends TestCase
             swapAction: $swapAction,
         );
 
-        $this->assertSame($handle, $handle->swapAndInvoice('default', 'plan_premium'));
+        $this->assertSame($handle, $handle->swapAndInvoice('plan_premium'));
     }
 
     public function test_cancel_calls_the_api_only(): void

--- a/tests/SubscriptionHandleTest.php
+++ b/tests/SubscriptionHandleTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests;
+
+use DateTimeImmutable;
+use Mockery;
+use ReflectionClass;
+use Vatly\API\Resources\Subscription as ApiSubscription;
+use Vatly\API\Types\Link;
+use Vatly\Fluent\Actions\CancelSubscription;
+use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\SwapSubscriptionPlan;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Exceptions\FeatureUnavailableException;
+use Vatly\Fluent\SubscriptionHandle;
+
+class SubscriptionHandleTest extends TestCase
+{
+    public function test_state_accessors_delegate_to_the_wrapped_subscription(): void
+    {
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
+        $subscription->shouldReceive('getType')->andReturn('default');
+        $subscription->shouldReceive('getPlanId')->andReturn('plan_basic');
+        $subscription->shouldReceive('getName')->andReturn('Basic Plan');
+        $subscription->shouldReceive('getQuantity')->andReturn(1);
+        $subscription->shouldReceive('isActive')->andReturn(true);
+        $subscription->shouldReceive('isCancelled')->andReturn(false);
+        $subscription->shouldReceive('isOnGracePeriod')->andReturn(false);
+
+        $handle = $this->buildHandle(subscription: $subscription);
+
+        $this->assertSame('subscription_abc', $handle->getVatlyId());
+        $this->assertSame('default', $handle->getType());
+        $this->assertSame('plan_basic', $handle->getPlanId());
+        $this->assertSame('Basic Plan', $handle->getName());
+        $this->assertSame(1, $handle->getQuantity());
+        $this->assertTrue($handle->active());
+        $this->assertFalse($handle->cancelled());
+        $this->assertFalse($handle->onGracePeriod());
+    }
+
+    public function test_swap_calls_the_action_and_persists_the_change(): void
+    {
+        $subscription = $this->stubSubscription('subscription_abc');
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_premium',
+            'quantity' => 2,
+        ]);
+
+        $swapAction = Mockery::mock(SwapSubscriptionPlan::class);
+        $swapAction->shouldReceive('execute')
+            ->with('subscription_abc', 'plan_premium', [])
+            ->andReturn($apiResponse);
+
+        $updatedSubscription = Mockery::mock(SubscriptionInterface::class);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->planId === 'plan_premium'
+                    && $data->quantity === 2
+                    && $data->type === 'team';
+            }))
+            ->andReturn($updatedSubscription);
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            swapAction: $swapAction,
+        );
+
+        $returned = $handle->swap('team', 'plan_premium');
+
+        $this->assertSame($handle, $returned);
+        $this->assertSame($updatedSubscription, $handle->model());
+    }
+
+    public function test_swap_and_invoice_forces_immediate_application(): void
+    {
+        $subscription = $this->stubSubscription('subscription_abc');
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_premium',
+            'quantity' => 1,
+        ]);
+
+        $swapAction = Mockery::mock(SwapSubscriptionPlan::class);
+        $swapAction->shouldReceive('execute')
+            ->with('subscription_abc', 'plan_premium', [
+                'applyImmediately' => true,
+                'invoiceImmediately' => true,
+            ])
+            ->andReturn($apiResponse);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')->andReturn(Mockery::mock(SubscriptionInterface::class));
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            swapAction: $swapAction,
+        );
+
+        $this->assertSame($handle, $handle->swapAndInvoice('default', 'plan_premium'));
+    }
+
+    public function test_cancel_calls_the_api_only(): void
+    {
+        $subscription = $this->stubSubscription('subscription_abc');
+
+        $cancelAction = Mockery::mock(CancelSubscription::class);
+        $cancelAction->shouldReceive('execute')->once()->with('subscription_abc');
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            cancelAction: $cancelAction,
+        );
+
+        $handle->cancel();
+    }
+
+    public function test_create_billing_update_link_returns_the_href(): void
+    {
+        $subscription = $this->stubSubscription('subscription_abc');
+
+        $link = new Link('https://vatly.example/billing/upd_xyz', 'text/html');
+
+        $linkAction = Mockery::mock(CreateSubscriptionBillingUpdateLink::class);
+        $linkAction->shouldReceive('execute')
+            ->with('subscription_abc', ['redirectUrlSuccess' => 'https://app/done'])
+            ->andReturn($link);
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            createBillingUpdateLinkAction: $linkAction,
+        );
+
+        $this->assertSame(
+            'https://vatly.example/billing/upd_xyz',
+            $handle->createBillingUpdateLink(['redirectUrlSuccess' => 'https://app/done']),
+        );
+    }
+
+    public function test_sync_fetches_from_api_and_persists(): void
+    {
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
+        $subscription->shouldReceive('getEndsAt')->andReturn(null);
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'endedAt' => '2026-06-01T00:00:00+00:00',
+            'cancelledAt' => null,
+            'trialUntil' => null,
+        ]);
+
+        $getAction = Mockery::mock(GetSubscription::class);
+        $getAction->shouldReceive('execute')
+            ->with('subscription_abc')
+            ->andReturn($apiResponse);
+
+        $updated = Mockery::mock(SubscriptionInterface::class);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->planId === 'plan_basic'
+                    && $data->name === 'Basic'
+                    && $data->quantity === 1
+                    && $data->endsAt instanceof DateTimeImmutable;
+            }))
+            ->andReturn($updated);
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            getSubscriptionAction: $getAction,
+        );
+
+        $handle->sync();
+
+        $this->assertSame($updated, $handle->model());
+    }
+
+    public function test_resume_throws_feature_unavailable(): void
+    {
+        $handle = $this->buildHandle();
+
+        $this->expectException(FeatureUnavailableException::class);
+
+        $handle->resume();
+    }
+
+    private function stubSubscription(string $vatlyId): SubscriptionInterface
+    {
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn($vatlyId);
+
+        return $subscription;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function makeApiSubscription(array $fields): ApiSubscription
+    {
+        /** @var ApiSubscription $resource */
+        $resource = (new ReflectionClass(ApiSubscription::class))->newInstanceWithoutConstructor();
+
+        foreach ($fields as $key => $value) {
+            $resource->{$key} = $value;
+        }
+
+        return $resource;
+    }
+
+    private function buildHandle(
+        ?SubscriptionInterface $subscription = null,
+        ?SubscriptionRepositoryInterface $subscriptions = null,
+        ?SwapSubscriptionPlan $swapAction = null,
+        ?CancelSubscription $cancelAction = null,
+        ?GetSubscription $getSubscriptionAction = null,
+        ?CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction = null,
+    ): SubscriptionHandle {
+        return new SubscriptionHandle(
+            subscription: $subscription ?? Mockery::mock(SubscriptionInterface::class),
+            subscriptions: $subscriptions ?? Mockery::mock(SubscriptionRepositoryInterface::class),
+            swapAction: $swapAction ?? Mockery::mock(SwapSubscriptionPlan::class),
+            cancelAction: $cancelAction ?? Mockery::mock(CancelSubscription::class),
+            getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
+            createBillingUpdateLinkAction: $createBillingUpdateLinkAction
+                ?? Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+        );
+    }
+}

--- a/tests/Webhooks/Reactions/CancelSubscriptionOnCanceledTest.php
+++ b/tests/Webhooks/Reactions/CancelSubscriptionOnCanceledTest.php
@@ -22,7 +22,9 @@ class CancelSubscriptionOnCanceledTest extends TestCase
         $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
         $reaction = new CancelSubscriptionOnCanceled($repo);
 
-        $this->assertTrue($reaction->supports(new SubscriptionCanceledImmediately('cus_1', 'sub_1')));
+        $event = new SubscriptionCanceledImmediately('cus_1', 'sub_1', new DateTimeImmutable());
+
+        $this->assertTrue($reaction->supports($event));
     }
 
     public function test_it_supports_subscription_canceled_with_grace_period_events(): void
@@ -43,20 +45,21 @@ class CancelSubscriptionOnCanceledTest extends TestCase
         $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 9900, 'EUR', null, null)));
     }
 
-    public function test_it_sets_ends_at_to_now_for_immediate_cancellation(): void
+    public function test_it_persists_the_event_ends_at_for_immediate_cancellation(): void
     {
+        $endsAt = new DateTimeImmutable('2026-05-20T10:00:00Z');
         $existing = Mockery::mock(SubscriptionInterface::class);
         $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
         $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturn($existing);
-        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateSubscriptionData $data) {
-            return $data->endsAt instanceof DateTimeImmutable;
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateSubscriptionData $data) use ($endsAt) {
+            return $data->endsAt === $endsAt;
         }))->andReturn($existing);
 
         $reaction = new CancelSubscriptionOnCanceled($repo);
-        $reaction->handle(new SubscriptionCanceledImmediately('cus_1', 'sub_1'));
+        $reaction->handle(new SubscriptionCanceledImmediately('cus_1', 'sub_1', $endsAt));
     }
 
-    public function test_it_sets_ends_at_to_grace_period_end_for_grace_period_cancellation(): void
+    public function test_it_persists_the_event_ends_at_for_grace_period_cancellation(): void
     {
         $endsAt = new DateTimeImmutable('2025-03-15T00:00:00Z');
         $existing = Mockery::mock(SubscriptionInterface::class);
@@ -77,6 +80,6 @@ class CancelSubscriptionOnCanceledTest extends TestCase
         $repo->shouldNotReceive('update');
 
         $reaction = new CancelSubscriptionOnCanceled($repo);
-        $reaction->handle(new SubscriptionCanceledImmediately('cus_1', 'sub_1'));
+        $reaction->handle(new SubscriptionCanceledImmediately('cus_1', 'sub_1', new DateTimeImmutable()));
     }
 }

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks;
+
+use Mockery;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
+use Vatly\Fluent\Webhooks\WebhookProcessor;
+use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
+
+class WebhookProcessorFactoryTest extends TestCase
+{
+    public function test_it_builds_a_processor_with_the_standard_reactions(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+        );
+
+        $this->assertInstanceOf(WebhookProcessor::class, $processor);
+
+        $reactions = $processor->getReactions();
+
+        $this->assertCount(3, $reactions);
+        $this->assertInstanceOf(SyncSubscriptionOnStarted::class, $reactions[0]);
+        $this->assertInstanceOf(CancelSubscriptionOnCanceled::class, $reactions[1]);
+        $this->assertInstanceOf(StoreOrderOnPaid::class, $reactions[2]);
+    }
+
+    public function test_it_appends_additional_reactions_after_the_standard_ones(): void
+    {
+        $custom = Mockery::mock(WebhookReactionInterface::class);
+
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            additionalReactions: [$custom],
+        );
+
+        $reactions = $processor->getReactions();
+
+        $this->assertCount(4, $reactions);
+        $this->assertSame($custom, $reactions[3]);
+    }
+
+    public function test_it_tolerates_a_null_webhook_secret(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config(null),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+        );
+
+        $this->assertInstanceOf(WebhookProcessor::class, $processor);
+    }
+
+    private function config(?string $secret): ConfigurationInterface
+    {
+        $config = Mockery::mock(ConfigurationInterface::class);
+        $config->shouldReceive('getWebhookSecret')->andReturn($secret);
+
+        return $config;
+    }
+}


### PR DESCRIPTION
## Summary

Two intertwined changes that together set this package up as the **shared driver internals** for the Vatly ecosystem (Laravel today; Symfony/WordPress next), with a clean canonical API surface that drivers expose through framework-idiomatic accessors.

### Repositioning (docs)
- README rewritten to lead with the **driver table** — most users want `vatly-laravel`, raw API users want `vatly-api-php`. Fluent is internal plumbing, not a marketed product.
- New **CONTRIBUTING.md** as the Driver Author Guide: the seven contracts a driver implements, the wiring sequence, the webhook endpoint pattern, design principles.

### Orchestrator (new core)
- `Vatly\Fluent\Billable` — the canonical per-owner API surface every driver exposes. Carries customer lifecycle, subscription state queries, and the entry points to checkout/subscription builders. Composes existing actions, builders, and repository contracts.
- `Vatly\Fluent\BillableFactory` — singleton in a driver's container with shared dependencies; `->forOwner($entity)` builds a fresh Billable. The driver's `vatlyBillable()` accessor calls this in one line.
- `Vatly\Fluent\SubscriptionHandle` — wraps a `SubscriptionInterface` with the actions that operate on it (`swap`, `swapAndInvoice`, `cancel`, `sync`, `createBillingUpdateLink`). Keeps `SubscriptionInterface` slim (state-only) while still exposing Cashier-parity operations.
- `Vatly\Fluent\Data\UpdateSubscriptionData` — gains an optional `type` field so `swap()` can move a subscription between types atomically with the plan change.

### Smaller additive piece
- `Vatly\Fluent\Webhooks\WebhookProcessorFactory::create()` — one-line builder for the standard reaction list. Replaces ~20 lines of driver-side wiring.
- `Vatly\Fluent\Webhooks\WebhookProcessor::getReactions()` — accessor so drivers/tests can introspect without reflection.

## Why
The Laravel driver had grown to ~15 classes (`Manages*` concerns, `VatlyApiActions/`, `Builders/`) that were essentially reimplementing what should be framework-agnostic plumbing. Pulling the canonical API surface into fluent means future Symfony/WordPress drivers inherit the operation set for free, and the Laravel driver collapses to a thin adapter (see the paired vatly-laravel PR).

## Test plan
- [x] `composer test` → 115/115 pass (50 new tests for the orchestrator, factory, handle, and webhook factory)
- [x] `composer analyse` → no new errors (2 pre-existing PHPStan errors on `origin/main` are unrelated and remain unchanged)
- [x] Verified against vatly-laravel locally via composer path repository — Laravel side has 27/27 passing tests against the new surface

## Companion PR
[vatly-laravel#14](https://github.com/Vatly/vatly-laravel/pull/14) — migrates the Laravel driver to consume this orchestrator and deletes the duplicate Builders/VatlyApiActions layers.

## Release coordination
This is the **0.5.0-alpha.1** release. The Laravel PR pins `vatly/vatly-fluent-php: 0.5.0-alpha.1` exactly, so:
1. Merge & tag this PR first
2. Then the Laravel PR's CI can resolve the new version and pass

Supersedes [#18](https://github.com/Vatly/vatly-fluent-php/pull/18) which was closed in favor of this larger combined PR.
