### PR TITLE
chore: sync with OpenAPI — rename action to UpdateSubscriptionBilling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "vatly/vatly-api-php": "^0.1.0-alpha.1"
+        "vatly/vatly-api-php": "^0.1.0-alpha.5"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/src/Actions/GetOrder.php
+++ b/src/Actions/GetOrder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Actions;
+
+use Vatly\API\Resources\Order;
+
+class GetOrder extends BaseAction
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function execute(string $orderId, array $parameters = []): Order
+    {
+        $order = $this->vatlyApiClient->orders->get($orderId, $parameters);
+
+        assert($order instanceof Order);
+
+        return $order;
+    }
+}

--- a/src/Actions/UpdateSubscriptionBilling.php
+++ b/src/Actions/UpdateSubscriptionBilling.php
@@ -6,7 +6,7 @@ namespace Vatly\Fluent\Actions;
 
 use Vatly\API\Types\Link;
 
-class CreateSubscriptionBillingUpdateLink extends BaseAction
+class UpdateSubscriptionBilling extends BaseAction
 {
     /**
      * Create a signed URL where the customer can update the billing details for a subscription
@@ -18,7 +18,7 @@ class CreateSubscriptionBillingUpdateLink extends BaseAction
      */
     public function execute(string $subscriptionId, array $prefillData = []): Link
     {
-        return $this->vatlyApiClient->subscriptions->createBillingUpdateLink(
+        return $this->vatlyApiClient->subscriptions->updateBilling(
             $subscriptionId,
             $prefillData
         );

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -8,7 +8,7 @@ use Vatly\API\Resources\Customer;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -44,7 +44,7 @@ class Billable
         private GetSubscription $getSubscriptionAction,
         private SwapSubscriptionPlan $swapSubscriptionPlanAction,
         private CancelSubscription $cancelSubscriptionAction,
-        private CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+        private UpdateSubscriptionBilling $updateBillingAction,
     ) {
         //
     }
@@ -164,7 +164,7 @@ class Billable
             swapAction: $this->swapSubscriptionPlanAction,
             cancelAction: $this->cancelSubscriptionAction,
             getSubscriptionAction: $this->getSubscriptionAction,
-            createBillingUpdateLinkAction: $this->createBillingUpdateLinkAction,
+            updateBillingAction: $this->updateBillingAction,
         );
     }
 

--- a/src/BillableFactory.php
+++ b/src/BillableFactory.php
@@ -7,7 +7,7 @@ namespace Vatly\Fluent;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -37,7 +37,7 @@ class BillableFactory
         private GetSubscription $getSubscriptionAction,
         private SwapSubscriptionPlan $swapSubscriptionPlanAction,
         private CancelSubscription $cancelSubscriptionAction,
-        private CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+        private UpdateSubscriptionBilling $updateBillingAction,
     ) {
         //
     }
@@ -56,7 +56,7 @@ class BillableFactory
             getSubscriptionAction: $this->getSubscriptionAction,
             swapSubscriptionPlanAction: $this->swapSubscriptionPlanAction,
             cancelSubscriptionAction: $this->cancelSubscriptionAction,
-            createBillingUpdateLinkAction: $this->createBillingUpdateLinkAction,
+            updateBillingAction: $this->updateBillingAction,
         );
     }
 }

--- a/src/Data/StoreOrderData.php
+++ b/src/Data/StoreOrderData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Data;
 
+use Vatly\Fluent\Types\TaxSummary;
+
 /**
  * Data for storing a new order from Vatly.
  *
@@ -19,5 +21,7 @@ class StoreOrderData
         public string $currency,
         public ?string $invoiceNumber = null,
         public ?string $paymentMethod = null,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
     ) {}
 }

--- a/src/Data/UpdateOrderData.php
+++ b/src/Data/UpdateOrderData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Data;
 
+use Vatly\Fluent\Types\TaxSummary;
+
 /**
  * Data for updating an existing order from Vatly.
  *
@@ -17,5 +19,7 @@ class UpdateOrderData
         public ?string $currency = null,
         public ?string $invoiceNumber = null,
         public ?string $paymentMethod = null,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
     ) {}
 }

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
+
 /**
  * Event representing an order being paid at Vatly.
+ *
+ * Carries the full tax breakdown so consumers can materialize a local invoice
+ * without a follow-up API call. The webhook payload itself is sparse; the
+ * WebhookEventFactory enriches via `GetOrder` before dispatching.
  *
  * @immutable
  */
@@ -17,6 +25,8 @@ class OrderPaid
         public string $customerId,
         public string $orderId,
         public int $total,
+        public int $subtotal,
+        public TaxSummary $taxSummary,
         public string $currency,
         public ?string $invoiceNumber,
         public ?string $paymentMethod,
@@ -24,15 +34,17 @@ class OrderPaid
         //
     }
 
