### PR TITLE
feat(webhooks): structured signature + Webhook::parse() + wire-shape rename

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "vatly/vatly-api-php": "^0.1.0-alpha.5"
+        "vatly/vatly-api-php": "^0.1.0-alpha.6"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/src/Contracts/WebhookCallRepositoryInterface.php
+++ b/src/Contracts/WebhookCallRepositoryInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Contracts;
 
-use DateTimeInterface;
-
 /**
  * Interface for webhook call persistence.
  */
@@ -14,16 +12,16 @@ interface WebhookCallRepositoryInterface
     /**
      * Record a webhook call.
      *
-     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $object Raw `object` field from the webhook payload.
      */
     public function record(
+        string $id,
+        string $resource,
         string $eventName,
-        string $resourceId,
-        string $resourceName,
-        array $payload,
-        DateTimeInterface $raisedAt,
-        bool $testmode,
-        ?string $vatlyCustomerId = null
+        string $entityType,
+        string $entityId,
+        array $object,
+        ?string $vatlyCustomerId = null,
     ): void;
 
     /**

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -26,10 +26,12 @@ class SubscriptionCanceledImmediately
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
+        $endsAt = $webhook->object['data']['endsAt'] ?? null;
+
         return new self(
             customerId: $webhook->object['data']['customerId'],
-            subscriptionId: $webhook->resourceId,
-            endsAt: new DateTimeImmutable($webhook->raisedAt),
+            subscriptionId: $webhook->entityId,
+            endsAt: $endsAt !== null ? new DateTimeImmutable($endsAt) : new DateTimeImmutable(),
         );
     }
 }

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -26,12 +26,10 @@ class SubscriptionCanceledImmediately
 
     public static function fromWebhook(WebhookReceived $webhook): self
     {
-        $endsAt = $webhook->object['data']['endsAt'] ?? null;
-
         return new self(
             customerId: $webhook->object['data']['customerId'],
             subscriptionId: $webhook->entityId,
-            endsAt: $endsAt !== null ? new DateTimeImmutable($endsAt) : new DateTimeImmutable(),
+            endsAt: new DateTimeImmutable(),
         );
     }
 }

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -27,9 +27,9 @@ class SubscriptionCanceledImmediately
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
+            customerId: $webhook->object['customerId'],
             subscriptionId: $webhook->entityId,
-            endsAt: new DateTimeImmutable(),
+            endsAt: new DateTimeImmutable($webhook->object['endedAt']),
         );
     }
 }

--- a/src/Events/SubscriptionCanceledWithGracePeriod.php
+++ b/src/Events/SubscriptionCanceledWithGracePeriod.php
@@ -28,7 +28,7 @@ class SubscriptionCanceledWithGracePeriod
     {
         return new self(
             customerId: $webhook->object['data']['customerId'],
-            subscriptionId: $webhook->resourceId,
+            subscriptionId: $webhook->entityId,
             endsAt: new DateTimeImmutable($webhook->object['data']['endsAt']),
         );
     }

--- a/src/Events/SubscriptionCanceledWithGracePeriod.php
+++ b/src/Events/SubscriptionCanceledWithGracePeriod.php
@@ -27,9 +27,9 @@ class SubscriptionCanceledWithGracePeriod
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
+            customerId: $webhook->object['customerId'],
             subscriptionId: $webhook->entityId,
-            endsAt: new DateTimeImmutable($webhook->object['data']['endsAt']),
+            endsAt: new DateTimeImmutable($webhook->object['endedAt']),
         );
     }
 }

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -30,7 +30,7 @@ class SubscriptionStarted
     {
         return new self(
             customerId: $webhook->object['data']['customerId'],
-            subscriptionId: $webhook->resourceId,
+            subscriptionId: $webhook->entityId,
             planId: $webhook->object['data']['subscriptionPlanId'],
             type: self::DEFAULT_TYPE,
             name: $webhook->object['data']['name'],

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -29,12 +29,12 @@ class SubscriptionStarted
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
-            customerId: $webhook->object['data']['customerId'],
+            customerId: $webhook->object['customerId'],
             subscriptionId: $webhook->entityId,
-            planId: $webhook->object['data']['subscriptionPlanId'],
+            planId: $webhook->object['subscriptionPlanId'],
             type: self::DEFAULT_TYPE,
-            name: $webhook->object['data']['name'],
-            quantity: $webhook->object['data']['quantity'],
+            name: $webhook->object['name'],
+            quantity: $webhook->object['quantity'],
         );
     }
 }

--- a/src/Events/UnsupportedWebhookReceived.php
+++ b/src/Events/UnsupportedWebhookReceived.php
@@ -15,12 +15,12 @@ class UnsupportedWebhookReceived
      * @param array<string, mixed> $object
      */
     public function __construct(
+        public string $id,
+        public string $resource,
         public string $eventName,
-        public string $resourceId,
-        public string $resourceName,
+        public string $entityType,
+        public string $entityId,
         public array $object,
-        public string $raisedAt,
-        public bool $testmode,
     ) {
         //
     }
@@ -28,12 +28,12 @@ class UnsupportedWebhookReceived
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(
+            id: $webhook->id,
+            resource: $webhook->resource,
             eventName: $webhook->eventName,
-            resourceId: $webhook->resourceId,
-            resourceName: $webhook->resourceName,
+            entityType: $webhook->entityType,
+            entityId: $webhook->entityId,
             object: $webhook->object,
-            raisedAt: $webhook->raisedAt,
-            testmode: $webhook->testmode,
         );
     }
 }

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -7,6 +7,12 @@ namespace Vatly\Fluent\Events;
 /**
  * Event representing a raw webhook call received from Vatly.
  *
+ * Mirrors the wire shape returned by `Vatly\API\Webhooks\Webhook::parse()`
+ * — see {@see \Vatly\API\Webhooks\WebhookPayload}. The `object` field is
+ * converted from the upstream stdClass to a deep array so consumers can
+ * use array access (`$webhook->object['data']['customerId']`) without
+ * juggling property/array syntax.
+ *
  * @immutable
  */
 class WebhookReceived
@@ -15,12 +21,12 @@ class WebhookReceived
      * @param array<string, mixed> $object
      */
     public function __construct(
+        public string $id,
+        public string $resource,
         public string $eventName,
-        public string $resourceId,
-        public string $resourceName,
+        public string $entityType,
+        public string $entityId,
         public array $object,
-        public string $raisedAt,
-        public bool $testmode,
     ) {
         //
     }
