### PR TITLE
feat: promote Vatly to composition root with Wiring DTO

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+        php: ['8.2', '8.3', '8.4']
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "vatly/vatly-api-php": "^0.1.0-alpha.8"
     },
     "require-dev": {

--- a/src/Concerns/DerivesTestmodeFromApiKey.php
+++ b/src/Concerns/DerivesTestmodeFromApiKey.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Concerns;
+
+/**
+ * Default implementation of {@see \Vatly\Fluent\Contracts\ConfigurationInterface::isTestmode()}.
+ *
+ * Testmode is inferred from the API key prefix: keys starting with `test_`
+ * indicate testmode. A configuration impl that wants different semantics
+ * (e.g. an explicit `VATLY_TESTMODE` env) can simply implement `isTestmode()`
+ * itself instead of using this trait.
+ *
+ * Requires the using class to expose `getApiKey(): string`, which the
+ * interface already mandates.
+ */
+trait DerivesTestmodeFromApiKey
+{
+    public function isTestmode(): bool
+    {
+        return str_starts_with($this->getApiKey(), 'test_');
+    }
+}

--- a/src/Configuration/ArrayConfiguration.php
+++ b/src/Configuration/ArrayConfiguration.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Configuration;
+
+use Vatly\Fluent\Concerns\DerivesTestmodeFromApiKey;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+
+/**
+ * In-memory {@see ConfigurationInterface} for tests and non-framework
+ * adopters that don't need a config-file backed implementation.
+ *
+ * Required: `api_key`. All other values fall back to sensible defaults.
+ */
+final class ArrayConfiguration implements ConfigurationInterface
+{
+    use DerivesTestmodeFromApiKey;
+
+    /**
+     * @param array{
+     *     api_key: string,
+     *     api_url?: string,
+     *     api_version?: string,
+     *     webhook_secret?: ?string,
+     *     redirect_url_success?: string,
+     *     redirect_url_canceled?: string,
+     * } $config
+     */
+    public function __construct(
+        private readonly array $config,
+    ) {
+        //
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->config['api_key'];
+    }
+
+    public function getApiUrl(): string
+    {
+        return $this->config['api_url'] ?? 'https://api.vatly.com';
+    }
+
+    public function getApiVersion(): string
+    {
+        return $this->config['api_version'] ?? 'v1';
+    }
+
+    public function getWebhookSecret(): ?string
+    {
+        return $this->config['webhook_secret'] ?? null;
+    }
+
+    public function getDefaultRedirectUrlSuccess(): string
+    {
+        return $this->config['redirect_url_success'] ?? '';
+    }
+
+    public function getDefaultRedirectUrlCanceled(): string
+    {
+        return $this->config['redirect_url_canceled'] ?? '';
+    }
+}

--- a/src/Contracts/ConfigurationInterface.php
+++ b/src/Contracts/ConfigurationInterface.php
@@ -43,9 +43,4 @@ interface ConfigurationInterface
      * Get the default cancel redirect URL.
      */
     public function getDefaultRedirectUrlCanceled(): string;
-
-    /**
-     * Get the billable model class name.
-     */
-    public function getBillableModel(): string;
 }

--- a/src/Events/NullEventDispatcher.php
+++ b/src/Events/NullEventDispatcher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+
+/**
+ * No-op {@see EventDispatcherInterface}.
+ *
+ * Useful in tests and for api-only consumers that don't need to react to
+ * webhook events.
+ */
+final class NullEventDispatcher implements EventDispatcherInterface
+{
+    public function dispatch(object $event): void
+    {
+        //
+    }
+}