-    public static function fromWebhook(WebhookReceived $webhook): self
+    public static function fromApiOrder(ApiOrder $order): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
-            orderId: $webhook->resourceId,
-            total: $webhook->object['data']['total'],
-            currency: $webhook->object['data']['currency'],
-            invoiceNumber: $webhook->object['data']['invoiceNumber'] ?? null,
-            paymentMethod: $webhook->object['data']['paymentMethod'] ?? null,
+            customerId: $order->customerId ?? '',
+            orderId: $order->id,
+            total: Money::fromApiMoneyToCents($order->total),
+            subtotal: Money::fromApiMoneyToCents($order->subtotal),
+            taxSummary: TaxSummary::fromApiResource($order->taxSummary),
+            currency: $order->total->currency,
+            invoiceNumber: $order->invoiceNumber,
+            paymentMethod: $order->paymentMethod,
         );
     }
 }

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -6,7 +6,7 @@ namespace Vatly\Fluent;
 
 use DateTimeInterface;
 use Vatly\Fluent\Actions\CancelSubscription;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\BillableInterface;
@@ -30,7 +30,7 @@ class SubscriptionHandle
         private SwapSubscriptionPlan $swapAction,
         private CancelSubscription $cancelAction,
         private GetSubscription $getSubscriptionAction,
-        private CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction,
+        private UpdateSubscriptionBilling $updateBillingAction,
     ) {
         //
     }
@@ -172,9 +172,9 @@ class SubscriptionHandle
      *
      * @param array<string, mixed> $prefillData Optional pre-fill data.
      */
