### PR TITLE
feat: add OrderHandle + derived subscription predicates

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,8 @@ parameters:
         # Intentionally untyped for Laravel Model compatibility
         - '#Method Vatly\\Fluent\\Contracts\\BillableInterface::getKey\(\) has no return type specified#'
         - '#Method Vatly\\Fluent\\Contracts\\BillableInterface::save\(\) has no return type specified#'
+        # Trait is consumed by driver impls (e.g. vatly-laravel's Eloquent Subscription)
+        # and by tests; no in-src consumer is required.
+        -
+            identifier: trait.unused
+            path: src/Concerns/DerivesSubscriptionState.php

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -10,6 +10,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -42,6 +43,7 @@ class Billable
         private CreateCheckout $createCheckoutAction,
         private CreateCustomer $createCustomerAction,
         private GetCustomer $getCustomerAction,
+        private GetOrder $getOrderAction,
         private GetSubscription $getSubscriptionAction,
         private SwapSubscriptionPlan $swapSubscriptionPlanAction,
         private CancelSubscription $cancelSubscriptionAction,
@@ -179,5 +181,19 @@ class Billable
     public function orders(): array
     {
         return $this->orders->findAllByOwner($this->owner);
+    }
+
+    /**
+     * Build an {@see OrderHandle} for one of this owner's orders.
+     *
+     * Throws {@see \Vatly\Fluent\Exceptions\InvalidOrderException} when no
+     * order with the given Vatly id exists for this owner.
+     */
+    public function order(string $vatlyId): OrderHandle
+    {
+        return new OrderHandle(
+            order: $this->orders->findForOwnerOrFail($this->owner, $vatlyId),
+            getOrderAction: $this->getOrderAction,
+        );
     }
 }

--- a/src/BillableFactory.php
+++ b/src/BillableFactory.php
@@ -9,6 +9,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -35,6 +36,7 @@ class BillableFactory
         private CreateCheckout $createCheckoutAction,
         private CreateCustomer $createCustomerAction,
         private GetCustomer $getCustomerAction,
+        private GetOrder $getOrderAction,
         private GetSubscription $getSubscriptionAction,
         private SwapSubscriptionPlan $swapSubscriptionPlanAction,
         private CancelSubscription $cancelSubscriptionAction,
@@ -55,6 +57,7 @@ class BillableFactory
             createCheckoutAction: $this->createCheckoutAction,
             createCustomerAction: $this->createCustomerAction,
             getCustomerAction: $this->getCustomerAction,
+            getOrderAction: $this->getOrderAction,
             getSubscriptionAction: $this->getSubscriptionAction,
             swapSubscriptionPlanAction: $this->swapSubscriptionPlanAction,
             cancelSubscriptionAction: $this->cancelSubscriptionAction,

--- a/src/Concerns/DerivesSubscriptionState.php
+++ b/src/Concerns/DerivesSubscriptionState.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Concerns;
+
+use DateTimeImmutable;
+
+/**
+ * Default implementations of the derived state predicates declared on
+ * {@see \Vatly\Fluent\Contracts\SubscriptionInterface}.
+ *
+ * Drivers MAY use this trait to satisfy the predicate methods. A driver
+ * that needs different semantics — e.g. a SQL-side `WHERE ends_at IS NULL
+ * OR ends_at > NOW()` for cheap active-checks at the query level — can
+ * simply implement any subset of the predicates itself; PHP trait conflict
+ * resolution favors the class's own definition.
+ *
+ * Requires the using class to implement `getEndsAt(): ?DateTimeInterface`
+ * from `SubscriptionInterface`. All other predicates compose from there.
+ */
+trait DerivesSubscriptionState
+{
+    public function isCancelled(): bool
+    {
+        return $this->getEndsAt() !== null;
+    }
+
+    public function isOnGracePeriod(): bool
+    {
+        $endsAt = $this->getEndsAt();
+
+        return $endsAt !== null && $endsAt > new DateTimeImmutable();
+    }
+
+    public function isActive(): bool
+    {
+        return ! $this->isCancelled() || $this->isOnGracePeriod();
+    }
+
+    public function isValid(): bool
+    {
+        // Equivalent to isActive() today. When trials land, this becomes
+        // isActive() || isOnTrial().
+        return $this->isActive();
+    }
+
+    public function isRecurring(): bool
+    {
+        return ! $this->isCancelled();
+    }
+
+    public function isEnded(): bool
+    {
+        return $this->isCancelled() && ! $this->isOnGracePeriod();
+    }
+}