@@ -31,12 +37,12 @@ class WebhookReceived
     public function toArray(): array
     {
         return [
+            'id' => $this->id,
+            'resource' => $this->resource,
             'eventName' => $this->eventName,
-            'resourceId' => $this->resourceId,
-            'resourceName' => $this->resourceName,
+            'entityType' => $this->entityType,
+            'entityId' => $this->entityId,
             'object' => $this->object,
-            'raisedAt' => $this->raisedAt,
-            'testmode' => $this->testmode,
         ];
     }
 

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -10,8 +10,8 @@ namespace Vatly\Fluent\Events;
  * Mirrors the wire shape returned by `Vatly\API\Webhooks\Webhook::parse()`
  * — see {@see \Vatly\API\Webhooks\WebhookPayload}. The `object` field is
  * converted from the upstream stdClass to a deep array so consumers can
- * use array access (`$webhook->object['data']['customerId']`) without
- * juggling property/array syntax.
+ * use array access (`$webhook->object['customerId']`) without juggling
+ * property/array syntax.
  *
  * @immutable
  */

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -51,6 +51,6 @@ class WebhookReceived
      */
     public function getCustomerId(): ?string
     {
-        return $this->object['data']['customerId'] ?? null;
+        return $this->object['customerId'] ?? null;
     }
 }

--- a/src/Webhooks/SignatureVerifier.php
+++ b/src/Webhooks/SignatureVerifier.php
@@ -4,24 +4,40 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
+use Vatly\API\Exceptions\InvalidSignatureException;
+use Vatly\API\Webhooks\WebhookSignatureValidator;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
 
+/**
+ * Verify the structured `Vatly-Signature` header on incoming webhook
+ * deliveries.
+ *
+ * The header value has the form `t=<unix_seconds>,v1=<hex_hmac_sha256>`
+ * where the HMAC input is `"{$t}.{$rawBody}"`. Delegates to the upstream
+ * {@see WebhookSignatureValidator} and rethrows its exception as the
+ * framework-agnostic {@see InvalidWebhookSignatureException} that drivers
+ * (Laravel, etc.) already catch.
+ */
 class SignatureVerifier
 {
     /**
      * Verify the webhook signature.
      *
+     * @param  string  $signatureHeader  Full value of the `Vatly-Signature` header.
+     * @param  string  $payload          Raw request body bytes, exactly as received.
+     * @param  string  $secret           Webhook signing secret.
+     *
      * @throws InvalidWebhookSignatureException
      */
-    public function verify(string $signature, string $payload, string $secret): void
+    public function verify(string $signatureHeader, string $payload, string $secret): void
     {
-        if (empty($signature)) {
+        if ($signatureHeader === '') {
             throw InvalidWebhookSignatureException::missingSignature();
         }
 
-        $expectedSignature = hash_hmac('sha256', $payload, $secret);
-
-        if (!hash_equals($expectedSignature, $signature)) {
+        try {
+            (new WebhookSignatureValidator($secret))->verify($payload, $signatureHeader);
+        } catch (InvalidSignatureException) {
             throw InvalidWebhookSignatureException::invalidSignature();
         }
     }
@@ -29,14 +45,14 @@ class SignatureVerifier
     /**
      * Check if the signature is valid (returns boolean instead of throwing).
      */
-    public function isValid(string $signature, string $payload, string $secret): bool
+    public function isValid(string $signatureHeader, string $payload, string $secret): bool
     {
-        if (empty($signature)) {
+        try {
+            $this->verify($signatureHeader, $payload, $secret);
+        } catch (InvalidWebhookSignatureException) {
             return false;
         }
 
-        $expectedSignature = hash_hmac('sha256', $payload, $secret);
-
-        return hash_equals($expectedSignature, $signature);
+        return true;
     }
 }

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
+use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
@@ -35,25 +36,29 @@ class WebhookEventFactory
             SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromWebhook($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
-            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->resourceId)),
+            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->entityId)),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
 
     /**
-     * Parse raw webhook payload into a WebhookReceived event.
-     *
-     * @param array<string, mixed> $payload
+     * Build the framework-agnostic {@see WebhookReceived} from the upstream
+     * {@see WebhookPayload}. The upstream `object` is a `stdClass`; we deep-
+     * convert to an array so consumers keep using array access.
      */
-    public function parsePayload(array $payload): WebhookReceived
+    public function fromPayload(WebhookPayload $payload): WebhookReceived
     {
+        $object = $payload->object !== null
+            ? (array) json_decode((string) json_encode($payload->object), true)
+            : [];
+
         return new WebhookReceived(
-            eventName: $payload['eventName'] ?? '',
-            resourceId: $payload['resourceId'] ?? '',
-            resourceName: $payload['resourceName'] ?? '',
-            object: $payload['object'] ?? [],
-            raisedAt: $payload['raisedAt'] ?? '',
-            testmode: $payload['testmode'] ?? false,
+            id: $payload->id,
+            resource: $payload->resource,
+            eventName: $payload->eventName,
+            entityType: $payload->entityType,
+            entityId: $payload->entityId,
+            object: $object,
         );
     }
 

