### PR TITLE
docs: scope messaging to Laravel only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing
 
-Thanks for considering a contribution to `vatly-fluent-php`. This guide is for changes **to this package itself** — bug fixes, new contracts, new reactions, doc improvements, etc.
-
-If you're looking to *build a driver* on top of fluent (Symfony, WordPress, …), the guide for that lives in the [README](README.md#building-a-driver), not here.
+Thanks for considering a contribution to `vatly-fluent-php`. This guide is for changes to this package itself — bug fixes, new contracts, new reactions, doc improvements, etc.
 
 ## Local setup
 
@@ -20,8 +18,8 @@ Tests are PHPUnit + Mockery, fully isolated — no framework or HTTP needed. The
 
 These are the constraints to preserve when changing code under `src/`:
 
-- **Zero framework imports.** No `use Illuminate\…` or `use Symfony\…` under `src/`. Drivers depend on us; we never depend on them. The webhook pipeline, the orchestrator, the reactions, and the actions are all built against framework-agnostic contracts.
-- **Stateless domain logic.** Reactions, builders, the processor — none of them hold persistent state. State lives in the repository implementations the driver provides.
+- **No framework-specific imports.** Nothing under `src/` should import framework code. The webhook pipeline, the orchestrator, the reactions, and the actions are all built against framework-agnostic contracts so [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) can depend on this package without us depending on Laravel.
+- **Stateless domain logic.** Reactions, builders, the processor — none of them hold persistent state. State lives in the repository implementations the consumer provides.
 - **Raw API resources.** Actions return `Vatly\API\Resources\*` directly. We deliberately don't add a response-wrapper layer.
 - **Immutable DTOs** for repository inputs (`StoreSubscriptionData`, `UpdateOrderData`, …) and for typed events.
 - **Webhook events carry their own data.** Don't synthesise timestamps in reactions — pull them from the event, which pulled them from Vatly.
@@ -32,14 +30,6 @@ These are the constraints to preserve when changing code under `src/`:
 2. Add or update tests for the change.
 3. Run `composer test` and `composer analyse` locally — both must be green.
 4. Open the PR. CI runs the same checks across PHP 8.0 – 8.4.