-    public function createBillingUpdateLink(array $prefillData = []): string
+    public function updateBilling(array $prefillData = []): string
     {
-        $link = $this->createBillingUpdateLinkAction->execute(
+        $link = $this->updateBillingAction->execute(
             $this->subscription->getVatlyId(),
             $prefillData,
         );

--- a/src/Types/Money.php
+++ b/src/Types/Money.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Types;
+
+use Vatly\API\Types\Money as ApiMoney;
+
+/**
+ * Internal helper for converting api-php's decimal-string Money into the
+ * cents-as-int convention used everywhere else in fluent-php.
+ */
+final class Money
+{
+    /**
+     * Convert a decimal-string value ("17.35") to integer cents (1735).
+     * Avoids float-precision pitfalls of `(int) ((float) $v * 100)`.
+     */
+    public static function decimalToCents(string $value): int
+    {
+        $negative = str_starts_with($value, '-');
+        $value = ltrim($value, '-');
+
+        if (str_contains($value, '.')) {
+            [$major, $minor] = explode('.', $value, 2);
+        } else {
+            $major = $value;
+            $minor = '0';
+        }
+
+        $minor = substr(str_pad($minor, 2, '0'), 0, 2);
+        $cents = ((int) $major) * 100 + (int) $minor;
+
+        return $negative ? -$cents : $cents;
+    }
+
+    public static function fromApiMoneyToCents(ApiMoney $money): int
+    {
+        return self::decimalToCents($money->value);
+    }
+}

--- a/src/Types/TaxSummary.php
+++ b/src/Types/TaxSummary.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Types;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+use Vatly\API\Types\TaxSummaryCollection as ApiTaxSummaryCollection;
+
+/**
+ * Per-rate tax breakdown for an order. Iterable and countable.
+ *
+ * @immutable
+ * @implements IteratorAggregate<int, TaxSummaryItem>
+ */
+class TaxSummary implements IteratorAggregate, Countable
+{
+    /**
+     * @param TaxSummaryItem[] $items
+     */
+    public function __construct(
+        public array $items = [],
+    ) {
+    }
+
+    public static function fromApiResource(ApiTaxSummaryCollection $collection): self
+    {
+        return new self(
+            items: array_map(
+                fn ($item) => TaxSummaryItem::fromApiResource($item),
+                $collection->items,
+            ),
+        );
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * @return array<int, array{rate: array{name: string, percentage: float, taxablePercentage: float}, amount: int, currency: string}>
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            fn (TaxSummaryItem $item) => [
+                'rate' => [
+                    'name' => $item->rate->name,
+                    'percentage' => $item->rate->percentage,
+                    'taxablePercentage' => $item->rate->taxablePercentage,
+                ],
+                'amount' => $item->amount,
+                'currency' => $item->currency,
+            ],
+            $this->items,
+        );
+    }
+}

--- a/src/Types/TaxSummaryItem.php
+++ b/src/Types/TaxSummaryItem.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Types;
+
+use Vatly\API\Types\TaxSummaryItem as ApiTaxSummaryItem;
+
+/**
+ * A single tax-rate bucket on an order: rate metadata + the amount it produced.
+ *
+ * Amount is in minor units (cents) for parity with the rest of the fluent API.
+ *
+ * @immutable
+ */
+class TaxSummaryItem
+{
+    public function __construct(
+        public TaxSummaryRate $rate,
+        public int $amount,
+        public string $currency,
+    ) {
+    }
+
+    public static function fromApiResource(ApiTaxSummaryItem $item): self
+    {
+        return new self(
+            rate: TaxSummaryRate::fromApiResource($item->taxRate),
+            amount: Money::fromApiMoneyToCents($item->amount),
+            currency: $item->amount->currency,
+        );
+    }
+}

--- a/src/Types/TaxSummaryRate.php
+++ b/src/Types/TaxSummaryRate.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Types;
+
+use Vatly\API\Types\TaxSummaryRate as ApiTaxSummaryRate;
+
+/**
+ * @immutable
+ */
+class TaxSummaryRate
+{
+    public function __construct(
+        public string $name,
+        public float $percentage,
+        public float $taxablePercentage,
+    ) {
+    }
+
+    public static function fromApiResource(ApiTaxSummaryRate $rate): self
+    {
+        return new self(
+            name: $rate->name,
+            percentage: $rate->percentage,
+            taxablePercentage: $rate->taxablePercentage,
+        );
+    }
+}

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -9,6 +9,7 @@ use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\API\VatlyApiClient;
@@ -30,6 +31,7 @@ class Vatly
     // Lazy-loaded actions
     private ?CreateCustomer $createCustomer = null;
     private ?GetCustomer $getCustomer = null;
+    private ?GetOrder $getOrder = null;
     private ?CreateCheckout $createCheckout = null;
     private ?GetSubscription $getSubscription = null;
     private ?CancelSubscription $cancelSubscription = null;
@@ -42,7 +44,7 @@ class Vatly
         $this->apiClient = new VatlyApiClient();
         $this->apiClient->setApiKey($apiKey);
         $this->signatureVerifier = new SignatureVerifier();
-        $this->webhookEventFactory = new WebhookEventFactory();
+        $this->webhookEventFactory = new WebhookEventFactory($this->getOrder());
     }
 
     /**
@@ -79,6 +81,11 @@ class Vatly
     public function getCustomer(): GetCustomer
     {
         return $this->getCustomer ??= new GetCustomer($this->apiClient);
+    }
+
+    public function getOrder(): GetOrder
+    {
+        return $this->getOrder ??= new GetOrder($this->apiClient);
     }
 
     public function createCheckout(): CreateCheckout

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent;
 
 use Vatly\Fluent\Actions\CancelSubscription;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCustomer;
@@ -34,7 +34,7 @@ class Vatly
     private ?GetSubscription $getSubscription = null;
     private ?CancelSubscription $cancelSubscription = null;
     private ?SwapSubscriptionPlan $swapSubscriptionPlan = null;
-    private ?CreateSubscriptionBillingUpdateLink $createSubscriptionBillingUpdateLink = null;
+    private ?UpdateSubscriptionBilling $updateSubscriptionBilling = null;
 
     public function __construct(
         string $apiKey,
@@ -101,8 +101,8 @@ class Vatly
         return $this->swapSubscriptionPlan ??= new SwapSubscriptionPlan($this->apiClient);
     }
 
-    public function createSubscriptionBillingUpdateLink(): CreateSubscriptionBillingUpdateLink
+    public function updateSubscriptionBilling(): UpdateSubscriptionBilling
     {
-        return $this->createSubscriptionBillingUpdateLink ??= new CreateSubscriptionBillingUpdateLink($this->apiClient);
+        return $this->updateSubscriptionBilling ??= new UpdateSubscriptionBilling($this->apiClient);
     }
 }

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -36,6 +36,8 @@ class StoreOrderOnPaid implements WebhookReactionInterface
                 currency: $event->currency,
                 invoiceNumber: $event->invoiceNumber,
                 paymentMethod: $event->paymentMethod,
+                subtotal: $event->subtotal,
+                taxSummary: $event->taxSummary,
             ));
 
             return;
@@ -49,6 +51,8 @@ class StoreOrderOnPaid implements WebhookReactionInterface
             currency: $event->currency,
             invoiceNumber: $event->invoiceNumber,
             paymentMethod: $event->paymentMethod,
+            subtotal: $event->subtotal,
+            taxSummary: $event->taxSummary,
         ));
     }
 }

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
@@ -13,8 +14,18 @@ use Vatly\Fluent\Events\WebhookReceived;
 
 class WebhookEventFactory
 {
+    public function __construct(
+        private GetOrder $getOrder,
+    ) {
+        //
+    }
+
     /**
      * Create a typed event from a raw webhook.
+     *
+     * For `order.paid` the factory performs a follow-up API GET so the
+     * dispatched event carries the full tax breakdown — webhook payloads
+     * themselves only include gross total.
      *
      * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|UnsupportedWebhookReceived
      */