--- a/src/Webhooks/WebhookProcessor.php
+++ b/src/Webhooks/WebhookProcessor.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
-use DateTimeImmutable;
+use InvalidArgumentException;
+use Vatly\API\Exceptions\InvalidSignatureException;
+use Vatly\API\Webhooks\Webhook;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
 
 /**
  * @immutable
@@ -18,7 +21,6 @@ class WebhookProcessor
      * @param  WebhookReactionInterface[]  $reactions
      */
     public function __construct(
-        private SignatureVerifier $signatureVerifier,
         private WebhookEventFactory $eventFactory,
         private WebhookCallRepositoryInterface $repository,
         private EventDispatcherInterface $dispatcher,
@@ -31,28 +33,40 @@ class WebhookProcessor
     /**
      * Handle an incoming webhook request.
      *
-     * Flow: verify → parse → store → react → dispatch
+     * Flow: parse (verify + decode + validate) → store → react → dispatch
      *
-     * Reactions handle core billing logic (storing orders, syncing subscriptions).
-     * The dispatcher fires the event for framework-specific listeners (emails, etc).
+     * Verification and structural validation are delegated to
+     * {@see Webhook::parse()}; this method only deals with the
+     * downstream bookkeeping. Reactions handle core billing logic
+     * (storing orders, syncing subscriptions). The dispatcher fires the
+     * event for framework-specific listeners (emails, etc).
      *
-     * @throws \Vatly\Fluent\Exceptions\InvalidWebhookSignatureException
+     * @throws InvalidWebhookSignatureException When the signature is missing, the
+     *                                          timestamp is outside the replay
+     *                                          window, the HMAC does not match,
+     *                                          or the payload structure is invalid.
      */
     public function handle(string $payload, string $signature): void
     {
-        $this->signatureVerifier->verify($signature, $payload, $this->webhookSecret);
+        if ($signature === '') {
+            throw InvalidWebhookSignatureException::missingSignature();
+        }
 
-        $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $parsed = Webhook::parse($payload, $signature, $this->webhookSecret);
+        } catch (InvalidSignatureException|InvalidArgumentException) {
+            throw InvalidWebhookSignatureException::invalidSignature();
+        }
 
-        $webhook = $this->eventFactory->parsePayload($decoded);
+        $webhook = $this->eventFactory->fromPayload($parsed);
 
         $this->repository->record(
+            id: $webhook->id,
+            resource: $webhook->resource,
             eventName: $webhook->eventName,
-            resourceId: $webhook->resourceId,
-            resourceName: $webhook->resourceName,
-            payload: $decoded,
-            raisedAt: new DateTimeImmutable($webhook->raisedAt),
-            testmode: $webhook->testmode,
+            entityType: $webhook->entityType,
+            entityId: $webhook->entityId,
+            object: $webhook->object,
             vatlyCustomerId: $webhook->getCustomerId(),
         );
 

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -35,7 +35,6 @@ class WebhookProcessorFactory
         array $additionalReactions = [],
     ): WebhookProcessor {
         return new WebhookProcessor(
-            signatureVerifier: new SignatureVerifier(),
             eventFactory: new WebhookEventFactory($getOrder),
             repository: $webhookCalls,
             dispatcher: $dispatcher,

--- a/tests/Events/SubscriptionCanceledTest.php
+++ b/tests/Events/SubscriptionCanceledTest.php
@@ -33,15 +33,20 @@ class SubscriptionCanceledTest extends TestCase
         $this->assertSame($endsAt, $event->endsAt);
     }
 
-    public function test_immediately_creates_from_webhook(): void
+    public function test_immediately_creates_from_webhook_using_object_ends_at(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.canceled_immediately',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
-            object: ['data' => ['customerId' => 'cus_456']],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            object: [
+                'data' => [
+                    'customerId' => 'cus_456',
+                    'endsAt' => '2024-01-15T10:00:00Z',
+                ],
+            ],
         );
 
         $event = SubscriptionCanceledImmediately::fromWebhook($webhook);
@@ -52,6 +57,25 @@ class SubscriptionCanceledTest extends TestCase
             new DateTimeImmutable('2024-01-15T10:00:00Z'),
             $event->endsAt,
         );
+    }
+
+    public function test_immediately_falls_back_to_now_when_object_lacks_ends_at(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.canceled_immediately',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            object: ['data' => ['customerId' => 'cus_456']],
+        );
+
+        $before = new DateTimeImmutable();
+        $event = SubscriptionCanceledImmediately::fromWebhook($webhook);
+        $after = new DateTimeImmutable();
+
+        $this->assertGreaterThanOrEqual($before, $event->endsAt);
+        $this->assertLessThanOrEqual($after, $event->endsAt);
     }
 
     public function test_with_grace_period_has_correct_vatly_event_name_constant(): void
@@ -77,17 +101,17 @@ class SubscriptionCanceledTest extends TestCase
     public function test_with_grace_period_creates_from_webhook_with_parsed_date(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.canceled_with_grace_period',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: [
                 'data' => [
                     'customerId' => 'cus_456',
                     'endsAt' => '2024-02-15T10:00:00Z',
                 ],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = SubscriptionCanceledWithGracePeriod::fromWebhook($webhook);

--- a/tests/Events/SubscriptionCanceledTest.php
+++ b/tests/Events/SubscriptionCanceledTest.php
@@ -33,33 +33,7 @@ class SubscriptionCanceledTest extends TestCase
         $this->assertSame($endsAt, $event->endsAt);
     }
 
-    public function test_immediately_creates_from_webhook_using_object_ends_at(): void
-    {
-        $webhook = new WebhookReceived(
-            id: 'webhook_event_abc',
-            resource: 'webhook_event',
-            eventName: 'subscription.canceled_immediately',
-            entityType: 'subscription',
-            entityId: 'sub_123',
-            object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'endsAt' => '2024-01-15T10:00:00Z',
-                ],
-            ],
-        );
-
-        $event = SubscriptionCanceledImmediately::fromWebhook($webhook);
-
-        $this->assertSame('cus_456', $event->customerId);
-        $this->assertSame('sub_123', $event->subscriptionId);
-        $this->assertEquals(
-            new DateTimeImmutable('2024-01-15T10:00:00Z'),
-            $event->endsAt,
-        );
-    }
-
-    public function test_immediately_falls_back_to_now_when_object_lacks_ends_at(): void
+    public function test_immediately_creates_from_webhook_with_ends_at_now(): void
     {
         $webhook = new WebhookReceived(
             id: 'webhook_event_abc',
@@ -74,6 +48,8 @@ class SubscriptionCanceledTest extends TestCase
         $event = SubscriptionCanceledImmediately::fromWebhook($webhook);
         $after = new DateTimeImmutable();
 
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
         $this->assertGreaterThanOrEqual($before, $event->endsAt);
         $this->assertLessThanOrEqual($after, $event->endsAt);
     }

--- a/tests/Events/SubscriptionCanceledTest.php
+++ b/tests/Events/SubscriptionCanceledTest.php
@@ -33,7 +33,7 @@ class SubscriptionCanceledTest extends TestCase
         $this->assertSame($endsAt, $event->endsAt);
     }
 
