### PR TITLE
feat: custom webhook reactions via Wiring; min PHP back to 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
 
     name: PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,21 @@ $vatly = new Vatly(new Wiring(
 
 Register the `Vatly` instance as a singleton in your framework's container. Everything else resolves through it.
 
+If your driver ships plugin-specific webhook reactions (e.g. assigning a membership level on `subscription.started`), pass them as `additionalWebhookReactions`:
+
+```php
+$vatly = new Vatly(new Wiring(
+    config:        $config,
+    // ... repos + events ...
+    additionalWebhookReactions: [
+        new AssignMembershipLevelOnStarted(...),
+        new RevokeMembershipLevelOnCanceled(...),
+    ],
+));
+```
+
+They run after fluent's built-in reactions (subscription sync, order persistence, cancellation handling).
+
 ### 8. Expose the per-owner orchestrator
 
 Give your User model a way to reach `Vatly\Fluent\Billable`:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "vatly/vatly-api-php": "^0.1.0-alpha.8"
     },
     "require-dev": {

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -116,6 +116,7 @@ class Vatly
             dispatcher: $this->wiring->events
                 ?? throw IncompleteWiring::missing('events', 'WebhookProcessor'),
             getOrder: $this->getOrder(),
+            additionalReactions: $this->wiring->additionalWebhookReactions,
         );
     }
 

--- a/src/Wiring.php
+++ b/src/Wiring.php
@@ -10,6 +10,7 @@ use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
 
 /**
  * Composition-time dependencies passed to {@see Vatly}.
@@ -18,18 +19,25 @@ use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
  * omitted for api-only mode; calling a method on `Vatly` that needs an
  * absent dependency raises {@see \Vatly\Fluent\Exceptions\IncompleteWiring}.
  *
- * Drivers (Laravel, etc.) construct one of these from their container and
- * pass it to `new Vatly($wiring)` — typically bound as a singleton.
+ * Drivers (Laravel, WordPress, etc.) construct one of these from their
+ * container and pass it to `new Vatly($wiring)` — typically bound as
+ * a singleton. Drivers that ship plugin-specific webhook reactions
+ * (e.g. PMPro membership assignment, FluentCart order confirmation)
+ * supply them via `additionalWebhookReactions`.
  */
-final readonly class Wiring
+final class Wiring
 {
+    /**
+     * @param WebhookReactionInterface[] $additionalWebhookReactions
+     */
     public function __construct(
-        public ConfigurationInterface $config,
-        public ?SubscriptionRepositoryInterface $subscriptions = null,
-        public ?CustomerRepositoryInterface $customers = null,
-        public ?OrderRepositoryInterface $orders = null,
-        public ?WebhookCallRepositoryInterface $webhookCalls = null,
-        public ?EventDispatcherInterface $events = null,
+        public readonly ConfigurationInterface $config,
+        public readonly ?SubscriptionRepositoryInterface $subscriptions = null,
+        public readonly ?CustomerRepositoryInterface $customers = null,
+        public readonly ?OrderRepositoryInterface $orders = null,
+        public readonly ?WebhookCallRepositoryInterface $webhookCalls = null,
+        public readonly ?EventDispatcherInterface $events = null,
+        public readonly array $additionalWebhookReactions = [],
     ) {
         //
     }

--- a/tests/VatlyTest.php
+++ b/tests/VatlyTest.php
@@ -165,6 +165,31 @@ class VatlyTest extends TestCase
         $this->assertInstanceOf(WebhookProcessor::class, $vatly->webhookProcessor());
     }
 
+    public function test_additional_webhook_reactions_from_wiring_are_passed_through(): void
+    {
+        $customReaction = Mockery::mock(\Vatly\Fluent\Contracts\WebhookReactionInterface::class);
+
+        $vatly = new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            customers: Mockery::mock(CustomerRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            events: Mockery::mock(EventDispatcherInterface::class),
+            additionalWebhookReactions: [$customReaction],
+        ));
+
+        $processor = $vatly->webhookProcessor();
+
+        // Reach in to confirm the custom reaction made it into the processor's list.
+        $ref = (new \ReflectionClass($processor))->getProperty('reactions');
+        $reactions = $ref->getValue($processor);
+
+        $this->assertContains($customReaction, $reactions);
+        // The 3 standard reactions stay on top, plus our extra one = 4.
+        $this->assertCount(4, $reactions);
+    }
+
     public function test_subscription_handle_wraps_the_given_subscription(): void
     {
         $vatly = $this->fullyWiredVatly();


### PR DESCRIPTION
> Driven by reviewing the broader portfolio — vatly-pmpro and vatly-fluentcart-wp can't adopt v0.7.0-alpha.1 as-is. This closes the two blockers.

## 1. Custom webhook reactions via \`Wiring\`

Both WordPress drivers ship plugin-specific webhook reactions:

- **vatly-pmpro**: \`AssignMembershipLevelOnStarted\`, \`RevokeMembershipLevelOnCanceled\`, \`WriteOrderRowOnPaid\`
- **vatly-fluentcart-wp**: \`ConfirmOrderOnPaid\`, \`RecordRenewalOnPaid\`, \`SyncSubscriptionOnStarted\`, \`CancelSubscriptionOnCanceled\`

Today they pass these into \`WebhookProcessorFactory::create(..., additionalReactions: [...])\` directly. \`Vatly::webhookProcessor()\` had no equivalent escape hatch — drivers would have to bypass the composition root.

\`Wiring\` gains an \`\$additionalWebhookReactions\` field; \`Vatly::webhookProcessor()\` passes it through to the factory:

\`\`\`php
new Vatly(new Wiring(
    config: ...,
    // ... repos + events ...
    additionalWebhookReactions: [
        new AssignMembershipLevelOnStarted(\$customerRepo),
        new RevokeMembershipLevelOnCanceled(\$customerRepo),
    ],
));
\`\`\`

Built-in reactions (subscription sync, order persistence, cancellation) run first; the extras append.

## 2. Min PHP back to 8.1

v0.7.0-alpha.1 bumped to PHP 8.2 because \`Wiring\` used \`final readonly class\` (class-level readonly is 8.2+). Property-level \`readonly\` on \`Wiring\`'s individual fields is 8.1+ and gives the same write-protection. Walked back to 8.1.

This matters for the WordPress side: WordPress install distribution still has meaningful PHP 8.1 share (~15-20%). PMPro and fluentcart-wp both declare \`php: ^8.0\` — going to 8.1 puts them within reach; 8.2 cuts off a real audience.

Laravel-side \`^8.3\` constraint unchanged (Laravel apps are already ahead).

| Surface | Before | After |
|---|---|---|
| \`Wiring\` declaration | \`final readonly class Wiring\` | \`final class Wiring\` + \`public readonly\` per property |
| \`composer.json\` | \`"php": "^8.2"\` | \`"php": "^8.1"\` |
| CI matrix | 8.2, 8.3, 8.4 | 8.1, 8.2, 8.3, 8.4 |
| \`Wiring\`'s extra field | — | \`\$additionalWebhookReactions: array = []\` |
| \`Vatly::webhookProcessor()\` | passes 0 additional reactions | passes \`\$wiring->additionalWebhookReactions\` |

## Test plan
- [x] \`composer test\` — 149/149 pass (+1 covering the reactions pass-through)
- [x] \`composer analyse\` — clean

## Follow-up

Tag v0.7.0-alpha.2 once merged. \`vatly-laravel\` doesn't need to change (no custom reactions, already on 8.3+); \`vatly-pmpro\` and \`vatly-fluentcart-wp\` can now adopt v0.7.x in a follow-up PR each.