--- a/src/Exceptions/IncompleteWiring.php
+++ b/src/Exceptions/IncompleteWiring.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Exceptions;
+
+/**
+ * Thrown when {@see \Vatly\Fluent\Vatly} is asked for a service whose
+ * required dependency was not provided to the {@see \Vatly\Fluent\Wiring} DTO.
+ *
+ * Examples:
+ * - calling `Vatly::billableFactory()` without a repository in the wiring.
+ * - calling `Vatly::webhookProcessor()` without an event dispatcher.
+ *
+ * The exception names the missing dependency and the feature being requested
+ * so the fix is mechanical: add the dependency to your Wiring construction.
+ */
+class IncompleteWiring extends VatlyException
+{
+    public static function missing(string $dependency, string $forFeature): self
+    {
+        return new self(sprintf(
+            "Vatly cannot resolve '%s' because the '%s' dependency was not provided in Wiring. "
+            ."Pass it to `new Wiring(...)` when constructing `Vatly`.",
+            $forFeature,
+            $dependency,
+        ));
+    }
+}

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent;
 
+use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\CancelSubscription;
-use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCustomer;
@@ -13,21 +13,29 @@ use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
-use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
+use Vatly\Fluent\Configuration\ArrayConfiguration;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Exceptions\IncompleteWiring;
 use Vatly\Fluent\Webhooks\SignatureVerifier;
 use Vatly\Fluent\Webhooks\WebhookEventFactory;
+use Vatly\Fluent\Webhooks\WebhookProcessor;
+use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
 
 /**
- * Main entry point for the Vatly SDK.
+ * Composition root for the Vatly SDK.
  *
- * This class provides access to all Vatly operations and can be used
- * in any PHP application without framework dependencies.
+ * Drivers (Laravel, etc.) construct a single instance — typically a singleton
+ * — from a {@see Wiring} DTO that supplies the configuration and the driver's
+ * concrete contract implementations (repositories, event dispatcher). Every
+ * other fluent service (`BillableFactory`, `SubscriptionHandle`, `OrderHandle`,
+ * `WebhookProcessor`, etc.) resolves lazily through methods on this class.
+ *
+ * For non-driver scripts that only need to hit the API, see {@see self::apiOnly()}.
  */
 class Vatly
 {
     private VatlyApiClient $apiClient;
-    private SignatureVerifier $signatureVerifier;
-    private WebhookEventFactory $webhookEventFactory;
 
     // Lazy-loaded actions
     private ?CreateCustomer $createCustomer = null;
@@ -40,51 +48,104 @@ class Vatly
     private ?SwapSubscriptionPlan $swapSubscriptionPlan = null;
     private ?UpdateSubscriptionBilling $updateSubscriptionBilling = null;
 
+    // Lazy-loaded composed services
+    private ?BillableFactory $billableFactory = null;
+    private ?WebhookProcessor $webhookProcessor = null;
+    private ?WebhookEventFactory $webhookEventFactory = null;
+    private ?SignatureVerifier $signatureVerifier = null;
+
     public function __construct(
-        string $apiKey,
-        ?string $apiEndpoint = null,
-        ?string $apiVersion = null,
+        private readonly Wiring $wiring,
     ) {
+        $config = $wiring->config;
+
         $this->apiClient = new VatlyApiClient();
-        $this->apiClient->setApiKey($apiKey);
-
-        if ($apiEndpoint !== null) {
-            $this->apiClient->setApiEndpoint($apiEndpoint);
-        }
-
-        if ($apiVersion !== null) {
-            $this->apiClient->setApiVersion($apiVersion);
-        }
-
-        $this->signatureVerifier = new SignatureVerifier();
-        $this->webhookEventFactory = new WebhookEventFactory($this->getOrder());
+        $this->apiClient->setApiKey($config->getApiKey());
+        $this->apiClient->setApiEndpoint($config->getApiUrl());
+        $this->apiClient->setApiVersion($config->getApiVersion());
     }
 
     /**
-     * Get the API client for direct API access.
+     * Quick-start constructor for non-driver consumers that only need to
+     * hit the API. Equivalent to `new Vatly(new Wiring(new ArrayConfiguration(...)))`.
+     *
+     * Calling repository-dependent methods on the returned instance throws
+     * {@see IncompleteWiring}.
      */
+    public static function apiOnly(string $apiKey): self
+    {
+        return new self(new Wiring(
+            config: new ArrayConfiguration(['api_key' => $apiKey]),
+        ));
+    }
+
+    public function getWiring(): Wiring
+    {
+        return $this->wiring;
+    }
+
     public function getApiClient(): VatlyApiClient
     {
         return $this->apiClient;
     }
 
-    /**
-     * Get the signature verifier for webhook validation.
-     */
+    // --- Webhook helpers ---
+
     public function getSignatureVerifier(): SignatureVerifier
     {
-        return $this->signatureVerifier;
+        return $this->signatureVerifier ??= new SignatureVerifier();
     }
 
-    /**
-     * Get the webhook event factory.
-     */
     public function getWebhookEventFactory(): WebhookEventFactory
     {
-        return $this->webhookEventFactory;
+        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder());
     }
 