-    public function test_immediately_creates_from_webhook_with_ends_at_now(): void
+    public function test_immediately_creates_from_webhook(): void
     {
         $webhook = new WebhookReceived(
             id: 'webhook_event_abc',
@@ -41,17 +41,20 @@ class SubscriptionCanceledTest extends TestCase
             eventName: 'subscription.canceled_immediately',
             entityType: 'subscription',
             entityId: 'sub_123',
-            object: ['data' => ['customerId' => 'cus_456']],
+            object: [
+                'customerId' => 'cus_456',
+                'endedAt' => '2024-01-15T10:00:00Z',
+            ],
         );
 
-        $before = new DateTimeImmutable();
         $event = SubscriptionCanceledImmediately::fromWebhook($webhook);
-        $after = new DateTimeImmutable();
 
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('sub_123', $event->subscriptionId);
-        $this->assertGreaterThanOrEqual($before, $event->endsAt);
-        $this->assertLessThanOrEqual($after, $event->endsAt);
+        $this->assertEquals(
+            new DateTimeImmutable('2024-01-15T10:00:00Z'),
+            $event->endsAt,
+        );
     }
 
     public function test_with_grace_period_has_correct_vatly_event_name_constant(): void
@@ -83,10 +86,8 @@ class SubscriptionCanceledTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'endsAt' => '2024-02-15T10:00:00Z',
-                ],
+                'customerId' => 'cus_456',
+                'endedAt' => '2024-02-15T10:00:00Z',
             ],
         );
 

--- a/tests/Events/SubscriptionStartedTest.php
+++ b/tests/Events/SubscriptionStartedTest.php
@@ -42,9 +42,11 @@ class SubscriptionStartedTest extends TestCase
     public function test_it_creates_from_webhook(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.started',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: [
                 'data' => [
                     'customerId' => 'cus_456',
@@ -53,8 +55,6 @@ class SubscriptionStartedTest extends TestCase
                     'quantity' => 1,
                 ],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = SubscriptionStarted::fromWebhook($webhook);

--- a/tests/Events/SubscriptionStartedTest.php
+++ b/tests/Events/SubscriptionStartedTest.php
@@ -48,12 +48,10 @@ class SubscriptionStartedTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'subscriptionPlanId' => 'plan_789',
-                    'name' => 'Basic Plan',
-                    'quantity' => 1,
-                ],
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Basic Plan',
+                'quantity' => 1,
             ],
         );
 

--- a/tests/Events/UnsupportedWebhookReceivedTest.php
+++ b/tests/Events/UnsupportedWebhookReceivedTest.php
@@ -13,41 +13,41 @@ class UnsupportedWebhookReceivedTest extends TestCase
     public function test_it_can_be_instantiated_with_all_properties(): void
     {
         $event = new UnsupportedWebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'unknown.event',
-            resourceId: 'res_123',
-            resourceName: 'resource',
+            entityType: 'resource',
+            entityId: 'res_123',
             object: ['data' => ['key' => 'value']],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: true,
         );
 
+        $this->assertSame('webhook_event_abc', $event->id);
+        $this->assertSame('webhook_event', $event->resource);
         $this->assertSame('unknown.event', $event->eventName);
-        $this->assertSame('res_123', $event->resourceId);
-        $this->assertSame('resource', $event->resourceName);
+        $this->assertSame('resource', $event->entityType);
+        $this->assertSame('res_123', $event->entityId);
         $this->assertSame(['data' => ['key' => 'value']], $event->object);
-        $this->assertSame('2024-01-15T10:00:00Z', $event->raisedAt);
-        $this->assertTrue($event->testmode);
     }
 
     public function test_it_creates_from_webhook_received(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_xyz',
+            resource: 'webhook_event',
             eventName: 'unknown.event.type',
-            resourceId: 'xyz_789',
-            resourceName: 'unknown_resource',
+            entityType: 'unknown_resource',
+            entityId: 'xyz_789',
             object: ['foo' => 'bar'],
-            raisedAt: '2024-06-01T12:00:00Z',
-            testmode: false,
         );
 
         $event = UnsupportedWebhookReceived::fromWebhook($webhook);
 
         $this->assertInstanceOf(UnsupportedWebhookReceived::class, $event);
+        $this->assertSame('webhook_event_xyz', $event->id);
+        $this->assertSame('webhook_event', $event->resource);
         $this->assertSame('unknown.event.type', $event->eventName);
-        $this->assertSame('xyz_789', $event->resourceId);
-        $this->assertSame('unknown_resource', $event->resourceName);
+        $this->assertSame('unknown_resource', $event->entityType);
+        $this->assertSame('xyz_789', $event->entityId);
         $this->assertSame(['foo' => 'bar'], $event->object);
-        $this->assertSame('2024-06-01T12:00:00Z', $event->raisedAt);
-        $this->assertFalse($event->testmode);
     }
 }

--- a/tests/Events/WebhookReceivedTest.php
+++ b/tests/Events/WebhookReceivedTest.php
@@ -12,53 +12,53 @@ class WebhookReceivedTest extends TestCase
     public function test_it_can_be_instantiated_with_all_properties(): void
     {
         $event = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.started',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: ['data' => ['customerId' => 'cus_456']],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: true,
         );
 
+        $this->assertSame('webhook_event_abc', $event->id);
+        $this->assertSame('webhook_event', $event->resource);
         $this->assertSame('subscription.started', $event->eventName);
-        $this->assertSame('sub_123', $event->resourceId);
-        $this->assertSame('subscription', $event->resourceName);
+        $this->assertSame('subscription', $event->entityType);
+        $this->assertSame('sub_123', $event->entityId);
         $this->assertSame(['data' => ['customerId' => 'cus_456']], $event->object);
-        $this->assertSame('2024-01-15T10:00:00Z', $event->raisedAt);
-        $this->assertTrue($event->testmode);
     }
 
     public function test_it_converts_to_array(): void
     {
         $event = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.started',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: ['data' => []],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $array = $event->toArray();
 
+        $this->assertArrayHasKey('id', $array);
+        $this->assertArrayHasKey('resource', $array);
         $this->assertArrayHasKey('eventName', $array);
-        $this->assertArrayHasKey('resourceId', $array);
-        $this->assertArrayHasKey('resourceName', $array);
+        $this->assertArrayHasKey('entityType', $array);
+        $this->assertArrayHasKey('entityId', $array);
         $this->assertArrayHasKey('object', $array);
-        $this->assertArrayHasKey('raisedAt', $array);
-        $this->assertArrayHasKey('testmode', $array);
         $this->assertSame('subscription.started', $array['eventName']);
     }
 
     public function test_it_extracts_customer_id_from_object(): void
     {
         $event = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.started',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: ['data' => ['customerId' => 'cus_456']],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $this->assertSame('cus_456', $event->getCustomerId());
@@ -67,12 +67,12 @@ class WebhookReceivedTest extends TestCase
     public function test_it_returns_null_when_customer_id_not_present(): void
     {
         $event = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'test.event',
-            resourceId: 'res_123',
-            resourceName: 'resource',
+            entityType: 'resource',
+            entityId: 'res_123',
             object: ['data' => []],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $this->assertNull($event->getCustomerId());

--- a/tests/Events/WebhookReceivedTest.php
+++ b/tests/Events/WebhookReceivedTest.php
@@ -17,7 +17,7 @@ class WebhookReceivedTest extends TestCase
             eventName: 'subscription.started',
             entityType: 'subscription',
             entityId: 'sub_123',
-            object: ['data' => ['customerId' => 'cus_456']],
+            object: ['customerId' => 'cus_456'],
         );
 
         $this->assertSame('webhook_event_abc', $event->id);
@@ -25,7 +25,7 @@ class WebhookReceivedTest extends TestCase
         $this->assertSame('subscription.started', $event->eventName);
         $this->assertSame('subscription', $event->entityType);
         $this->assertSame('sub_123', $event->entityId);
-        $this->assertSame(['data' => ['customerId' => 'cus_456']], $event->object);
+        $this->assertSame(['customerId' => 'cus_456'], $event->object);
     }
 
     public function test_it_converts_to_array(): void