@@ -24,7 +35,7 @@ class WebhookEventFactory
             SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromWebhook($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
-            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromWebhook($webhook),
+            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->resourceId)),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
@@ -30,11 +31,12 @@ class WebhookProcessorFactory
         OrderRepositoryInterface $orders,
         WebhookCallRepositoryInterface $webhookCalls,
         EventDispatcherInterface $dispatcher,
+        GetOrder $getOrder,
         array $additionalReactions = [],
     ): WebhookProcessor {
         return new WebhookProcessor(
             signatureVerifier: new SignatureVerifier(),
-            eventFactory: new WebhookEventFactory(),
+            eventFactory: new WebhookEventFactory($getOrder),
             repository: $webhookCalls,
             dispatcher: $dispatcher,
             webhookSecret: $config->getWebhookSecret() ?? '',

--- a/tests/Actions/UpdateSubscriptionBillingTest.php
+++ b/tests/Actions/UpdateSubscriptionBillingTest.php
@@ -8,14 +8,14 @@ use Mockery;
 use Vatly\API\Endpoints\SubscriptionEndpoint;
 use Vatly\API\Types\Link;
 use Vatly\API\VatlyApiClient;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Tests\TestCase;
 
-class CreateSubscriptionBillingUpdateLinkTest extends TestCase
+class UpdateSubscriptionBillingTest extends TestCase
 {
     private VatlyApiClient $mockApiClient;
     private SubscriptionEndpoint $mockSubscriptionEndpoint;
-    private CreateSubscriptionBillingUpdateLink $action;
+    private UpdateSubscriptionBilling $action;
 
     protected function setUp(): void
     {
@@ -25,7 +25,7 @@ class CreateSubscriptionBillingUpdateLinkTest extends TestCase
         $this->mockSubscriptionEndpoint = Mockery::mock(SubscriptionEndpoint::class);
         $this->mockApiClient->subscriptions = $this->mockSubscriptionEndpoint;
 
-        $this->action = new CreateSubscriptionBillingUpdateLink($this->mockApiClient);
+        $this->action = new UpdateSubscriptionBilling($this->mockApiClient);
     }
 
     public function test_it_returns_the_billing_update_link(): void
@@ -34,7 +34,7 @@ class CreateSubscriptionBillingUpdateLinkTest extends TestCase
         $expectedUrl = 'https://checkout.vatly.com/billing-update/abc123';
 
         $this->mockSubscriptionEndpoint
-            ->shouldReceive('createBillingUpdateLink')
+            ->shouldReceive('updateBilling')
             ->once()
             ->with($subscriptionId, [])
             ->andReturn(new Link($expectedUrl, 'text/html'));
@@ -58,7 +58,7 @@ class CreateSubscriptionBillingUpdateLinkTest extends TestCase
         ];
 
         $this->mockSubscriptionEndpoint
-            ->shouldReceive('createBillingUpdateLink')
+            ->shouldReceive('updateBilling')
             ->once()
             ->with($subscriptionId, $prefillData)
             ->andReturn(new Link('https://checkout.vatly.com/billing-update/xyz', 'text/html'));

--- a/tests/BillableFactoryTest.php
+++ b/tests/BillableFactoryTest.php
@@ -8,7 +8,7 @@ use Mockery;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -37,7 +37,7 @@ class BillableFactoryTest extends TestCase
             getSubscriptionAction: Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
-            createBillingUpdateLinkAction: Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+            updateBillingAction: Mockery::mock(UpdateSubscriptionBilling::class),
         );
 
         $billable = $factory->forOwner($owner);
@@ -59,7 +59,7 @@ class BillableFactoryTest extends TestCase
             getSubscriptionAction: Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
-            createBillingUpdateLinkAction: Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+            updateBillingAction: Mockery::mock(UpdateSubscriptionBilling::class),
         );
 
         $ownerA = Mockery::mock(BillableInterface::class);

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -10,7 +10,7 @@ use Vatly\API\Resources\Customer;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -238,7 +238,7 @@ class BillableTest extends TestCase
         ?GetSubscription $getSubscriptionAction = null,
         ?SwapSubscriptionPlan $swapSubscriptionPlanAction = null,
         ?CancelSubscription $cancelSubscriptionAction = null,
-        ?CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction = null,
+        ?UpdateSubscriptionBilling $updateBillingAction = null,
     ): Billable {
         return new Billable(
             owner: $owner ?? $this->stubOwner(),
@@ -252,8 +252,8 @@ class BillableTest extends TestCase
             getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: $swapSubscriptionPlanAction ?? Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: $cancelSubscriptionAction ?? Mockery::mock(CancelSubscription::class),
-            createBillingUpdateLinkAction: $createBillingUpdateLinkAction
-                ?? Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+            updateBillingAction: $updateBillingAction
+                ?? Mockery::mock(UpdateSubscriptionBilling::class),
         );
     }
 }

