### PR TITLE
feat: wire SubscriptionHandle::resume() to the API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "vatly/vatly-api-php": "^0.1.0-alpha.7"
+        "vatly/vatly-api-php": "^0.1.0-alpha.8"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/src/Actions/ResumeSubscription.php
+++ b/src/Actions/ResumeSubscription.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Actions;
+
+use Vatly\API\Resources\Subscription;
+
+class ResumeSubscription extends BaseAction
+{
+    public function execute(string $subscriptionId): Subscription
+    {
+        /** @var Subscription $resource */
+        $resource = $this->vatlyApiClient->subscriptions->resume($subscriptionId);
+
+        return $resource;
+    }
+}

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -11,6 +11,7 @@ use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Builders\CheckoutBuilder;
 use Vatly\Fluent\Builders\SubscriptionBuilder;
@@ -44,6 +45,7 @@ class Billable
         private GetSubscription $getSubscriptionAction,
         private SwapSubscriptionPlan $swapSubscriptionPlanAction,
         private CancelSubscription $cancelSubscriptionAction,
+        private ResumeSubscription $resumeSubscriptionAction,
         private UpdateSubscriptionBilling $updateBillingAction,
     ) {
         //
@@ -163,6 +165,7 @@ class Billable
             subscriptions: $this->subscriptions,
             swapAction: $this->swapSubscriptionPlanAction,
             cancelAction: $this->cancelSubscriptionAction,
+            resumeAction: $this->resumeSubscriptionAction,
             getSubscriptionAction: $this->getSubscriptionAction,
             updateBillingAction: $this->updateBillingAction,
         );

--- a/src/BillableFactory.php
+++ b/src/BillableFactory.php
@@ -10,6 +10,7 @@ use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
@@ -37,6 +38,7 @@ class BillableFactory
         private GetSubscription $getSubscriptionAction,
         private SwapSubscriptionPlan $swapSubscriptionPlanAction,
         private CancelSubscription $cancelSubscriptionAction,
+        private ResumeSubscription $resumeSubscriptionAction,
         private UpdateSubscriptionBilling $updateBillingAction,
     ) {
         //
@@ -56,6 +58,7 @@ class BillableFactory
             getSubscriptionAction: $this->getSubscriptionAction,
             swapSubscriptionPlanAction: $this->swapSubscriptionPlanAction,
             cancelSubscriptionAction: $this->cancelSubscriptionAction,
+            resumeSubscriptionAction: $this->resumeSubscriptionAction,
             updateBillingAction: $this->updateBillingAction,
         );
     }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -18,5 +18,6 @@ class UpdateSubscriptionData
         public ?string $name = null,
         public ?int $quantity = null,
         public ?DateTimeInterface $endsAt = null,