@@ -36,7 +36,7 @@ class WebhookReceivedTest extends TestCase
             eventName: 'subscription.started',
             entityType: 'subscription',
             entityId: 'sub_123',
-            object: ['data' => []],
+            object: [],
         );
 
         $array = $event->toArray();
@@ -58,7 +58,7 @@ class WebhookReceivedTest extends TestCase
             eventName: 'subscription.started',
             entityType: 'subscription',
             entityId: 'sub_123',
-            object: ['data' => ['customerId' => 'cus_456']],
+            object: ['customerId' => 'cus_456'],
         );
 
         $this->assertSame('cus_456', $event->getCustomerId());
@@ -72,7 +72,7 @@ class WebhookReceivedTest extends TestCase
             eventName: 'test.event',
             entityType: 'resource',
             entityId: 'res_123',
-            object: ['data' => []],
+            object: [],
         );
 
         $this->assertNull($event->getCustomerId());

--- a/tests/Webhooks/SignatureVerifierTest.php
+++ b/tests/Webhooks/SignatureVerifierTest.php
@@ -25,10 +25,10 @@ class SignatureVerifierTest extends TestCase
 
     public function test_it_verifies_valid_signature(): void
     {
-        $validSignature = hash_hmac('sha256', $this->payload, $this->secret);
+        $header = $this->makeSignatureHeader($this->payload, $this->secret);
 
         // Should not throw
-        $this->verifier->verify($validSignature, $this->payload, $this->secret);
+        $this->verifier->verify($header, $this->payload, $this->secret);
 
         $this->assertTrue(true); // If we get here, verification passed
     }
@@ -38,7 +38,9 @@ class SignatureVerifierTest extends TestCase
         $this->expectException(InvalidWebhookSignatureException::class);
         $this->expectExceptionMessage('Invalid Vatly webhook signature');
 
-        $this->verifier->verify('invalid-signature', $this->payload, $this->secret);
+        $header = 't='.time().',v1=deadbeef';
+
+        $this->verifier->verify($header, $this->payload, $this->secret);
     }
 
     public function test_it_throws_exception_for_missing_signature(): void
@@ -49,20 +51,68 @@ class SignatureVerifierTest extends TestCase
         $this->verifier->verify('', $this->payload, $this->secret);
     }
 
+    public function test_it_throws_exception_for_malformed_header(): void
+    {
+        $this->expectException(InvalidWebhookSignatureException::class);
+
+        $this->verifier->verify('garbage', $this->payload, $this->secret);
+    }
+
+    public function test_it_throws_exception_for_stale_timestamp(): void
+    {
+        $this->expectException(InvalidWebhookSignatureException::class);
+
+        $staleTimestamp = time() - 3600;
+        $signature = hash_hmac('sha256', $staleTimestamp.'.'.$this->payload, $this->secret);
+        $header = "t={$staleTimestamp},v1={$signature}";
+
+        $this->verifier->verify($header, $this->payload, $this->secret);
+    }
+
+    public function test_it_throws_exception_for_tampered_payload(): void
+    {
+        $this->expectException(InvalidWebhookSignatureException::class);
+
+        $header = $this->makeSignatureHeader($this->payload, $this->secret);
+
+        $this->verifier->verify($header, $this->payload.'tampered', $this->secret);
+    }
+
     public function test_is_valid_returns_true_for_valid_signature(): void
     {
-        $validSignature = hash_hmac('sha256', $this->payload, $this->secret);
+        $header = $this->makeSignatureHeader($this->payload, $this->secret);
 
-        $this->assertTrue($this->verifier->isValid($validSignature, $this->payload, $this->secret));
+        $this->assertTrue($this->verifier->isValid($header, $this->payload, $this->secret));
     }
 
     public function test_is_valid_returns_false_for_invalid_signature(): void
     {
-        $this->assertFalse($this->verifier->isValid('invalid', $this->payload, $this->secret));
+        $header = 't='.time().',v1=deadbeef';
+
+        $this->assertFalse($this->verifier->isValid($header, $this->payload, $this->secret));
     }
 
     public function test_is_valid_returns_false_for_empty_signature(): void
     {
         $this->assertFalse($this->verifier->isValid('', $this->payload, $this->secret));
+    }
+
+    public function test_it_tolerates_unknown_future_scheme_keys(): void
+    {
+        $timestamp = time();
+        $v1 = hash_hmac('sha256', $timestamp.'.'.$this->payload, $this->secret);
+        $header = "t={$timestamp},v1={$v1},v2=somethingfromthefuture";
+
+        $this->verifier->verify($header, $this->payload, $this->secret);
+
+        $this->assertTrue(true);
+    }
+
+    private function makeSignatureHeader(string $payload, string $secret, ?int $timestamp = null): string
+    {
+        $timestamp ??= time();
+        $signature = hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
+
+        return "t={$timestamp},v1={$signature}";
     }
 }

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -10,6 +10,7 @@ use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
+use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
@@ -33,33 +34,52 @@ class WebhookEventFactoryTest extends TestCase
         $this->factory = new WebhookEventFactory($this->getOrder);
     }
 