--- a/tests/Events/OrderPaidTest.php
+++ b/tests/Events/OrderPaidTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Tests\Events;
 
+use Mockery;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Events\OrderPaid;
-use Vatly\Fluent\Events\WebhookReceived;
 use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
 
 class OrderPaidTest extends TestCase
 {
@@ -21,6 +26,8 @@ class OrderPaidTest extends TestCase
             customerId: 'cus_123',
             orderId: 'ord_456',
             total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
             currency: 'EUR',
             invoiceNumber: 'INV-2024-001',
             paymentMethod: 'credit_card',
@@ -29,64 +36,65 @@ class OrderPaidTest extends TestCase
         $this->assertSame('cus_123', $event->customerId);
         $this->assertSame('ord_456', $event->orderId);
         $this->assertSame(9900, $event->total);
+        $this->assertSame(8182, $event->subtotal);
+        $this->assertCount(0, $event->taxSummary);
         $this->assertSame('EUR', $event->currency);
         $this->assertSame('INV-2024-001', $event->invoiceNumber);
         $this->assertSame('credit_card', $event->paymentMethod);
     }
 
-    public function test_it_creates_from_webhook(): void
+    public function test_it_builds_from_api_order_resource_with_tax_breakdown(): void
     {
-        $webhook = new WebhookReceived(
-            eventName: 'order.paid',
-            resourceId: 'ord_123',
-            resourceName: 'order',
-            object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'total' => 4999,
-                    'currency' => 'USD',
-                    'invoiceNumber' => 'INV-2024-002',
-                    'paymentMethod' => 'ideal',
-                ],
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_123';
+        $apiOrder->customerId = 'cus_456';
+        $apiOrder->total = new Money('USD', '49.99');
+        $apiOrder->subtotal = new Money('USD', '41.31');
+        $apiOrder->invoiceNumber = 'INV-2024-002';
+        $apiOrder->paymentMethod = 'ideal';
+        $apiOrder->status = 'paid';
+        $apiOrder->taxSummary = new TaxSummaryCollection([
+            [
+                'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                'amount' => ['currency' => 'USD', 'value' => '8.68'],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
-        );
+        ]);
 
-        $event = OrderPaid::fromWebhook($webhook);
+        $event = OrderPaid::fromApiOrder($apiOrder);
 
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_123', $event->orderId);
         $this->assertSame(4999, $event->total);
+        $this->assertSame(4131, $event->subtotal);
         $this->assertSame('USD', $event->currency);
         $this->assertSame('INV-2024-002', $event->invoiceNumber);
         $this->assertSame('ideal', $event->paymentMethod);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame(868, $event->taxSummary->items[0]->amount);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
     }
 
-    public function test_it_creates_from_webhook_with_nullable_fields(): void
+    public function test_it_builds_from_api_order_with_no_customer_or_invoice(): void
     {
-        $webhook = new WebhookReceived(
-            eventName: 'order.paid',
-            resourceId: 'ord_789',
-            resourceName: 'order',
-            object: [
-                'data' => [
-                    'customerId' => 'cus_012',
-                    'total' => 1500,
-                    'currency' => 'GBP',
-                ],
-            ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
-        );
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_789';
+        $apiOrder->customerId = null;
+        $apiOrder->total = new Money('GBP', '15.00');
+        $apiOrder->subtotal = new Money('GBP', '12.40');
+        $apiOrder->invoiceNumber = null;
+        $apiOrder->paymentMethod = null;
+        $apiOrder->status = 'paid';
+        $apiOrder->taxSummary = new TaxSummaryCollection([]);
 
-        $event = OrderPaid::fromWebhook($webhook);
+        $event = OrderPaid::fromApiOrder($apiOrder);
 
-        $this->assertSame('cus_012', $event->customerId);
+        $this->assertSame('', $event->customerId);
         $this->assertSame('ord_789', $event->orderId);
         $this->assertSame(1500, $event->total);
+        $this->assertSame(1240, $event->subtotal);
         $this->assertSame('GBP', $event->currency);
         $this->assertNull($event->invoiceNumber);
         $this->assertNull($event->paymentMethod);
+        $this->assertCount(0, $event->taxSummary);
     }
 }

--- a/tests/SubscriptionHandleTest.php
+++ b/tests/SubscriptionHandleTest.php
@@ -10,7 +10,7 @@ use ReflectionClass;
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Link;
 use Vatly\Fluent\Actions\CancelSubscription;
-use Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
@@ -132,19 +132,19 @@ class SubscriptionHandleTest extends TestCase
 
         $link = new Link('https://vatly.example/billing/upd_xyz', 'text/html');
 