+        public bool $clearEndsAt = false,
     ) {}
 }

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -8,12 +8,12 @@ use DateTimeInterface;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
-use Vatly\Fluent\Exceptions\FeatureUnavailableException;
 
 /**
  * Framework-agnostic operations on a subscription.
@@ -29,6 +29,7 @@ class SubscriptionHandle
         private SubscriptionRepositoryInterface $subscriptions,
         private SwapSubscriptionPlan $swapAction,
         private CancelSubscription $cancelAction,
+        private ResumeSubscription $resumeAction,
         private GetSubscription $getSubscriptionAction,
         private UpdateSubscriptionBilling $updateBillingAction,
     ) {
@@ -155,13 +156,27 @@ class SubscriptionHandle
     }
 
     /**
-     * Resume a cancelled subscription.
+     * Resume a subscription that is currently on its grace period.
      *
-     * @throws FeatureUnavailableException Vatly's API does not currently support resuming.
+     * Reverses a pending cancellation while the subscription is still active.
+     * Clears the local end date so the subscription is treated as active again.
      */
     public function resume(): self
     {
-        throw FeatureUnavailableException::notImplementedOnApi();
+        $response = $this->resumeAction->execute($this->subscription->getVatlyId());
+
+        $updated = $this->subscriptions->update(
+            $this->subscription,
+            new UpdateSubscriptionData(
+                planId: $response->subscriptionPlanId,
+                quantity: $response->quantity,
+                clearEndsAt: true,
+            ),
+        );
+
+        $this->subscription = $updated;
+
+        return $this;
     }
 
     /**

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -11,6 +11,7 @@ use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Webhooks\SignatureVerifier;
@@ -35,6 +36,7 @@ class Vatly
     private ?CreateCheckout $createCheckout = null;
     private ?GetSubscription $getSubscription = null;
     private ?CancelSubscription $cancelSubscription = null;
+    private ?ResumeSubscription $resumeSubscription = null;
     private ?SwapSubscriptionPlan $swapSubscriptionPlan = null;
     private ?UpdateSubscriptionBilling $updateSubscriptionBilling = null;
 
@@ -101,6 +103,11 @@ class Vatly
     public function cancelSubscription(): CancelSubscription
     {
         return $this->cancelSubscription ??= new CancelSubscription($this->apiClient);
+    }
+
+    public function resumeSubscription(): ResumeSubscription
+    {
+        return $this->resumeSubscription ??= new ResumeSubscription($this->apiClient);
     }
 
     public function swapSubscriptionPlan(): SwapSubscriptionPlan

--- a/tests/BillableFactoryTest.php
+++ b/tests/BillableFactoryTest.php
@@ -11,6 +11,7 @@ use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Billable;
 use Vatly\Fluent\BillableFactory;
@@ -37,6 +38,7 @@ class BillableFactoryTest extends TestCase
             getSubscriptionAction: Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
+            resumeSubscriptionAction: Mockery::mock(ResumeSubscription::class),
             updateBillingAction: Mockery::mock(UpdateSubscriptionBilling::class),
         );
 
@@ -59,6 +61,7 @@ class BillableFactoryTest extends TestCase
             getSubscriptionAction: Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
+            resumeSubscriptionAction: Mockery::mock(ResumeSubscription::class),
             updateBillingAction: Mockery::mock(UpdateSubscriptionBilling::class),
         );
 

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -13,6 +13,7 @@ use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Billable;
 use Vatly\Fluent\Builders\CheckoutBuilder;
@@ -238,6 +239,7 @@ class BillableTest extends TestCase
         ?GetSubscription $getSubscriptionAction = null,
         ?SwapSubscriptionPlan $swapSubscriptionPlanAction = null,
         ?CancelSubscription $cancelSubscriptionAction = null,
+        ?ResumeSubscription $resumeSubscriptionAction = null,
         ?UpdateSubscriptionBilling $updateBillingAction = null,
     ): Billable {
         return new Billable(
@@ -252,6 +254,7 @@ class BillableTest extends TestCase
             getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: $swapSubscriptionPlanAction ?? Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: $cancelSubscriptionAction ?? Mockery::mock(CancelSubscription::class),
+            resumeSubscriptionAction: $resumeSubscriptionAction ?? Mockery::mock(ResumeSubscription::class),
             updateBillingAction: $updateBillingAction
                 ?? Mockery::mock(UpdateSubscriptionBilling::class),
         );

--- a/tests/SubscriptionHandleTest.php
+++ b/tests/SubscriptionHandleTest.php
@@ -12,11 +12,11 @@ use Vatly\API\Types\Link;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
-use Vatly\Fluent\Exceptions\FeatureUnavailableException;
 use Vatly\Fluent\SubscriptionHandle;
 
 class SubscriptionHandleTest extends TestCase
@@ -192,13 +192,44 @@ class SubscriptionHandleTest extends TestCase
         $this->assertSame($updated, $handle->model());
     }
 
-    public function test_resume_throws_feature_unavailable(): void
+    public function test_resume_calls_the_action_and_clears_ends_at(): void
     {
-        $handle = $this->buildHandle();
+        $subscription = $this->stubSubscription('subscription_abc');
 
-        $this->expectException(FeatureUnavailableException::class);
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_basic',
+            'quantity' => 1,
+        ]);
 
-        $handle->resume();
+        $resumeAction = Mockery::mock(ResumeSubscription::class);
+        $resumeAction->shouldReceive('execute')
+            ->once()
+            ->with('subscription_abc')
+            ->andReturn($apiResponse);
+
+        $updatedSubscription = Mockery::mock(SubscriptionInterface::class);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->planId === 'plan_basic'
+                    && $data->quantity === 1
+                    && $data->endsAt === null
+                    && $data->clearEndsAt === true;
+            }))
+            ->andReturn($updatedSubscription);
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            resumeAction: $resumeAction,
+        );
+
+        $returned = $handle->resume();
+
+        $this->assertSame($handle, $returned);
+        $this->assertSame($updatedSubscription, $handle->model());
     }
 
     private function stubSubscription(string $vatlyId): SubscriptionInterface
@@ -229,6 +260,7 @@ class SubscriptionHandleTest extends TestCase
         ?SubscriptionRepositoryInterface $subscriptions = null,
         ?SwapSubscriptionPlan $swapAction = null,
         ?CancelSubscription $cancelAction = null,
+        ?ResumeSubscription $resumeAction = null,
         ?GetSubscription $getSubscriptionAction = null,
         ?UpdateSubscriptionBilling $updateBillingAction = null,
     ): SubscriptionHandle {
@@ -237,6 +269,7 @@ class SubscriptionHandleTest extends TestCase
             subscriptions: $subscriptions ?? Mockery::mock(SubscriptionRepositoryInterface::class),
             swapAction: $swapAction ?? Mockery::mock(SwapSubscriptionPlan::class),
             cancelAction: $cancelAction ?? Mockery::mock(CancelSubscription::class),
+            resumeAction: $resumeAction ?? Mockery::mock(ResumeSubscription::class),
             getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
             updateBillingAction: $updateBillingAction
                 ?? Mockery::mock(UpdateSubscriptionBilling::class),


### PR DESCRIPTION
## Summary
- Replaces the `FeatureUnavailableException` stub on `SubscriptionHandle::resume()` now that vatly-api-php exposes `POST /v1/subscriptions/{id}/resume`.
- After resume, the local subscription has `endsAt` cleared so `isActive()` / `isOnGracePeriod()` reflect the new state immediately (no webhook round-trip required).
- Bumps `vatly/vatly-api-php` to `^0.1.0-alpha.8` (the release containing the new endpoint).

## Files
- `src/Actions/ResumeSubscription.php` (new) — calls `$client->subscriptions->resume($id)`, returns the resumed `Subscription`.
- `src/SubscriptionHandle.php` — `resume()` calls the action, then persists `planId`/`quantity` and clears `endsAt`. Returns `self` for chaining (matches `swap()`).
- `src/Data/UpdateSubscriptionData.php` — adds `bool $clearEndsAt = false`. Necessary because `endsAt: null` already means "leave alone" for other callers (swap, sync, webhook reactions).
- `src/Billable.php`, `src/BillableFactory.php`, `src/Vatly.php` — DI wiring for the new action.
- `composer.json` — `vatly/vatly-api-php: ^0.1.0-alpha.8`.
- Tests: `test_resume_calls_the_action_and_clears_ends_at` replaces the old `expectException` test.

## Test plan
- [x] `vendor/bin/phpunit` — 120/120 pass
- [x] `vendor/bin/phpstan` — clean

## Upstream
- https://github.com/vatly/vatly-api-php/releases/tag/v0.1.0-alpha.8 (merged + published)