-    public function test_it_parses_webhook_payload_into_webhook_received_event(): void
+    public function test_it_converts_upstream_webhook_payload_into_webhook_received_event(): void
     {
-        $payload = [
-            'eventName' => 'subscription.started',
-            'resourceId' => 'sub_123',
-            'resourceName' => 'subscription',
-            'object' => ['data' => ['customerId' => 'cus_456']],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => true,
-        ];
+        $payload = new WebhookPayload(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            object: (object) ['data' => (object) ['customerId' => 'cus_456']],
+        );
 
-        $event = $this->factory->parsePayload($payload);
+        $event = $this->factory->fromPayload($payload);
 
         $this->assertInstanceOf(WebhookReceived::class, $event);
+        $this->assertSame('webhook_event_abc', $event->id);
+        $this->assertSame('webhook_event', $event->resource);
         $this->assertSame('subscription.started', $event->eventName);
-        $this->assertSame('sub_123', $event->resourceId);
-        $this->assertSame('subscription', $event->resourceName);
-        $this->assertTrue($event->testmode);
+        $this->assertSame('subscription', $event->entityType);
+        $this->assertSame('sub_123', $event->entityId);
         $this->assertSame('cus_456', $event->getCustomerId());
+    }
+
+    public function test_it_converts_payload_with_null_object_into_empty_array(): void
+    {
+        $payload = new WebhookPayload(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'unknown.event',
+            entityType: 'unknown',
+            entityId: 'res_123',
+            object: null,
+        );
+
+        $event = $this->factory->fromPayload($payload);
+
+        $this->assertSame([], $event->object);
     }
 
     public function test_it_creates_subscription_started_event_from_webhook(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.started',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: [
                 'data' => [
                     'customerId' => 'cus_456',
@@ -68,8 +88,6 @@ class WebhookEventFactoryTest extends TestCase
                     'quantity' => 1,
                 ],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = $this->factory->createFromWebhook($webhook);
@@ -85,16 +103,16 @@ class WebhookEventFactoryTest extends TestCase
     public function test_it_creates_subscription_canceled_immediately_event_from_webhook(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.canceled_immediately',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: [
                 'data' => [
                     'customerId' => 'cus_456',
                 ],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = $this->factory->createFromWebhook($webhook);
@@ -107,17 +125,17 @@ class WebhookEventFactoryTest extends TestCase
     public function test_it_creates_subscription_canceled_with_grace_period_event_from_webhook(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'subscription.canceled_with_grace_period',
-            resourceId: 'sub_123',
-            resourceName: 'subscription',
+            entityType: 'subscription',
+            entityId: 'sub_123',
             object: [
                 'data' => [
                     'customerId' => 'cus_456',
                     'endsAt' => '2024-02-15T10:00:00Z',
                 ],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = $this->factory->createFromWebhook($webhook);
@@ -148,9 +166,11 @@ class WebhookEventFactoryTest extends TestCase
             ->andReturn($apiOrder);
 
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'order.paid',
-            resourceId: 'ord_123',
-            resourceName: 'order',
+            entityType: 'order',
+            entityId: 'ord_123',
             object: [
                 'data' => [
                     'customerId' => 'cus_456',
@@ -160,8 +180,6 @@ class WebhookEventFactoryTest extends TestCase
                     'paymentMethod' => 'credit_card',
                 ],
             ],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = $this->factory->createFromWebhook($webhook);
@@ -184,12 +202,12 @@ class WebhookEventFactoryTest extends TestCase
     public function test_it_creates_unsupported_webhook_received_for_unknown_events(): void
     {
         $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
             eventName: 'unknown.event',
-            resourceId: 'res_123',
-            resourceName: 'unknown',
+            entityType: 'unknown',
+            entityId: 'res_123',
             object: [],
-            raisedAt: '2024-01-15T10:00:00Z',
-            testmode: false,
         );
 
         $event = $this->factory->createFromWebhook($webhook);

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -42,7 +42,7 @@ class WebhookEventFactoryTest extends TestCase
             eventName: 'subscription.started',
             entityType: 'subscription',
             entityId: 'sub_123',
-            object: (object) ['data' => (object) ['customerId' => 'cus_456']],
+            object: (object) ['customerId' => 'cus_456'],
         );
 
         $event = $this->factory->fromPayload($payload);
@@ -81,12 +81,10 @@ class WebhookEventFactoryTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'subscriptionPlanId' => 'plan_789',
-                    'name' => 'Premium Plan',
-                    'quantity' => 1,
-                ],
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
             ],
         );
 
@@ -109,9 +107,8 @@ class WebhookEventFactoryTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                ],
+                'customerId' => 'cus_456',
+                'endedAt' => '2024-01-15T10:00:00Z',
             ],
         );
 
@@ -131,10 +128,8 @@ class WebhookEventFactoryTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'endsAt' => '2024-02-15T10:00:00Z',
-                ],
+                'customerId' => 'cus_456',
+                'endedAt' => '2024-02-15T10:00:00Z',
             ],
         );
 
@@ -172,13 +167,10 @@ class WebhookEventFactoryTest extends TestCase
             entityType: 'order',
             entityId: 'ord_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'total' => 9900,
-                    'currency' => 'EUR',
-                    'invoiceNumber' => 'INV-2024-001',
-                    'paymentMethod' => 'credit_card',
-                ],
+                'customerId' => 'cus_456',
+                'total' => ['currency' => 'EUR', 'value' => '99.00'],
+                'invoiceNumber' => 'INV-2024-001',
+                'paymentMethod' => 'credit_card',
             ],
         );
 

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Tests\Webhooks;
 
-use DateTimeInterface;
 use Mockery;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -14,14 +13,12 @@ use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
 use Vatly\Fluent\Tests\TestCase;