-
-## Listing your driver
-
-If you've built a Vatly driver for a framework not yet on the driver table, please open a PR adding it to the [Looking for a Vatly integration?](README.md#looking-for-a-vatly-integration) section. To be listed, a driver should:
-
-- Be published on Packagist
-- Have a test suite that runs in CI
-- Have a README that gets a new user from `composer require` to a working webhook + first subscription, in the style of [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,18 @@
 
 > **Alpha release -- under active development. Expect breaking changes.**
 
-Shared internals for [Vatly](https://vatly.com) framework drivers. This package is the framework-agnostic core that powers driver packages like [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — webhook processing, contracts, events, DTOs, and the per-owner orchestrator (`Vatly\Fluent\Billable`) that drivers reuse so they don't reimplement the same patterns.
+The framework-agnostic core that powers [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — webhook processing, contracts, events, DTOs, and the per-owner orchestrator (`Vatly\Fluent\Billable`) that the Laravel package reuses so it doesn't reimplement them inline.
 
 ## Looking for a Vatly integration?
 
-**Most users want a framework driver, not this package directly:**
+**Most users want vatly-laravel, not this package directly:**
 
-| Framework | Package |
+| Use case | Package |
 | --- | --- |
-| Laravel | [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) |
-| Symfony, WordPress, etc. | _Planned. Want to build one? See [Building a driver](#building-a-driver) below._ |
-| No framework / raw API | [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) |
+| Laravel application | [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) |
+| Raw API access (no framework) | [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) |
 
-This package on its own doesn't persist anything, dispatch events, or read configuration — those concerns belong to a driver. You install it transitively through a driver.
+This package on its own doesn't persist anything, dispatch events, or read configuration — those concerns belong to the Laravel package. You install it transitively when you require `vatly/vatly-laravel`.
 
 ## Installation
 
@@ -36,130 +35,13 @@ composer require vatly/vatly-fluent-php:v0.5.0-alpha.1
 
 ## What's inside
 
-- **Orchestrator** ([src/Billable.php](src/Billable.php), [src/BillableFactory.php](src/BillableFactory.php), [src/SubscriptionHandle.php](src/SubscriptionHandle.php)): the canonical per-owner API surface — `subscribe()`, `checkout()`, `subscribed()`, `subscription()`, `createAsVatlyCustomer()`, etc. Drivers expose this through a framework-idiomatic accessor.
+- **Orchestrator** ([src/Billable.php](src/Billable.php), [src/BillableFactory.php](src/BillableFactory.php), [src/SubscriptionHandle.php](src/SubscriptionHandle.php)): the canonical per-owner API surface — `subscribe()`, `checkout()`, `subscribed()`, `subscription()`, `createAsVatlyCustomer()`, etc.
 - **Contracts** ([src/Contracts](src/Contracts)): `BillableInterface`, `SubscriptionInterface`, `OrderInterface`, repository interfaces (subscription / customer / order / webhook call), `EventDispatcherInterface`, `ConfigurationInterface`, `WebhookReactionInterface`.
 - **Webhook pipeline** ([src/Webhooks](src/Webhooks)): `WebhookProcessor` orchestrates signature verification → event parsing → audit logging → reactions → dispatch. Built-in reactions: `SyncSubscriptionOnStarted`, `StoreOrderOnPaid`, `CancelSubscriptionOnCanceled`. Wire it in one call with `WebhookProcessorFactory::create()`.
 - **Events** ([src/Events](src/Events)): typed POPOs — `OrderPaid`, `SubscriptionStarted`, `SubscriptionCanceledImmediately`, `SubscriptionCanceledWithGracePeriod`, `LocalSubscriptionCreated`, `WebhookReceived`, `UnsupportedWebhookReceived`.
 - **Actions** ([src/Actions](src/Actions)): thin wrappers around [`vatly/vatly-api-php`](https://github.com/Vatly/vatly-api-php) returning raw `Vatly\API\Resources\*` objects.
 - **Builders** ([src/Builders](src/Builders)): `CheckoutBuilder` and `SubscriptionBuilder` driven by a `BillableInterface`.
 - **Data DTOs** ([src/Data](src/Data)): immutable inputs for repository operations.
-
-## Building a driver
-
-A driver is the framework-specific layer that fills in the abstractions defined here. The reference driver is [`vatly/vatly-laravel`](https://github.com/Vatly/vatly-laravel) — its `VatlyServiceProvider` and `Billable` trait are the working examples to crib from.
-
-### Architecture
-
-| Concern | Lives in fluent | Lives in the driver |
-| --- | --- | --- |
-| Webhook signature, parsing, reactions, dispatch | ✅ | — |
-| Typed events (`OrderPaid`, `SubscriptionStarted`, …) | ✅ | — |
-| Action wrappers around the raw API SDK | ✅ | — |
-| Per-owner orchestrator (`Vatly\Fluent\Billable`) | ✅ | — |
-| Repository **contracts** | ✅ | — |
-| Repository **implementations** (Eloquent / Doctrine / `$wpdb` / …) | — | ✅ |
-| `BillableInterface` implementation on a User/Tenant entity | — | ✅ |
-| Configuration source (env, framework config) | — | ✅ |
-| Event dispatcher bridge | — | ✅ |
-| HTTP route for the webhook endpoint | — | ✅ |
-| DI / service-container wiring | — | ✅ |
-| `vatlyBillable()` accessor on the host entity | — | ✅ |
-
-### 1. Contracts to implement
-
-All under `Vatly\Fluent\Contracts\`:
-
-- **`BillableInterface`** — represents a customer entity (User, Tenant, etc.). Methods: `getVatlyId()`, `setVatlyId()`, `hasVatlyId()`, `getVatlyEmail()`, `getVatlyName()`, `getKey()`, `save()`.
-- **`ConfigurationInterface`** — `getApiKey()`, `getApiUrl()`, `getApiVersion()`, `getWebhookSecret()`, `isTestmode()`, `getDefaultRedirectUrlSuccess()`, `getDefaultRedirectUrlCanceled()`, `getBillableModel()`.
-- **`SubscriptionRepositoryInterface`** — `findByVatlyId()`, `findByOwnerAndType()`, `findAllByOwner()`, `ownerHasActiveSubscription()`, `store(StoreSubscriptionData)`, `update(SubscriptionInterface, UpdateSubscriptionData)`.
-- **`CustomerRepositoryInterface`** — `findByVatlyId()`, `findByVatlyIdOrFail()`, `save(BillableInterface)`.
-- **`OrderRepositoryInterface`** — `findByVatlyId()`, `findAllByOwner()`, `store(StoreOrderData)`, `update(OrderInterface, UpdateOrderData)`.
-- **`WebhookCallRepositoryInterface`** — `record(…)` (audit log), `cleanUp(int $days)`.
-- **`EventDispatcherInterface`** — single method `dispatch(object $event)`. Bridge to your framework's event bus or PSR-14.
-
-Your driver also needs concrete `SubscriptionInterface` and `OrderInterface` implementations (typically your ORM models).
-
-### 2. Wiring sequence
-
-In your driver's bootstrap (`ServiceProvider`, bundle config, plugin init), wire in this order:
-
-1. Bind your `ConfigurationInterface` implementation.
-2. Construct a `Vatly\API\VatlyApiClient` and configure it from your `ConfigurationInterface`.
-3. Bind your repository implementations to the four repository contracts.
-4. Bind your event dispatcher implementation to `EventDispatcherInterface`.
-5. Build a `WebhookProcessor` via the factory:
-
-```php
-use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
-
-$processor = WebhookProcessorFactory::create(
-    config: $config,
-    subscriptions: $subscriptionRepository,
-    orders: $orderRepository,
-    webhookCalls: $webhookCallRepository,
-    dispatcher: $eventDispatcher,
-    additionalReactions: [
-        // Optional custom reactions implementing WebhookReactionInterface
-    ],
-);
-```
-
-If you need to swap out the `SignatureVerifier` or `WebhookEventFactory`, construct `WebhookProcessor` directly with all the reactions instead.
-
-6. Register a `BillableFactory` singleton with the shared dependencies:
-
-```php
-use Vatly\Fluent\BillableFactory;
-
-$factory = new BillableFactory(
-    subscriptions: $subscriptionRepository,
-    customers: $customerRepository,
-    orders: $orderRepository,
-    config: $config,
-    createCheckoutAction: new CreateCheckout($apiClient),
-    createCustomerAction: new CreateCustomer($apiClient),
-    getCustomerAction: new GetCustomer($apiClient),
-    getSubscriptionAction: new GetSubscription($apiClient),
-    swapSubscriptionPlanAction: new SwapSubscriptionPlan($apiClient),
-    cancelSubscriptionAction: new CancelSubscription($apiClient),
-    createBillingUpdateLinkAction: new CreateSubscriptionBillingUpdateLink($apiClient),
-);
-```
-
-7. In your User/Tenant trait or base class, expose the orchestrator:
-
-```php
-public function vatlyBillable(): \Vatly\Fluent\Billable
-{
-    return $container->get(BillableFactory::class)->forOwner($this);
-}
-```
-
-### 3. The webhook endpoint
-
-Expose a single POST route in your framework. In the handler:
-
-```php
-try {
-    $processor->handle(
-        payload: $request->getRawBody(),       // raw, not deserialized
-        signature: $request->getHeader('X-Vatly-Signature') ?? '',
-    );
-    return new Response(status: 201);
-} catch (InvalidWebhookSignatureException) {
-    return new Response(status: 403);
-}
-```
-
-Return `2xx` on success, `403` on signature mismatch. Anything else and Vatly will retry.
-
-### 4. Application-facing ergonomics
-
-The canonical per-owner API surface lives on `Vatly\Fluent\Billable` (returned by `vatlyBillable()`). Drivers typically expose that surface through framework idioms:
-
-- **Cashier-style proxy methods** on the entity trait — `$user->subscribe()`, `$user->subscribed('default')`, `$user->subscription('default')`, `$user->checkout()` — that delegate to `vatlyBillable()->X()`. See [vatly-laravel's `Billable` trait](https://github.com/Vatly/vatly-laravel/blob/main/src/Billable.php) for the reference.
-- **ORM-native relations** for collection-style access (`$user->subscriptions`) that fluent can't provide.
-- **Audit/admin views, console commands, fakes** — purely driver-level.
 
 ## Testing
 
@@ -169,7 +51,7 @@ composer test
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, design principles, and the PR process. If you've built a Vatly driver for a framework not yet covered, that's also where to PR yourself onto the driver table above.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, design principles, and the PR process.
 
 ## License
 


### PR DESCRIPTION
## Summary

Removed multi-framework references from the README and CONTRIBUTING.md so the package's external story matches what we actually ship and support: **Laravel**.

## Changed

- **README**:
  - Dropped the "Symfony, WordPress, etc. — Planned" row from the integration table. Now just Laravel + the raw API.
  - Removed the entire "Building a driver" section (architecture table, contracts list, wiring sequence, webhook endpoint, ergonomics). Content was inherently about other-framework integrations.
  - Reframed the intro: "shared internals for Vatly framework drivers" → "framework-agnostic core that powers vatly-laravel".
- **CONTRIBUTING.md**:
  - Removed the "build a driver" intro.
  - Removed the "Listing your driver" section.
  - Reworded the design principle to drop the `use Symfony\…` example.

## Why

We're focusing on Laravel as the supported framework. The architecture is unchanged — fluent still has zero framework imports under src/ and the contracts are intact — but we shouldn't market a multi-framework platform we're not currently shipping. If we ever ship a second driver, we restore the relevant docs at that point. Git history preserves the prior version.

## Test plan
- [x] composer test → 115/115 pass
- [x] composer analyse → no errors
- [x] No remaining 'Symfony' / 'WordPress' / 'Doctrine' / '\$wpdb' references in README, CONTRIBUTING, or src/