-        $linkAction = Mockery::mock(CreateSubscriptionBillingUpdateLink::class);
+        $linkAction = Mockery::mock(UpdateSubscriptionBilling::class);
         $linkAction->shouldReceive('execute')
             ->with('subscription_abc', ['redirectUrlSuccess' => 'https://app/done'])
             ->andReturn($link);
 
         $handle = $this->buildHandle(
             subscription: $subscription,
-            createBillingUpdateLinkAction: $linkAction,
+            updateBillingAction: $linkAction,
         );
 
         $this->assertSame(
             'https://vatly.example/billing/upd_xyz',
-            $handle->createBillingUpdateLink(['redirectUrlSuccess' => 'https://app/done']),
+            $handle->updateBilling(['redirectUrlSuccess' => 'https://app/done']),
         );
     }
 
@@ -230,7 +230,7 @@ class SubscriptionHandleTest extends TestCase
         ?SwapSubscriptionPlan $swapAction = null,
         ?CancelSubscription $cancelAction = null,
         ?GetSubscription $getSubscriptionAction = null,
-        ?CreateSubscriptionBillingUpdateLink $createBillingUpdateLinkAction = null,
+        ?UpdateSubscriptionBilling $updateBillingAction = null,
     ): SubscriptionHandle {
         return new SubscriptionHandle(
             subscription: $subscription ?? Mockery::mock(SubscriptionInterface::class),
@@ -238,8 +238,8 @@ class SubscriptionHandleTest extends TestCase
             swapAction: $swapAction ?? Mockery::mock(SwapSubscriptionPlan::class),
             cancelAction: $cancelAction ?? Mockery::mock(CancelSubscription::class),
             getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
-            createBillingUpdateLinkAction: $createBillingUpdateLinkAction
-                ?? Mockery::mock(CreateSubscriptionBillingUpdateLink::class),
+            updateBillingAction: $updateBillingAction
+                ?? Mockery::mock(UpdateSubscriptionBilling::class),
         );
     }
 }

--- a/tests/Webhooks/Reactions/CancelSubscriptionOnCanceledTest.php
+++ b/tests/Webhooks/Reactions/CancelSubscriptionOnCanceledTest.php
@@ -13,6 +13,7 @@ use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
 use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
 use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
 
 class CancelSubscriptionOnCanceledTest extends TestCase
@@ -42,7 +43,7 @@ class CancelSubscriptionOnCanceledTest extends TestCase
         $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
         $reaction = new CancelSubscriptionOnCanceled($repo);
 
-        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 9900, 'EUR', null, null)));
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
     }
 
     public function test_it_persists_the_event_ends_at_for_immediate_cancellation(): void

--- a/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
@@ -12,6 +12,9 @@ use Vatly\Fluent\Data\UpdateOrderData;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Types\TaxSummaryItem;
+use Vatly\Fluent\Types\TaxSummaryRate;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
 
 class StoreOrderOnPaidTest extends TestCase
@@ -21,9 +24,7 @@ class StoreOrderOnPaidTest extends TestCase
         $repo = Mockery::mock(OrderRepositoryInterface::class);
         $reaction = new StoreOrderOnPaid($repo);
 
-        $event = new OrderPaid('cus_1', 'ord_1', 9900, 'EUR', 'INV-001', 'card');
-
-        $this->assertTrue($reaction->supports($event));
+        $this->assertTrue($reaction->supports($this->makeEvent()));
     }
 
     public function test_it_does_not_support_other_events(): void
@@ -36,35 +37,71 @@ class StoreOrderOnPaidTest extends TestCase
         $this->assertFalse($reaction->supports($event));
     }
 
-    public function test_it_stores_an_order_when_none_exists(): void
+    public function test_it_stores_an_order_with_tax_breakdown_when_none_exists(): void
     {
+        $taxSummary = $this->makeTaxSummary();
+        $event = $this->makeEvent(taxSummary: $taxSummary);
+
         $repo = Mockery::mock(OrderRepositoryInterface::class);
         $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
-        $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreOrderData $data) {
+        $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreOrderData $data) use ($taxSummary) {
             return $data->vatlyId === 'ord_1'
                 && $data->customerId === 'cus_1'
                 && $data->status === 'paid'
                 && $data->total === 9900
+                && $data->subtotal === 8182
+                && $data->taxSummary === $taxSummary
                 && $data->currency === 'EUR'
                 && $data->invoiceNumber === 'INV-001'
                 && $data->paymentMethod === 'card';
         }))->andReturn(Mockery::mock(OrderInterface::class));
 
         $reaction = new StoreOrderOnPaid($repo);
-        $reaction->handle(new OrderPaid('cus_1', 'ord_1', 9900, 'EUR', 'INV-001', 'card'));
+        $reaction->handle($event);
     }
 