--- a/src/Contracts/OrderRepositoryInterface.php
+++ b/src/Contracts/OrderRepositoryInterface.php
@@ -18,6 +18,17 @@ interface OrderRepositoryInterface
     public function findByVatlyId(string $vatlyId): ?OrderInterface;
 
     /**
+     * Find a single order owned by the given billable.
+     *
+     * Used by {@see \Vatly\Fluent\Billable::order()} to construct an
+     * {@see \Vatly\Fluent\OrderHandle} for a known owner+id pair.
+     *
+     * @throws \Vatly\Fluent\Exceptions\InvalidOrderException When no order
+     *         with the given Vatly id exists for the owner.
+     */
+    public function findForOwnerOrFail(BillableInterface $owner, string $vatlyId): OrderInterface;
+
+    /**
      * Find all orders for an owner.
      *
      * @return OrderInterface[]

--- a/src/Contracts/SubscriptionInterface.php
+++ b/src/Contracts/SubscriptionInterface.php
@@ -57,6 +57,26 @@ interface SubscriptionInterface
     public function isActive(): bool;
 
     /**
+     * Check if the subscription is currently usable.
+     *
+     * Today equivalent to {@see self::isActive()}. Reserved as a broader
+     * umbrella that will also account for trials once those land.
+     */
+    public function isValid(): bool;
+
+    /**
+     * Check if the subscription is recurring — i.e. not (yet) cancelled and
+     * will renew at the next billing cycle.
+     */
+    public function isRecurring(): bool;
+
+    /**
+     * Check if the subscription has fully ended — cancelled and past the
+     * grace period.
+     */
+    public function isEnded(): bool;
+
+    /**
      * Get the owner of this subscription.
      */
     public function getOwner(): BillableInterface;

--- a/src/Exceptions/InvalidOrderException.php
+++ b/src/Exceptions/InvalidOrderException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Exceptions;
+
+class InvalidOrderException extends VatlyException
+{
+    public static function notFound(string $vatlyId): self
+    {
+        return new self("No order found with Vatly order ID: {$vatlyId}");
+    }
+
+    public static function notOwnedBy(string $vatlyId, object $owner): self
+    {
+        $class = get_class($owner);
+        $shortClass = substr($class, strrpos($class, '\\') + 1);
+
+        return new self("Order {$vatlyId} is not owned by the given {$shortClass}.");
+    }
+}

--- a/src/OrderHandle.php
+++ b/src/OrderHandle.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent;
+
+use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\OrderInterface;
+
+/**
+ * Framework-agnostic operations on an order.
+ *
+ * Wraps an {@see OrderInterface} (the persistent state, owned by the driver)
+ * with the actions that operate on it. Drivers expose this via
+ * {@see Billable::order()}.
+ *
+ * Mirrors {@see SubscriptionHandle} for orders. State accessors delegate to
+ * the underlying {@see OrderInterface}; operations (e.g. `invoiceUrl()`)
+ * reach the Vatly API through injected actions.
+ */
+class OrderHandle
+{
+    public function __construct(
+        private readonly OrderInterface $order,
+        private readonly GetOrder $getOrderAction,
+    ) {
+        //
+    }
+
+    /**
+     * The underlying persistent order record.
+     */
+    public function model(): OrderInterface
+    {
+        return $this->order;
+    }
+
+    // --- State accessors (delegate to OrderInterface) ---
+
+    public function getVatlyId(): string
+    {
+        return $this->order->getVatlyId();
+    }
+
+    public function getStatus(): string
+    {
+        return $this->order->getStatus();
+    }
+
+    public function getInvoiceNumber(): ?string
+    {
+        return $this->order->getInvoiceNumber();
+    }
+
+    public function getTotal(): int
+    {
+        return $this->order->getTotal();
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->order->getCurrency();
+    }
+
+    public function getPaymentMethod(): ?string
+    {
+        return $this->order->getPaymentMethod();
+    }
+
+    public function getOwner(): BillableInterface
+    {
+        return $this->order->getOwner();
+    }
+
+    public function isPaid(): bool
+    {
+        return $this->order->isPaid();
+    }
+
+    // --- Operations ---
+
+    /**
+     * Fetch the hosted invoice URL from the Vatly API.
+     *
+     * Each call hits the API; cache at the call site if you need to render
+     * many orders. Returns null when the upstream order doesn't (yet) have
+     * an invoice attached.
+     */
+    public function invoiceUrl(): ?string
+    {
+        $apiOrder = $this->getOrderAction->execute($this->order->getVatlyId());
+
+        return $apiOrder->links->customerInvoice?->href;
+    }
+}

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -111,6 +111,36 @@ class SubscriptionHandle
         return $this->subscription->isActive();
     }
 