-use Vatly\Fluent\Webhooks\SignatureVerifier;
 use Vatly\Fluent\Webhooks\WebhookEventFactory;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 
 class WebhookProcessorTest extends TestCase
 {
     private string $secret;
-    private SignatureVerifier $signatureVerifier;
     private WebhookEventFactory $eventFactory;
     private WebhookCallRepositoryInterface $repository;
     private EventDispatcherInterface $dispatcher;
@@ -32,13 +29,11 @@ class WebhookProcessorTest extends TestCase
         parent::setUp();
 
         $this->secret = 'test-webhook-secret';
-        $this->signatureVerifier = new SignatureVerifier();
         $this->eventFactory = new WebhookEventFactory(Mockery::mock(GetOrder::class));
         $this->repository = Mockery::mock(WebhookCallRepositoryInterface::class);
         $this->dispatcher = Mockery::mock(EventDispatcherInterface::class);
 
         $this->processor = new WebhookProcessor(
-            $this->signatureVerifier,
             $this->eventFactory,
             $this->repository,
             $this->dispatcher,
@@ -48,11 +43,12 @@ class WebhookProcessorTest extends TestCase
 
     public function test_it_processes_a_valid_webhook_end_to_end(): void
     {
-        $payload = json_encode([
-            'eventName' => 'subscription.started',
-            'resourceId' => 'sub_123',
-            'resourceName' => 'subscription',
-            'object' => [
+        $payload = $this->makePayload(
+            id: 'webhook_event_abc',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            object: [
                 'data' => [
                     'customerId' => 'cus_456',
                     'subscriptionPlanId' => 'plan_789',
@@ -60,9 +56,7 @@ class WebhookProcessorTest extends TestCase
                     'quantity' => 1,
                 ],
             ],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => false,
-        ]);
+        );
 
         $signature = $this->makeSignatureHeader($payload, $this->secret);
 
@@ -70,20 +64,20 @@ class WebhookProcessorTest extends TestCase
             ->shouldReceive('record')
             ->once()
             ->withArgs(function (
+                string $id,
+                string $resource,
                 string $eventName,
-                string $resourceId,
-                string $resourceName,
-                array $recordedPayload,
-                DateTimeInterface $raisedAt,
-                bool $testmode,
+                string $entityType,
+                string $entityId,
+                array $object,
                 ?string $vatlyCustomerId,
             ) {
-                return $eventName === 'subscription.started'
-                    && $resourceId === 'sub_123'
-                    && $resourceName === 'subscription'
-                    && $recordedPayload['eventName'] === 'subscription.started'
-                    && $raisedAt->format('Y-m-d') === '2024-01-15'
-                    && $testmode === false
+                return $id === 'webhook_event_abc'
+                    && $resource === 'webhook_event'
+                    && $eventName === 'subscription.started'
+                    && $entityType === 'subscription'
+                    && $entityId === 'sub_123'
+                    && $object['data']['customerId'] === 'cus_456'
                     && $vatlyCustomerId === 'cus_456';
             });
 
@@ -102,11 +96,12 @@ class WebhookProcessorTest extends TestCase
 
     public function test_it_runs_matching_reactions_before_dispatching(): void
     {
-        $payload = json_encode([
-            'eventName' => 'subscription.started',
-            'resourceId' => 'sub_123',
-            'resourceName' => 'subscription',
-            'object' => [
+        $payload = $this->makePayload(
+            id: 'webhook_event_xyz',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            object: [
                 'data' => [
                     'customerId' => 'cus_456',
                     'subscriptionPlanId' => 'plan_789',
@@ -114,9 +109,7 @@ class WebhookProcessorTest extends TestCase
                     'quantity' => 1,
                 ],
             ],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => false,
-        ]);
+        );
 
         $signature = $this->makeSignatureHeader($payload, $this->secret);
 
@@ -134,7 +127,6 @@ class WebhookProcessorTest extends TestCase
         $nonMatchingReaction->shouldNotReceive('handle');
 
         $processor = new WebhookProcessor(
-            $this->signatureVerifier,
             $this->eventFactory,
             $this->repository,
             $this->dispatcher,
@@ -147,33 +139,29 @@ class WebhookProcessorTest extends TestCase
 
     public function test_it_throws_exception_for_invalid_signature(): void
     {
-        $payload = json_encode([
-            'eventName' => 'subscription.started',
-            'resourceId' => 'sub_123',
-            'resourceName' => 'subscription',
-            'object' => [],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => false,
-        ]);
+        $payload = $this->makePayload(
+            id: 'webhook_event_abc',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+        );
 
         $this->repository->shouldNotReceive('record');
         $this->dispatcher->shouldNotReceive('dispatch');
 
         $this->expectException(InvalidWebhookSignatureException::class);
 
-        $this->processor->handle($payload, 'invalid-signature');
+        $this->processor->handle($payload, 't='.time().',v1=deadbeef');
     }
 
     public function test_it_throws_exception_for_missing_signature(): void
     {
-        $payload = json_encode([
-            'eventName' => 'subscription.started',
-            'resourceId' => 'sub_123',
-            'resourceName' => 'subscription',
-            'object' => [],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => false,
-        ]);
+        $payload = $this->makePayload(
+            id: 'webhook_event_abc',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+        );
 
         $this->repository->shouldNotReceive('record');
         $this->dispatcher->shouldNotReceive('dispatch');
@@ -183,16 +171,28 @@ class WebhookProcessorTest extends TestCase
         $this->processor->handle($payload, '');
     }
 
+    public function test_it_throws_exception_for_malformed_payload(): void
+    {
+        $this->repository->shouldNotReceive('record');
+        $this->dispatcher->shouldNotReceive('dispatch');
+
+        $payload = json_encode(['eventName' => 'subscription.started']); // missing required fields
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
+
+        $this->expectException(InvalidWebhookSignatureException::class);
+
+        $this->processor->handle($payload, $signature);
+    }
+
     public function test_it_dispatches_unsupported_webhook_received_for_unknown_events(): void
     {
-        $payload = json_encode([
-            'eventName' => 'unknown.event',
-            'resourceId' => 'res_123',
-            'resourceName' => 'unknown',
-            'object' => [],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => false,
-        ]);
+        $payload = $this->makePayload(
+            id: 'webhook_event_abc',
+            eventName: 'unknown.event',
+            entityType: 'unknown',
+            entityId: 'res_123',
+            object: [],
+        );
 
         $signature = $this->makeSignatureHeader($payload, $this->secret);
 
@@ -209,44 +209,25 @@ class WebhookProcessorTest extends TestCase
         $this->processor->handle($payload, $signature);
     }
 
-    public function test_it_records_webhook_with_testmode_flag(): void
-    {
-        $payload = json_encode([
-            'eventName' => 'subscription.started',
-            'resourceId' => 'sub_123',
-            'resourceName' => 'subscription',
-            'object' => [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'subscriptionPlanId' => 'plan_789',
-                    'name' => 'Test Plan',
-                    'quantity' => 1,
-                ],
-            ],
-            'raisedAt' => '2024-01-15T10:00:00Z',
-            'testmode' => true,
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function makePayload(
+        string $id,
+        string $eventName,
+        string $entityType,
+        string $entityId,
+        array $object = [],
+        string $resource = 'webhook_event',
+    ): string {
+        return (string) json_encode([
+            'id' => $id,
+            'resource' => $resource,
+            'eventName' => $eventName,
+            'entityType' => $entityType,
+            'entityId' => $entityId,
+            'object' => (object) $object,
         ]);
-
-        $signature = $this->makeSignatureHeader($payload, $this->secret);
-
-        $this->repository
-            ->shouldReceive('record')
-            ->once()
-            ->withArgs(function (
-                string $eventName,
-                string $resourceId,
-                string $resourceName,
-                array $recordedPayload,
-                DateTimeInterface $raisedAt,
-                bool $testmode,
-                ?string $vatlyCustomerId,
-            ) {
-                return $testmode === true;
-            });
-
-        $this->dispatcher->shouldReceive('dispatch')->once();
-
-        $this->processor->handle($payload, $signature);
     }
 
     private function makeSignatureHeader(string $payload, string $secret, ?int $timestamp = null): string

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -64,7 +64,7 @@ class WebhookProcessorTest extends TestCase
             'testmode' => false,
         ]);
 
-        $signature = hash_hmac('sha256', $payload, $this->secret);
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
 
         $this->repository
             ->shouldReceive('record')
@@ -118,7 +118,7 @@ class WebhookProcessorTest extends TestCase
             'testmode' => false,
         ]);
 
-        $signature = hash_hmac('sha256', $payload, $this->secret);
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
 
         $this->repository->shouldReceive('record')->once();
         $this->dispatcher->shouldReceive('dispatch')->once();
@@ -194,7 +194,7 @@ class WebhookProcessorTest extends TestCase
             'testmode' => false,
         ]);
 
-        $signature = hash_hmac('sha256', $payload, $this->secret);
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
 
         $this->repository->shouldReceive('record')->once();
 
@@ -227,7 +227,7 @@ class WebhookProcessorTest extends TestCase
             'testmode' => true,
         ]);
 
-        $signature = hash_hmac('sha256', $payload, $this->secret);
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
 
         $this->repository
             ->shouldReceive('record')
@@ -247,5 +247,13 @@ class WebhookProcessorTest extends TestCase
         $this->dispatcher->shouldReceive('dispatch')->once();
 
         $this->processor->handle($payload, $signature);
+    }
+
+    private function makeSignatureHeader(string $payload, string $secret, ?int $timestamp = null): string
+    {
+        $timestamp ??= time();
+        $signature = hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
+
+        return "t={$timestamp},v1={$signature}";
     }
 }

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -49,12 +49,10 @@ class WebhookProcessorTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'subscriptionPlanId' => 'plan_789',
-                    'name' => 'Premium Plan',
-                    'quantity' => 1,
-                ],
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
             ],
         );
 
