### PR TITLE
feat: expose API client config + signature header via Vatly facade

### DIFF
--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -42,9 +42,20 @@ class Vatly
 
     public function __construct(
         string $apiKey,
+        ?string $apiEndpoint = null,
+        ?string $apiVersion = null,
     ) {
         $this->apiClient = new VatlyApiClient();
         $this->apiClient->setApiKey($apiKey);
+
+        if ($apiEndpoint !== null) {
+            $this->apiClient->setApiEndpoint($apiEndpoint);
+        }
+
+        if ($apiVersion !== null) {
+            $this->apiClient->setApiVersion($apiVersion);
+        }
+
         $this->signatureVerifier = new SignatureVerifier();
         $this->webhookEventFactory = new WebhookEventFactory($this->getOrder());
     }

--- a/src/Webhooks/SignatureVerifier.php
+++ b/src/Webhooks/SignatureVerifier.php
@@ -21,6 +21,15 @@ use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
 class SignatureVerifier
 {
     /**
+     * HTTP header name carrying the structured Vatly webhook signature.
+     *
+     * Re-exported from the upstream {@see WebhookSignatureValidator} so that
+     * framework drivers (Laravel, etc.) can read it without taking a direct
+     * dependency on `vatly/vatly-api-php`.
+     */
+    public const SIGNATURE_HEADER_NAME = WebhookSignatureValidator::SIGNATURE_HEADER_NAME;
+
+    /**
      * Verify the webhook signature.
      *
      * @param  string  $signatureHeader  Full value of the `Vatly-Signature` header.

--- a/tests/VatlyTest.php
+++ b/tests/VatlyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests;
+
+use Vatly\Fluent\Vatly;
+
+class VatlyTest extends TestCase
+{
+    public function test_constructor_applies_api_endpoint_when_provided(): void
+    {
+        $vatly = new Vatly(
+            apiKey: 'test_abcdefghijklmnopqrstuvwxyz',
+            apiEndpoint: 'https://api.example.test',
+        );
+
+        $this->assertSame('https://api.example.test', $vatly->getApiClient()->getApiEndpoint());
+    }
+
+    public function test_constructor_applies_api_version_when_provided(): void
+    {
+        $vatly = new Vatly(
+            apiKey: 'test_abcdefghijklmnopqrstuvwxyz',
+            apiVersion: 'v2',
+        );
+
+        $this->assertSame('v2', $vatly->getApiClient()->getApiVersion());
+    }
+
+    public function test_constructor_leaves_endpoint_and_version_at_defaults_when_omitted(): void
+    {
+        $vatlyOnlyKey = new Vatly('test_abcdefghijklmnopqrstuvwxyz');
+        $vatlyAllArgs = new Vatly(
+            apiKey: 'test_abcdefghijklmnopqrstuvwxyz',
+            apiEndpoint: null,
+            apiVersion: null,
+        );
+
+        $this->assertSame(
+            $vatlyOnlyKey->getApiClient()->getApiEndpoint(),
+            $vatlyAllArgs->getApiClient()->getApiEndpoint(),
+        );
+        $this->assertSame(
+            $vatlyOnlyKey->getApiClient()->getApiVersion(),
+            $vatlyAllArgs->getApiClient()->getApiVersion(),
+        );
+    }
+}

--- a/tests/Webhooks/SignatureVerifierTest.php
+++ b/tests/Webhooks/SignatureVerifierTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Tests\Webhooks;
 
+use Vatly\API\Webhooks\WebhookSignatureValidator;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
 use Vatly\Fluent\Webhooks\SignatureVerifier;
 use Vatly\Fluent\Tests\TestCase;
@@ -95,6 +96,17 @@ class SignatureVerifierTest extends TestCase
     public function test_is_valid_returns_false_for_empty_signature(): void
     {
         $this->assertFalse($this->verifier->isValid('', $this->payload, $this->secret));
+    }
+
+    public function test_signature_header_name_mirrors_upstream_constant(): void
+    {
+        // The constant is re-exported so framework drivers can read the header
+        // without depending on vatly/vatly-api-php directly.
+        $this->assertSame(
+            WebhookSignatureValidator::SIGNATURE_HEADER_NAME,
+            SignatureVerifier::SIGNATURE_HEADER_NAME,
+        );
+        $this->assertSame('Vatly-Signature', SignatureVerifier::SIGNATURE_HEADER_NAME);
     }
 
     public function test_it_tolerates_unknown_future_scheme_keys(): void


### PR DESCRIPTION
## Summary
Two small additions so framework drivers can use fluent without taking a direct dependency on `vatly/vatly-api-php`.

- `Vatly::__construct` accepts optional `?string $apiEndpoint = null` and `?string $apiVersion = null`. They're applied via `setApiEndpoint`/`setApiVersion` on the underlying client when non-null; existing single-arg callers are unaffected.
- `SignatureVerifier::SIGNATURE_HEADER_NAME` re-exports the upstream `WebhookSignatureValidator::SIGNATURE_HEADER_NAME` so webhook controllers can read the header name through fluent.

## Motivation
`vatly-laravel` currently `use`s `Vatly\API\VatlyApiClient` and `Vatly\API\Webhooks\WebhookSignatureValidator` directly — only because fluent didn't expose equivalents. After this PR, Laravel can drop its direct dep on `vatly/vatly-api-php` and route everything through fluent.

## Files
- `src/Vatly.php` — extended constructor.
- `src/Webhooks/SignatureVerifier.php` — new `SIGNATURE_HEADER_NAME` constant.
- `tests/VatlyTest.php` (new) — verifies endpoint/version are applied and that omitted args leave defaults intact.
- `tests/Webhooks/SignatureVerifierTest.php` — assertion that the re-exported constant matches upstream.

## Test plan
- [x] `vendor/bin/phpunit` — 124/124 pass (4 new)
- [x] `vendor/bin/phpstan` — clean