+    public function isValid(): bool
+    {
+        return $this->subscription->isValid();
+    }
+
+    public function valid(): bool
+    {
+        return $this->subscription->isValid();
+    }
+
+    public function isRecurring(): bool
+    {
+        return $this->subscription->isRecurring();
+    }
+
+    public function recurring(): bool
+    {
+        return $this->subscription->isRecurring();
+    }
+
+    public function isEnded(): bool
+    {
+        return $this->subscription->isEnded();
+    }
+
+    public function ended(): bool
+    {
+        return $this->subscription->isEnded();
+    }
+
     // --- Operations ---
 
     /**

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -16,6 +16,8 @@ use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Configuration\ArrayConfiguration;
 use Vatly\Fluent\Contracts\BillableInterface;
+use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Exceptions\IncompleteWiring;
 use Vatly\Fluent\Webhooks\SignatureVerifier;
 use Vatly\Fluent\Webhooks\WebhookEventFactory;
@@ -132,6 +134,7 @@ class Vatly
             createCheckoutAction: $this->createCheckout(),
             createCustomerAction: $this->createCustomer(),
             getCustomerAction: $this->getCustomer(),
+            getOrderAction: $this->getOrder(),
             getSubscriptionAction: $this->getSubscription(),
             swapSubscriptionPlanAction: $this->swapSubscriptionPlan(),
             cancelSubscriptionAction: $this->cancelSubscription(),
@@ -143,6 +146,40 @@ class Vatly
     public function billable(BillableInterface $owner): Billable
     {
         return $this->billableFactory()->forOwner($owner);
+    }
+
+    /**
+     * Build a {@see SubscriptionHandle} wrapping a persistent subscription.
+     *
+     * Drivers use this so their Eloquent (or equivalent) Subscription model
+     * can expose Cashier-style operation methods that delegate here.
+     */
+    public function subscriptionHandle(SubscriptionInterface $subscription): SubscriptionHandle
+    {
+        return new SubscriptionHandle(
+            subscription: $subscription,
+            subscriptions: $this->wiring->subscriptions
+                ?? throw IncompleteWiring::missing('subscriptions', 'SubscriptionHandle'),
+            swapAction: $this->swapSubscriptionPlan(),
+            cancelAction: $this->cancelSubscription(),
+            resumeAction: $this->resumeSubscription(),
+            getSubscriptionAction: $this->getSubscription(),
+            updateBillingAction: $this->updateSubscriptionBilling(),
+        );
+    }
+
+    /**
+     * Build an {@see OrderHandle} wrapping a persistent order.
+     *
+     * Drivers use this so their Eloquent (or equivalent) Order model can
+     * expose operation methods (e.g. `invoiceUrl()`) that delegate here.
+     */
+    public function orderHandle(OrderInterface $order): OrderHandle
+    {
+        return new OrderHandle(
+            order: $order,
+            getOrderAction: $this->getOrder(),
+        );
     }
 
     // --- Action accessors ---

--- a/tests/BillableFactoryTest.php
+++ b/tests/BillableFactoryTest.php
@@ -10,6 +10,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -35,6 +36,7 @@ class BillableFactoryTest extends TestCase
             createCheckoutAction: Mockery::mock(CreateCheckout::class),
             createCustomerAction: Mockery::mock(CreateCustomer::class),
             getCustomerAction: Mockery::mock(GetCustomer::class),
+            getOrderAction: Mockery::mock(GetOrder::class),
             getSubscriptionAction: Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),
@@ -58,6 +60,7 @@ class BillableFactoryTest extends TestCase
             createCheckoutAction: Mockery::mock(CreateCheckout::class),
             createCustomerAction: Mockery::mock(CreateCustomer::class),
             getCustomerAction: Mockery::mock(GetCustomer::class),
+            getOrderAction: Mockery::mock(GetOrder::class),
             getSubscriptionAction: Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: Mockery::mock(CancelSubscription::class),

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -12,6 +12,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Actions\GetCustomer;
+use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -107,6 +108,25 @@ class BillableTest extends TestCase
         $billable = $this->buildBillable(owner: $owner, orders: $orders);
 
         $this->assertSame([$orderA, $orderB], $billable->orders());