@@ -77,7 +75,7 @@ class WebhookProcessorTest extends TestCase
                     && $eventName === 'subscription.started'
                     && $entityType === 'subscription'
                     && $entityId === 'sub_123'
-                    && $object['data']['customerId'] === 'cus_456'
+                    && $object['customerId'] === 'cus_456'
                     && $vatlyCustomerId === 'cus_456';
             });
 
@@ -102,12 +100,10 @@ class WebhookProcessorTest extends TestCase
             entityType: 'subscription',
             entityId: 'sub_123',
             object: [
-                'data' => [
-                    'customerId' => 'cus_456',
-                    'subscriptionPlanId' => 'plan_789',
-                    'name' => 'Premium Plan',
-                    'quantity' => 1,
-                ],
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
             ],
         );
 


### PR DESCRIPTION
## Summary

Bundles two related changes that touch the same `WebhookProcessor` entry point:

1. **Structured `Vatly-Signature` header.** Adopt the `t=<unix>,v1=<hex>` value over the raw request body introduced in `vatly/vatly-api-php` [v0.1.0-alpha.6](https://github.com/vatly/vatly-api-php/releases/tag/v0.1.0-alpha.6). The HMAC input is `"{$t}.{$rawBody}"`, with a 300s replay window enforced by the upstream `WebhookSignatureValidator`. `SignatureVerifier` becomes a thin wrapper that rethrows the upstream `InvalidSignatureException` as the package's existing `InvalidWebhookSignatureException`.

2. **Delegate to `Webhook::parse()` + adopt the real wire shape.** Closes [#23](https://github.com/vatly/vatly-fluent-php/issues/23). `WebhookProcessor::handle()` now calls `Webhook::parse()` for verify + decode + structural validation in one step. That pulls in the field-name fix: the previous `WebhookReceived` shape (`resourceId`, `resourceName`, `raisedAt`, `testmode`) didn't match what the API actually emits — the wire fields are `id`, `resource`, `eventName`, `entityType`, `entityId`, `object`, with no `raisedAt`/`testmode` at all. The old `parsePayload()` was silently reading absent fields, producing empty resource ids and a `now()` raisedAt regardless of the real event time.

## Breaking changes

- `WebhookReceived` and `UnsupportedWebhookReceived` fields renamed to match the wire (`id`, `resource`, `entityType`, `entityId`); `raisedAt` and `testmode` dropped.
- `WebhookCallRepositoryInterface::record()` signature changes — adds `id` + `resource`, renames `resourceId`/`resourceName` → `entityId`/`entityType`, drops `raisedAt`/`testmode`. Drivers (Laravel, etc.) must update their implementations and migration columns; the Laravel side is in [vatly/vatly-laravel#19](https://github.com/vatly/vatly-laravel/pull/19).
- `SubscriptionCanceledImmediately::endsAt` now sources from `object.data.endsAt` (with a `now()` fallback) — previously parsed the bogus `raisedAt`, which always meant "now" anyway.
- `WebhookProcessor` constructor no longer takes a `SignatureVerifier` (unused after delegating to `Webhook::parse()`). The standalone `SignatureVerifier` class is kept as a public utility.
- `WebhookEventFactory::parsePayload(array)` is replaced with `fromPayload(WebhookPayload)`.

## Why

The signature change is time-sensitive — the next core API rollout will start rejecting deliveries the moment it ships. The wire-shape rename is the longer-standing bug that the same release surfaces: now that `Webhook::parse()` validates the real required fields, our internal event/repo shapes have to match them or nothing parses. Doing both in one PR keeps the change set coherent: a single `handle()` rewrite, a single round of test fixtures.

## Test plan

- [x] `vendor/bin/phpunit` — 121 tests / 295 assertions pass.
- [x] `vendor/bin/phpstan analyse` — clean.