-    public function test_it_updates_an_existing_order(): void
+    public function test_it_updates_an_existing_order_with_tax_breakdown(): void
     {
+        $taxSummary = $this->makeTaxSummary();
+        $event = $this->makeEvent(taxSummary: $taxSummary);
+
         $existing = Mockery::mock(OrderInterface::class);
         $repo = Mockery::mock(OrderRepositoryInterface::class);
         $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
-        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateOrderData $data) {
-            return $data->status === 'paid' && $data->total === 9900;
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateOrderData $data) use ($taxSummary) {
+            return $data->status === 'paid'
+                && $data->total === 9900
+                && $data->subtotal === 8182
+                && $data->taxSummary === $taxSummary;
         }))->andReturn($existing);
         $repo->shouldNotReceive('store');
 
         $reaction = new StoreOrderOnPaid($repo);
-        $reaction->handle(new OrderPaid('cus_1', 'ord_1', 9900, 'EUR', 'INV-001', 'card'));
+        $reaction->handle($event);
+    }
+
+    private function makeEvent(?TaxSummary $taxSummary = null): OrderPaid
+    {
+        return new OrderPaid(
+            customerId: 'cus_1',
+            orderId: 'ord_1',
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: $taxSummary ?? TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: 'INV-001',
+            paymentMethod: 'card',
+        );
+    }
+
+    private function makeTaxSummary(): TaxSummary
+    {
+        return new TaxSummary([
+            new TaxSummaryItem(
+                rate: new TaxSummaryRate('VAT', 21.0, 100.0),
+                amount: 1718,
+                currency: 'EUR',
+            ),
+        ]);
     }
 }

--- a/tests/Webhooks/Reactions/SyncSubscriptionOnStartedTest.php
+++ b/tests/Webhooks/Reactions/SyncSubscriptionOnStartedTest.php
@@ -14,6 +14,7 @@ use Vatly\Fluent\Events\LocalSubscriptionCreated;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
 
 class SyncSubscriptionOnStartedTest extends TestCase
@@ -35,7 +36,7 @@ class SyncSubscriptionOnStartedTest extends TestCase
         $dispatcher = Mockery::mock(EventDispatcherInterface::class);
         $reaction = new SyncSubscriptionOnStarted($repo, $dispatcher);
 
-        $event = new OrderPaid('cus_1', 'ord_1', 9900, 'EUR', null, null);
+        $event = new OrderPaid('cus_1', 'ord_1', 9900, 8182, TaxSummary::empty(), 'EUR', null, null);
 
         $this->assertFalse($reaction->supports($event));
     }

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Tests\Webhooks;
 
 use DateTimeInterface;
+use Mockery;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
@@ -17,12 +23,14 @@ use Vatly\Fluent\Webhooks\WebhookEventFactory;
 class WebhookEventFactoryTest extends TestCase
 {
     private WebhookEventFactory $factory;
+    private GetOrder $getOrder;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->factory = new WebhookEventFactory();
+        $this->getOrder = Mockery::mock(GetOrder::class);
+        $this->factory = new WebhookEventFactory($this->getOrder);
     }
 
     public function test_it_parses_webhook_payload_into_webhook_received_event(): void
@@ -120,8 +128,25 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertInstanceOf(DateTimeInterface::class, $event->endsAt);
     }
 
-    public function test_it_creates_order_paid_event_from_webhook(): void
+    public function test_it_creates_order_paid_event_from_webhook_with_enriched_tax_data(): void
     {
+        $apiOrder = $this->buildApiOrder([
+            'id' => 'ord_123',
+            'customerId' => 'cus_456',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+            'subtotal' => ['currency' => 'EUR', 'value' => '81.82'],
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+            'invoiceNumber' => 'INV-2024-001',
+            'paymentMethod' => 'credit_card',
+        ]);
+
+        $this->getOrder->shouldReceive('execute')
+            ->once()
+            ->with('ord_123')
+            ->andReturn($apiOrder);
+
         $webhook = new WebhookReceived(
             eventName: 'order.paid',
             resourceId: 'ord_123',
@@ -145,9 +170,15 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_123', $event->orderId);
         $this->assertSame(9900, $event->total);
+        $this->assertSame(8182, $event->subtotal);
         $this->assertSame('EUR', $event->currency);
         $this->assertSame('INV-2024-001', $event->invoiceNumber);
         $this->assertSame('credit_card', $event->paymentMethod);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
+        $this->assertSame(21.0, $event->taxSummary->items[0]->rate->percentage);
+        $this->assertSame(1718, $event->taxSummary->items[0]->amount);
+        $this->assertSame('EUR', $event->taxSummary->items[0]->currency);
     }
 
     public function test_it_creates_unsupported_webhook_received_for_unknown_events(): void
@@ -182,5 +213,43 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertTrue($this->factory->isSupported('subscription.started'));
         $this->assertTrue($this->factory->isSupported('order.paid'));
         $this->assertFalse($this->factory->isSupported('unknown.event'));
+    }
+
+    /**
+     * @param array{
+     *   id: string,
+     *   customerId: string,
+     *   total: array{currency: string, value: string},
+     *   subtotal: array{currency: string, value: string},
+     *   taxRates: array<int, array{name: string, percentage: float, taxablePercentage: float, amount: string}>,
+     *   invoiceNumber: ?string,
+     *   paymentMethod: ?string,
+     * } $data
+     */
+    private function buildApiOrder(array $data): ApiOrder
+    {
+        $order = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $order->id = $data['id'];
+        $order->customerId = $data['customerId'];
+        $order->total = new Money($data['total']['currency'], $data['total']['value']);
+        $order->subtotal = new Money($data['subtotal']['currency'], $data['subtotal']['value']);
+        $order->invoiceNumber = $data['invoiceNumber'];
+        $order->paymentMethod = $data['paymentMethod'];
+        $order->status = 'paid';
+
+        $taxItems = array_map(
+            fn (array $rate) => [
+                'taxRate' => [
+                    'name' => $rate['name'],
+                    'percentage' => $rate['percentage'],
+                    'taxablePercentage' => $rate['taxablePercentage'],
+                ],
+                'amount' => ['currency' => $data['total']['currency'], 'value' => $rate['amount']],
+            ],
+            $data['taxRates'],
+        );
+        $order->taxSummary = new TaxSummaryCollection($taxItems);
+
+        return $order;
     }
 }

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Tests\Webhooks;
 
 use Mockery;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