+    }
+
+    public function test_order_returns_handle_wrapping_the_found_order(): void
+    {
+        $owner = $this->stubOwner();
+        $found = Mockery::mock(OrderInterface::class);
+
+        $orders = Mockery::mock(OrderRepositoryInterface::class);
+        $orders->shouldReceive('findForOwnerOrFail')
+            ->once()
+            ->with($owner, 'order_abc')
+            ->andReturn($found);
+
+        $billable = $this->buildBillable(owner: $owner, orders: $orders);
+
+        $handle = $billable->order('order_abc');
+
+        $this->assertInstanceOf(\Vatly\Fluent\OrderHandle::class, $handle);
+        $this->assertSame($found, $handle->model());
     }
 
     public function test_create_as_vatly_customer_creates_persists_and_returns_the_customer(): void
@@ -236,6 +256,7 @@ class BillableTest extends TestCase
         ?CreateCheckout $createCheckoutAction = null,
         ?CreateCustomer $createCustomerAction = null,
         ?GetCustomer $getCustomerAction = null,
+        ?GetOrder $getOrderAction = null,
         ?GetSubscription $getSubscriptionAction = null,
         ?SwapSubscriptionPlan $swapSubscriptionPlanAction = null,
         ?CancelSubscription $cancelSubscriptionAction = null,
@@ -251,6 +272,7 @@ class BillableTest extends TestCase
             createCheckoutAction: $createCheckoutAction ?? Mockery::mock(CreateCheckout::class),
             createCustomerAction: $createCustomerAction ?? Mockery::mock(CreateCustomer::class),
             getCustomerAction: $getCustomerAction ?? Mockery::mock(GetCustomer::class),
+            getOrderAction: $getOrderAction ?? Mockery::mock(GetOrder::class),
             getSubscriptionAction: $getSubscriptionAction ?? Mockery::mock(GetSubscription::class),
             swapSubscriptionPlanAction: $swapSubscriptionPlanAction ?? Mockery::mock(SwapSubscriptionPlan::class),
             cancelSubscriptionAction: $cancelSubscriptionAction ?? Mockery::mock(CancelSubscription::class),

--- a/tests/Concerns/DerivesSubscriptionStateTest.php
+++ b/tests/Concerns/DerivesSubscriptionStateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Concerns;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Vatly\Fluent\Concerns\DerivesSubscriptionState;
+use Vatly\Fluent\Tests\TestCase;
+
+class DerivesSubscriptionStateTest extends TestCase
+{
+    public function test_subscription_with_no_ends_at_is_active_and_recurring(): void
+    {
+        $sub = $this->subscription(endsAt: null);
+
+        $this->assertFalse($sub->isCancelled());
+        $this->assertFalse($sub->isOnGracePeriod());
+        $this->assertTrue($sub->isActive());
+        $this->assertTrue($sub->isValid());
+        $this->assertTrue($sub->isRecurring());
+        $this->assertFalse($sub->isEnded());
+    }
+
+    public function test_subscription_with_future_ends_at_is_on_grace_period(): void
+    {
+        $sub = $this->subscription(endsAt: new DateTimeImmutable('+7 days'));
+
+        $this->assertTrue($sub->isCancelled());
+        $this->assertTrue($sub->isOnGracePeriod());
+        $this->assertTrue($sub->isActive());
+        $this->assertTrue($sub->isValid());
+        $this->assertFalse($sub->isRecurring());
+        $this->assertFalse($sub->isEnded());
+    }
+
+    public function test_subscription_with_past_ends_at_is_ended(): void
+    {
+        $sub = $this->subscription(endsAt: new DateTimeImmutable('-7 days'));
+
+        $this->assertTrue($sub->isCancelled());
+        $this->assertFalse($sub->isOnGracePeriod());
+        $this->assertFalse($sub->isActive());
+        $this->assertFalse($sub->isValid());
+        $this->assertFalse($sub->isRecurring());
+        $this->assertTrue($sub->isEnded());
+    }
+
+    /**
+     * Build a minimal object exposing `getEndsAt()` and the
+     * trait's predicates. No SubscriptionInterface needed — we're testing
+     * the trait in isolation.
+     */
+    private function subscription(?DateTimeInterface $endsAt): object
+    {
+        return new class($endsAt) {
+            use DerivesSubscriptionState;
+
+            public function __construct(private ?DateTimeInterface $endsAt) {}
+
+            public function getEndsAt(): ?DateTimeInterface
+            {
+                return $this->endsAt;
+            }
+        };
+    }
+}