-    // Action accessors
+    public function webhookProcessor(): WebhookProcessor
+    {
+        return $this->webhookProcessor ??= WebhookProcessorFactory::create(
+            config: $this->wiring->config,
+            subscriptions: $this->wiring->subscriptions
+                ?? throw IncompleteWiring::missing('subscriptions', 'WebhookProcessor'),
+            orders: $this->wiring->orders
+                ?? throw IncompleteWiring::missing('orders', 'WebhookProcessor'),
+            webhookCalls: $this->wiring->webhookCalls
+                ?? throw IncompleteWiring::missing('webhookCalls', 'WebhookProcessor'),
+            dispatcher: $this->wiring->events
+                ?? throw IncompleteWiring::missing('events', 'WebhookProcessor'),
+            getOrder: $this->getOrder(),
+        );
+    }
+
+    // --- Billable composition ---
+
+    public function billableFactory(): BillableFactory
+    {
+        return $this->billableFactory ??= new BillableFactory(
+            subscriptions: $this->wiring->subscriptions
+                ?? throw IncompleteWiring::missing('subscriptions', 'BillableFactory'),
+            customers: $this->wiring->customers
+                ?? throw IncompleteWiring::missing('customers', 'BillableFactory'),
+            orders: $this->wiring->orders
+                ?? throw IncompleteWiring::missing('orders', 'BillableFactory'),
+            config: $this->wiring->config,
+            createCheckoutAction: $this->createCheckout(),
+            createCustomerAction: $this->createCustomer(),
+            getCustomerAction: $this->getCustomer(),
+            getSubscriptionAction: $this->getSubscription(),
+            swapSubscriptionPlanAction: $this->swapSubscriptionPlan(),
+            cancelSubscriptionAction: $this->cancelSubscription(),
+            resumeSubscriptionAction: $this->resumeSubscription(),
+            updateBillingAction: $this->updateSubscriptionBilling(),
+        );
+    }
+
+    public function billable(BillableInterface $owner): Billable
+    {
+        return $this->billableFactory()->forOwner($owner);
+    }
+
+    // --- Action accessors ---
 
     public function createCustomer(): CreateCustomer
     {

--- a/src/Wiring.php
+++ b/src/Wiring.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent;
+
+use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+
+/**
+ * Composition-time dependencies passed to {@see Vatly}.
+ *
+ * Only `config` is required. Optional impls (repos, dispatcher) can be
+ * omitted for api-only mode; calling a method on `Vatly` that needs an
+ * absent dependency raises {@see \Vatly\Fluent\Exceptions\IncompleteWiring}.
+ *
+ * Drivers (Laravel, etc.) construct one of these from their container and
+ * pass it to `new Vatly($wiring)` — typically bound as a singleton.
+ */
+final readonly class Wiring
+{
+    public function __construct(
+        public ConfigurationInterface $config,
+        public ?SubscriptionRepositoryInterface $subscriptions = null,
+        public ?CustomerRepositoryInterface $customers = null,
+        public ?OrderRepositoryInterface $orders = null,
+        public ?WebhookCallRepositoryInterface $webhookCalls = null,
+        public ?EventDispatcherInterface $events = null,
+    ) {
+        //
+    }
+}

--- a/tests/Builders/SubscriptionBuilderTest.php
+++ b/tests/Builders/SubscriptionBuilderTest.php
@@ -147,11 +147,6 @@ class SubscriptionBuilderTest extends TestCase
             {
                 return 'v1';
             }
-
-            public function getBillableModel(): string
-            {
-                return 'App\\Models\\User';
-            }
         };
     }
 