@@ -28,6 +29,7 @@ class WebhookProcessorFactoryTest extends TestCase
             orders: Mockery::mock(OrderRepositoryInterface::class),
             webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
             dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            getOrder: Mockery::mock(GetOrder::class),
         );
 
         $this->assertInstanceOf(WebhookProcessor::class, $processor);
@@ -50,6 +52,7 @@ class WebhookProcessorFactoryTest extends TestCase
             orders: Mockery::mock(OrderRepositoryInterface::class),
             webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
             dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            getOrder: Mockery::mock(GetOrder::class),
             additionalReactions: [$custom],
         );
 
@@ -67,6 +70,7 @@ class WebhookProcessorFactoryTest extends TestCase
             orders: Mockery::mock(OrderRepositoryInterface::class),
             webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
             dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            getOrder: Mockery::mock(GetOrder::class),
         );
 
         $this->assertInstanceOf(WebhookProcessor::class, $processor);

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Tests\Webhooks;
 
 use DateTimeInterface;
 use Mockery;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
@@ -32,7 +33,7 @@ class WebhookProcessorTest extends TestCase
 
         $this->secret = 'test-webhook-secret';
         $this->signatureVerifier = new SignatureVerifier();
-        $this->eventFactory = new WebhookEventFactory();
+        $this->eventFactory = new WebhookEventFactory(Mockery::mock(GetOrder::class));
         $this->repository = Mockery::mock(WebhookCallRepositoryInterface::class);
         $this->dispatcher = Mockery::mock(EventDispatcherInterface::class);
 


### PR DESCRIPTION
## Summary

Tracks the api-php endpoint/method rename in [vatly/vatly-api-php#16](https://github.com/vatly/vatly-api-php/pull/16). Upstream OpenAPI defines this as \`updateSubscriptionBilling\` on \`PATCH /subscriptions/{id}/update-billing\`, so the action that wraps it follows that name.

## Renames

| Before | After |
| --- | --- |
| \`Vatly\Fluent\Actions\CreateSubscriptionBillingUpdateLink\` | \`Vatly\Fluent\Actions\UpdateSubscriptionBilling\` |
| \`SubscriptionHandle::createBillingUpdateLink()\` | \`SubscriptionHandle::updateBilling()\` |
| \`Vatly::createSubscriptionBillingUpdateLink()\` entry-point getter | \`Vatly::updateSubscriptionBilling()\` |
| \`Billable\` / \`BillableFactory\` / \`SubscriptionHandle\` constructor prop \`\$createBillingUpdateLinkAction\` | \`\$updateBillingAction\` |

The action's internal call now hits \`\$apiClient->subscriptions->updateBilling()\` — matching the new method on the API client.

## Composer

Requires \`vatly/vatly-api-php: ^0.1.0-alpha.5\` (the renamed-methods release coordinated in vatly-api-php#16). **Merge after vatly-api-php#16 ships and is tagged.**

## Tests

All 115 fluent tests pass locally against a path-repo'd \`vatly-api-php\` on the matching branch.

## Release coordination

Breaking change. Companion update in \`vatly/vatly-laravel\` coordinated separately. Release order:
1. Merge vatly-api-php#16 → tag v0.1.0-alpha.5
2. Merge this PR → tag fluent next alpha
3. Open vatly-laravel coordination PR → tag laravel next alpha