--- a/tests/Events/LocalSubscriptionCreatedTest.php
+++ b/tests/Events/LocalSubscriptionCreatedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Tests\Events;
 
 use DateTimeInterface;
+use Vatly\Fluent\Concerns\DerivesSubscriptionState;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Events\LocalSubscriptionCreated;
@@ -35,6 +36,8 @@ class LocalSubscriptionCreatedTest extends TestCase
     private function createMockSubscription(): SubscriptionInterface
     {
         return new class implements SubscriptionInterface {
+            use DerivesSubscriptionState;
+
             public function getVatlyId(): string
             {
                 return 'sub_test_123';
@@ -63,21 +66,6 @@ class LocalSubscriptionCreatedTest extends TestCase
             public function getEndsAt(): ?DateTimeInterface
             {
                 return null;
-            }
-
-            public function isActive(): bool
-            {
-                return true;
-            }
-
-            public function isCancelled(): bool
-            {
-                return false;
-            }
-
-            public function isOnGracePeriod(): bool
-            {
-                return false;
             }
 
             public function getOwner(): BillableInterface

--- a/tests/OrderHandleTest.php
+++ b/tests/OrderHandleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests;
+
+use Mockery;
+use Vatly\API\Resources\Links\OrderLinks;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Link;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\OrderHandle;
+
+class OrderHandleTest extends TestCase
+{
+    public function test_state_accessors_delegate_to_the_underlying_order(): void
+    {
+        $order = Mockery::mock(OrderInterface::class);
+        $order->shouldReceive('getVatlyId')->andReturn('order_abc');
+        $order->shouldReceive('getStatus')->andReturn('paid');
+        $order->shouldReceive('getTotal')->andReturn(1999);
+        $order->shouldReceive('getCurrency')->andReturn('EUR');
+        $order->shouldReceive('getInvoiceNumber')->andReturn('INV-2026-0001');
+        $order->shouldReceive('getPaymentMethod')->andReturn('creditcard');
+        $order->shouldReceive('isPaid')->andReturn(true);
+
+        $handle = new OrderHandle(
+            order: $order,
+            getOrderAction: Mockery::mock(GetOrder::class),
+        );
+
+        $this->assertSame('order_abc', $handle->getVatlyId());
+        $this->assertSame('paid', $handle->getStatus());
+        $this->assertSame(1999, $handle->getTotal());
+        $this->assertSame('EUR', $handle->getCurrency());
+        $this->assertSame('INV-2026-0001', $handle->getInvoiceNumber());
+        $this->assertSame('creditcard', $handle->getPaymentMethod());
+        $this->assertTrue($handle->isPaid());
+        $this->assertSame($order, $handle->model());
+    }
+
+    public function test_invoice_url_returns_the_customer_invoice_href_when_present(): void
+    {
+        $apiOrder = $this->buildApiOrder(invoiceHref: 'https://invoices.vatly.test/inv_123.pdf');
+
+        $getOrder = Mockery::mock(GetOrder::class);
+        $getOrder->shouldReceive('execute')->with('order_abc')->andReturn($apiOrder);
+
+        $order = Mockery::mock(OrderInterface::class);
+        $order->shouldReceive('getVatlyId')->andReturn('order_abc');
+
+        $handle = new OrderHandle(order: $order, getOrderAction: $getOrder);
+
+        $this->assertSame('https://invoices.vatly.test/inv_123.pdf', $handle->invoiceUrl());
+    }
+
+    public function test_invoice_url_is_null_when_no_customer_invoice_link(): void
+    {
+        $apiOrder = $this->buildApiOrder(invoiceHref: null);
+
+        $getOrder = Mockery::mock(GetOrder::class);
+        $getOrder->shouldReceive('execute')->with('order_abc')->andReturn($apiOrder);
+
+        $order = Mockery::mock(OrderInterface::class);
+        $order->shouldReceive('getVatlyId')->andReturn('order_abc');
+
+        $handle = new OrderHandle(order: $order, getOrderAction: $getOrder);
+
+        $this->assertNull($handle->invoiceUrl());
+    }
+
+    private function buildApiOrder(?string $invoiceHref): ApiOrder
+    {
+        $client = Mockery::mock(VatlyApiClient::class);
+
+        $apiOrder = new ApiOrder($client);
+        $apiOrder->id = 'order_abc';
+
+        $apiOrder->links = new OrderLinks();
+        $apiOrder->links->customerInvoice = $invoiceHref !== null
+            ? new Link($invoiceHref, 'text/html')
+            : null;
+
+        return $apiOrder;
+    }
+}

--- a/tests/VatlyTest.php
+++ b/tests/VatlyTest.php
@@ -12,10 +12,14 @@ use Vatly\Fluent\Configuration\ArrayConfiguration;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Exceptions\IncompleteWiring;
+use Vatly\Fluent\OrderHandle;
+use Vatly\Fluent\SubscriptionHandle;
 use Vatly\Fluent\Vatly;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 use Vatly\Fluent\Wiring;
@@ -159,6 +163,38 @@ class VatlyTest extends TestCase
         $vatly = $this->fullyWiredVatly();
 
         $this->assertInstanceOf(WebhookProcessor::class, $vatly->webhookProcessor());
+    }
+
+    public function test_subscription_handle_wraps_the_given_subscription(): void
+    {
+        $vatly = $this->fullyWiredVatly();
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+
+        $handle = $vatly->subscriptionHandle($subscription);
+
+        $this->assertInstanceOf(SubscriptionHandle::class, $handle);
+        $this->assertSame($subscription, $handle->model());
+    }
+
+    public function test_subscription_handle_throws_when_subscriptions_missing(): void
+    {
+        $vatly = Vatly::apiOnly('test_abcdefghijklmnopqrstuvwxyz');
+
+        $this->expectException(IncompleteWiring::class);
+        $this->expectExceptionMessageMatches("/'SubscriptionHandle'.*'subscriptions'/");
+
+        $vatly->subscriptionHandle(Mockery::mock(SubscriptionInterface::class));
+    }
+
+    public function test_order_handle_wraps_the_given_order(): void
+    {
+        $vatly = Vatly::apiOnly('test_abcdefghijklmnopqrstuvwxyz');
+        $order = Mockery::mock(OrderInterface::class);
+
+        $handle = $vatly->orderHandle($order);
+
+        $this->assertInstanceOf(OrderHandle::class, $handle);
+        $this->assertSame($order, $handle->model());
     }
 
     private function fullyWiredVatly(): Vatly


### PR DESCRIPTION
> Stacked on #30 (composition-root refactor). Review #30 first; merge order: #30 then this.

## Summary
- **OrderHandle** mirrors `SubscriptionHandle` for the order side. State accessors delegate to the wrapped `OrderInterface`; `invoiceUrl()` reaches the API via `GetOrder`. Drivers' Eloquent (or equivalent) `Order` model can delegate to `OrderHandle` instead of reaching into the container for the raw API client.
- **Derived predicates** `isValid()`, `isRecurring()`, `isEnded()` added to `SubscriptionInterface`. `DerivesSubscriptionState` trait provides default impls for all six predicates (the existing three plus the new ones), so drivers can satisfy the interface with `use DerivesSubscriptionState;`.
- `OrderRepositoryInterface::findForOwnerOrFail(BillableInterface, string)` — drivers must implement.
- `Vatly::subscriptionHandle()` / `Vatly::orderHandle()` factory methods on the composition root.
- `Billable::order(string \$vatlyId): OrderHandle` consumer-facing convenience.

## Latent bug fixed
The old `\$apiOrder->links->invoice->href ?? null` (carried in `vatly-laravel`'s `Order::invoiceUrl()`) silently returned `null` in production — the upstream `OrderLinks` resource exposes `customerInvoice`, not `invoice`. `OrderHandle::invoiceUrl()` uses the correct property name.

## Breaking changes (pre-1.0, no live installs)
| Surface | Change |
|---|---|
| `OrderRepositoryInterface` | + `findForOwnerOrFail()` required |
| `SubscriptionInterface` | + `isValid()`, `isRecurring()`, `isEnded()` required (cheap via `DerivesSubscriptionState`) |
| `Billable::__construct` / `BillableFactory::__construct` | + `\$getOrderAction: GetOrder` |
| `Vatly\Laravel\Models\Order::invoiceUrl()` (follow-up PR) | URL property name corrected |

## Test plan
- [x] `composer test` — 148/148 pass (+10 new)
- [x] `composer analyse` — clean