--- a/tests/Configuration/ArrayConfigurationTest.php
+++ b/tests/Configuration/ArrayConfigurationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Configuration;
+
+use Vatly\Fluent\Configuration\ArrayConfiguration;
+use Vatly\Fluent\Tests\TestCase;
+
+class ArrayConfigurationTest extends TestCase
+{
+    public function test_returns_provided_values(): void
+    {
+        $config = new ArrayConfiguration([
+            'api_key' => 'test_abc',
+            'api_url' => 'https://api.example.test',
+            'api_version' => 'v2',
+            'webhook_secret' => 'whsec_xyz',
+            'redirect_url_success' => 'https://app.test/success',
+            'redirect_url_canceled' => 'https://app.test/canceled',
+        ]);
+
+        $this->assertSame('test_abc', $config->getApiKey());
+        $this->assertSame('https://api.example.test', $config->getApiUrl());
+        $this->assertSame('v2', $config->getApiVersion());
+        $this->assertSame('whsec_xyz', $config->getWebhookSecret());
+        $this->assertSame('https://app.test/success', $config->getDefaultRedirectUrlSuccess());
+        $this->assertSame('https://app.test/canceled', $config->getDefaultRedirectUrlCanceled());
+    }
+
+    public function test_applies_sensible_defaults_when_omitted(): void
+    {
+        $config = new ArrayConfiguration(['api_key' => 'test_abc']);
+
+        $this->assertSame('https://api.vatly.com', $config->getApiUrl());
+        $this->assertSame('v1', $config->getApiVersion());
+        $this->assertNull($config->getWebhookSecret());
+        $this->assertSame('', $config->getDefaultRedirectUrlSuccess());
+        $this->assertSame('', $config->getDefaultRedirectUrlCanceled());
+    }
+
+    public function test_testmode_is_true_for_test_prefix_keys(): void
+    {
+        $config = new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']);
+
+        $this->assertTrue($config->isTestmode());
+    }
+
+    public function test_testmode_is_false_for_live_keys(): void
+    {
+        $config = new ArrayConfiguration(['api_key' => 'live_abcdefghijklmnopqrstuvwxyz']);
+
+        $this->assertFalse($config->isTestmode());
+    }
+}

--- a/tests/Events/NullEventDispatcherTest.php
+++ b/tests/Events/NullEventDispatcherTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use stdClass;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Events\NullEventDispatcher;
+use Vatly\Fluent\Tests\TestCase;
+
+class NullEventDispatcherTest extends TestCase
+{
+    public function test_dispatch_swallows_events_without_side_effects(): void
+    {
+        $dispatcher = new NullEventDispatcher();
+
+        $dispatcher->dispatch(new stdClass());
+
+        // Reaching here means no exception was thrown — that's the contract.
+        $this->assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
+    }
+}

--- a/tests/VatlyTest.php
+++ b/tests/VatlyTest.php
@@ -4,46 +4,172 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Tests;
 
+use Mockery;
+use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Billable;
+use Vatly\Fluent\BillableFactory;
+use Vatly\Fluent\Configuration\ArrayConfiguration;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Exceptions\IncompleteWiring;
 use Vatly\Fluent\Vatly;
+use Vatly\Fluent\Webhooks\WebhookProcessor;
+use Vatly\Fluent\Wiring;
 
 class VatlyTest extends TestCase
 {
-    public function test_constructor_applies_api_endpoint_when_provided(): void
+    // --- API client construction ---
+
+    public function test_api_client_uses_configuration_values(): void
     {
-        $vatly = new Vatly(
-            apiKey: 'test_abcdefghijklmnopqrstuvwxyz',
-            apiEndpoint: 'https://api.example.test',
-        );
+        $vatly = new Vatly(new Wiring(
+            config: new ArrayConfiguration([
+                'api_key' => 'test_abcdefghijklmnopqrstuvwxyz',
+                'api_url' => 'https://api.example.test',
+                'api_version' => 'v2',
+            ]),
+        ));
 
         $this->assertSame('https://api.example.test', $vatly->getApiClient()->getApiEndpoint());
-    }
-
-    public function test_constructor_applies_api_version_when_provided(): void
-    {
-        $vatly = new Vatly(
-            apiKey: 'test_abcdefghijklmnopqrstuvwxyz',
-            apiVersion: 'v2',
-        );
-
         $this->assertSame('v2', $vatly->getApiClient()->getApiVersion());
     }
 
-    public function test_constructor_leaves_endpoint_and_version_at_defaults_when_omitted(): void
+    public function test_api_only_factory_constructs_without_repositories(): void
     {
-        $vatlyOnlyKey = new Vatly('test_abcdefghijklmnopqrstuvwxyz');
-        $vatlyAllArgs = new Vatly(
-            apiKey: 'test_abcdefghijklmnopqrstuvwxyz',
-            apiEndpoint: null,
-            apiVersion: null,
-        );
+        $vatly = Vatly::apiOnly('test_abcdefghijklmnopqrstuvwxyz');
 
-        $this->assertSame(
-            $vatlyOnlyKey->getApiClient()->getApiEndpoint(),
-            $vatlyAllArgs->getApiClient()->getApiEndpoint(),
-        );
-        $this->assertSame(
-            $vatlyOnlyKey->getApiClient()->getApiVersion(),
-            $vatlyAllArgs->getApiClient()->getApiVersion(),
-        );
+        // Action accessors resolve fine — they only need the API client.
+        $this->assertInstanceOf(CreateCustomer::class, $vatly->createCustomer());
+    }
+
+    // --- Lazy caching ---
+
+    public function test_action_accessors_return_the_same_instance(): void
+    {
+        $vatly = Vatly::apiOnly('test_abcdefghijklmnopqrstuvwxyz');
+
+        $this->assertSame($vatly->createCustomer(), $vatly->createCustomer());
+        $this->assertSame($vatly->getOrder(), $vatly->getOrder());
+    }
+
+    public function test_billable_factory_is_cached(): void
+    {
+        $vatly = $this->fullyWiredVatly();
+
+        $this->assertSame($vatly->billableFactory(), $vatly->billableFactory());
+    }
+
+    // --- IncompleteWiring on missing dependencies ---
+
+    public function test_billable_factory_throws_when_subscriptions_missing(): void
+    {
+        $vatly = Vatly::apiOnly('test_abcdefghijklmnopqrstuvwxyz');
+
+        $this->expectException(IncompleteWiring::class);
+        $this->expectExceptionMessageMatches("/'BillableFactory'.*'subscriptions'/");
+
+        $vatly->billableFactory();
+    }
+
+    public function test_billable_factory_throws_when_customers_missing(): void
+    {
+        $vatly = new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+        ));
+
+        $this->expectException(IncompleteWiring::class);
+        $this->expectExceptionMessageMatches("/'customers'/");
+
+        $vatly->billableFactory();
+    }
+
+    public function test_billable_factory_throws_when_orders_missing(): void
+    {
+        $vatly = new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            customers: Mockery::mock(CustomerRepositoryInterface::class),
+        ));
+
+        $this->expectException(IncompleteWiring::class);
+        $this->expectExceptionMessageMatches("/'orders'/");
+
+        $vatly->billableFactory();
+    }
+
+    public function test_webhook_processor_throws_when_events_dispatcher_missing(): void
+    {
+        $vatly = new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+        ));
+
+        $this->expectException(IncompleteWiring::class);
+        $this->expectExceptionMessageMatches("/'WebhookProcessor'.*'events'/");
+
+        $vatly->webhookProcessor();
+    }
+
+    public function test_webhook_processor_throws_when_webhook_calls_missing(): void
+    {
+        $vatly = new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            events: Mockery::mock(EventDispatcherInterface::class),
+        ));
+
+        $this->expectException(IncompleteWiring::class);
+        $this->expectExceptionMessageMatches("/'webhookCalls'/");
+
+        $vatly->webhookProcessor();
+    }
+
+    // --- Happy-path resolution ---
+
+    public function test_billable_returns_orchestrator_for_owner(): void
+    {
+        $vatly = $this->fullyWiredVatly();
+
+        $owner = Mockery::mock(BillableInterface::class);
+
+        $billable = $vatly->billable($owner);
+
+        $this->assertInstanceOf(Billable::class, $billable);
+        $this->assertSame($owner, $billable->owner());
+    }
+
+    public function test_billable_factory_is_built_from_wiring(): void
+    {
+        $vatly = $this->fullyWiredVatly();
+
+        $this->assertInstanceOf(BillableFactory::class, $vatly->billableFactory());
+    }
+
+    public function test_webhook_processor_is_built_from_wiring(): void
+    {
+        $vatly = $this->fullyWiredVatly();
+
+        $this->assertInstanceOf(WebhookProcessor::class, $vatly->webhookProcessor());
+    }
+
+    private function fullyWiredVatly(): Vatly
+    {
+        return new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            customers: Mockery::mock(CustomerRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            events: Mockery::mock(EventDispatcherInterface::class),
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Vatly becomes the single composition root — drivers construct it from a `Wiring` DTO and resolve every fluent service (`BillableFactory`, `WebhookProcessor`, actions) through its lazy accessors.
- Drops Laravel-specific `getBillableModel()` from `ConfigurationInterface` — that concept lives on the driver's concrete config now.
- Optional repos in `Wiring` enable api-only mode; calling a method that needs an absent repo throws `IncompleteWiring` with a "pass `X` to `Wiring`" message.

## Why
Today `vatly-laravel`'s ServiceProvider hand-wires every fluent service (~110 lines of bindings). Internal wiring changes in fluent require touching every driver. Promoting `Vatly` to composition root lets drivers register one singleton and reach everything through it. Future drivers (Symfony, etc.) plug in the same way.

## New surface
- `Vatly\Fluent\Wiring` — readonly DTO, config required, repos + dispatcher optional
- `Vatly\Fluent\Configuration\ArrayConfiguration` — in-memory `ConfigurationInterface` impl
- `Vatly\Fluent\Concerns\DerivesTestmodeFromApiKey` — opt-in default-impl trait for `isTestmode()` (`test_*` prefix → testmode)
- `Vatly\Fluent\Events\NullEventDispatcher` — no-op dispatcher for tests / api-only
- `Vatly\Fluent\Exceptions\IncompleteWiring`
- `Vatly::apiOnly(string \$apiKey)` — one-liner for non-driver scripts

## Breaking changes (pre-1.0, no live installs)
| Before | After |
|---|---|
| `new Vatly(string \$apiKey, ?string \$endpoint, ?string \$version)` | `new Vatly(Wiring \$wiring)` — endpoint/version sourced from `\$wiring->config` |
| `ConfigurationInterface::getBillableModel(): string` | removed — Laravel-specific concept |

`vatly-laravel` will bump in a follow-up PR to match.

## Test plan
- [x] `composer test` — 138/138 pass (+14 new)
- [x] `composer analyse` — clean
