### PR TITLE
refactor: split repo contracts into Reader + Writer roles (flysystem-style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Each contract is small (3–5 methods). See [src/Contracts](src/Contracts) for s
 
 Use your framework's ORM. There's no fluent-side abstraction over query building — you write straight ORM code.
 
+> Each of the three entity-side repos is also exposed as a Reader / Writer pair (`CustomerReader` + `CustomerWriter`, etc.). The combined interface extends both. Consumers — including your own webhook reactions — should typehint the narrowest role they actually need; reactions that only persist state can ask for `SubscriptionWriter` and won't be coupled to the read methods.
+
 ### 6. Implement `EventDispatcherInterface`
 
 ```php
@@ -368,10 +370,10 @@ In [src/Contracts](src/Contracts):
 - `BillableInterface` — the owner of subscriptions/orders
 - `SubscriptionInterface` — local subscription state + derived predicates
 - `OrderInterface` — local order state
-- `CustomerRepositoryInterface` — owner persistence
-- `SubscriptionRepositoryInterface` — subscription persistence
-- `OrderRepositoryInterface` — order persistence
-- `WebhookCallRepositoryInterface` — webhook audit log
+- `CustomerRepositoryInterface` — owner persistence. Splits into `CustomerReader` (find) + `CustomerWriter` (save) — typehint the narrowest you need.
+- `SubscriptionRepositoryInterface` — subscription persistence. Splits into `SubscriptionReader` (find/predicates) + `SubscriptionWriter` (store/update).
+- `OrderRepositoryInterface` — order persistence. Splits into `OrderReader` (find) + `OrderWriter` (store/update).
+- `WebhookCallRepositoryInterface` — webhook audit log (write-only by nature)
 - `EventDispatcherInterface` — fire domain events
 - `ConfigurationInterface` — API key, URL, version, webhook secret, redirect defaults
 - `WebhookReactionInterface` — extension point for adding your own webhook reactions

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -18,9 +18,9 @@ use Vatly\Fluent\Builders\CheckoutBuilder;
 use Vatly\Fluent\Builders\SubscriptionBuilder;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
-use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
+use Vatly\Fluent\Contracts\CustomerWriter;
 use Vatly\Fluent\Contracts\OrderInterface;
-use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\OrderReader;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Exceptions\CustomerAlreadyCreatedException;
@@ -37,8 +37,8 @@ class Billable
     public function __construct(
         private BillableInterface $owner,
         private SubscriptionRepositoryInterface $subscriptions,
-        private CustomerRepositoryInterface $customers,
-        private OrderRepositoryInterface $orders,
+        private CustomerWriter $customers,
+        private OrderReader $orders,
         private ConfigurationInterface $config,
         private CreateCheckout $createCheckoutAction,
         private CreateCustomer $createCustomerAction,

--- a/src/BillableFactory.php
+++ b/src/BillableFactory.php
@@ -15,8 +15,8 @@ use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
-use Vatly\Fluent\Contracts\CustomerRepositoryInterface;
-use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\CustomerWriter;
+use Vatly\Fluent\Contracts\OrderReader;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 
 /**
@@ -30,8 +30,8 @@ class BillableFactory
 {
     public function __construct(
         private SubscriptionRepositoryInterface $subscriptions,
-        private CustomerRepositoryInterface $customers,
-        private OrderRepositoryInterface $orders,
+        private CustomerWriter $customers,
+        private OrderReader $orders,
         private ConfigurationInterface $config,
         private CreateCheckout $createCheckoutAction,
         private CreateCustomer $createCustomerAction,

--- a/src/Contracts/CustomerReader.php
+++ b/src/Contracts/CustomerReader.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Read-side of the customer repository contract.
+ *
+ * Typehint this when you only need to look billables up — e.g. listing
+ * views, read-only dashboards. Pairs with {@see CustomerWriter}; both
+ * are combined into {@see CustomerRepositoryInterface} for callers that
+ * need both sides.
+ */
+interface CustomerReader
+{
+    /**
+     * Find a billable by its Vatly customer ID.
+     */
+    public function findByVatlyId(string $vatlyId): ?BillableInterface;
+
+    /**
+     * Find a billable by its Vatly customer ID or fail.
+     *
+     * @throws \Vatly\Fluent\Exceptions\InvalidCustomerException
+     */
+    public function findByVatlyIdOrFail(string $vatlyId): BillableInterface;
+}

--- a/src/Contracts/CustomerRepositoryInterface.php
+++ b/src/Contracts/CustomerRepositoryInterface.php
@@ -5,24 +5,13 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Contracts;
 
 /**
- * Interface for customer/billable persistence and lookup.
+ * Full customer repository — both read and write sides.
+ *
+ * Typehint this when a class genuinely needs both. Otherwise prefer the
+ * narrower {@see CustomerReader} or {@see CustomerWriter} so collaborators
+ * advertise the minimum capability they require.
  */
-interface CustomerRepositoryInterface
+interface CustomerRepositoryInterface extends CustomerReader, CustomerWriter
 {
-    /**
-     * Find a billable by its Vatly customer ID.
-     */
-    public function findByVatlyId(string $vatlyId): ?BillableInterface;
-
-    /**
-     * Find a billable by its Vatly customer ID or fail.
-     *
-     * @throws \Vatly\Fluent\Exceptions\InvalidCustomerException
-     */
-    public function findByVatlyIdOrFail(string $vatlyId): BillableInterface;
-
-    /**
-     * Save a billable entity.
-     */
-    public function save(BillableInterface $billable): void;
+    //
 }

--- a/src/Contracts/CustomerWriter.php
+++ b/src/Contracts/CustomerWriter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Write-side of the customer repository contract.
+ *
+ * Typehint this when you only need to persist billables — typically the
+ * customer-creation flow, where a new Vatly id is being attached to an
+ * existing owner. Pairs with {@see CustomerReader}.
+ */
+interface CustomerWriter
+{
+    /**
+     * Save a billable entity.
+     */
+    public function save(BillableInterface $billable): void;
+}

--- a/src/Contracts/OrderReader.php
+++ b/src/Contracts/OrderReader.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Read-side of the order repository contract.
+ *
+ * Typehint this for read-only consumers — order history views, invoice
+ * URL lookups, etc. Pairs with {@see OrderWriter}.
+ */
+interface OrderReader
+{
+    /**
+     * Find an order by its Vatly ID.
+     */
+    public function findByVatlyId(string $vatlyId): ?OrderInterface;
+
+    /**
+     * Find a single order owned by the given billable.
+     *
+     * Used by {@see \Vatly\Fluent\Billable::order()} to construct an
+     * {@see \Vatly\Fluent\OrderHandle} for a known owner+id pair.
+     *
+     * @throws \Vatly\Fluent\Exceptions\InvalidOrderException When no order
+     *         with the given Vatly id exists for the owner.
+     */
+    public function findForOwnerOrFail(BillableInterface $owner, string $vatlyId): OrderInterface;
+
+    /**
+     * Find all orders for an owner.
+     *
+     * @return OrderInterface[]
+     */
+    public function findAllByOwner(BillableInterface $owner): array;
+}

--- a/src/Contracts/OrderRepositoryInterface.php
+++ b/src/Contracts/OrderRepositoryInterface.php
@@ -4,44 +4,14 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Contracts;
 
-use Vatly\Fluent\Data\StoreOrderData;
-use Vatly\Fluent\Data\UpdateOrderData;
-
 /**
- * Interface for order persistence.
+ * Full order repository — both read and write sides.
+ *
+ * Typehint this when a class needs both. Otherwise prefer the narrower
+ * {@see OrderReader} or {@see OrderWriter} so collaborators advertise
+ * the minimum capability they require.
  */
-interface OrderRepositoryInterface
+interface OrderRepositoryInterface extends OrderReader, OrderWriter
 {
-    /**
-     * Find an order by its Vatly ID.
-     */
-    public function findByVatlyId(string $vatlyId): ?OrderInterface;
-
-    /**
-     * Find a single order owned by the given billable.
-     *
-     * Used by {@see \Vatly\Fluent\Billable::order()} to construct an
-     * {@see \Vatly\Fluent\OrderHandle} for a known owner+id pair.
-     *
-     * @throws \Vatly\Fluent\Exceptions\InvalidOrderException When no order
-     *         with the given Vatly id exists for the owner.
-     */
-    public function findForOwnerOrFail(BillableInterface $owner, string $vatlyId): OrderInterface;
-
-    /**
-     * Find all orders for an owner.
-     *
-     * @return OrderInterface[]
-     */
-    public function findAllByOwner(BillableInterface $owner): array;
-
-    /**
-     * Store a new order from Vatly.
-     */
-    public function store(StoreOrderData $data): OrderInterface;
-
-    /**
-     * Update an existing order from Vatly.
-     */
-    public function update(OrderInterface $order, UpdateOrderData $data): OrderInterface;
+    //
 }

--- a/src/Contracts/OrderWriter.php
+++ b/src/Contracts/OrderWriter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+use Vatly\Fluent\Data\StoreOrderData;
+use Vatly\Fluent\Data\UpdateOrderData;
+
+/**
+ * Write-side of the order repository contract.
+ *
+ * Typehint this from webhook reactions that only persist orders —
+ * order-paid, order-refunded. Pairs with {@see OrderReader}.
+ */
+interface OrderWriter
+{
+    /**
+     * Store a new order from Vatly.
+     */
+    public function store(StoreOrderData $data): OrderInterface;
+
+    /**
+     * Update an existing order from Vatly.
+     */
+    public function update(OrderInterface $order, UpdateOrderData $data): OrderInterface;
+}

--- a/src/Contracts/SubscriptionReader.php
+++ b/src/Contracts/SubscriptionReader.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Read-side of the subscription repository contract.
+ *
+ * Typehint this for read-only consumers — admin dashboards, status
+ * predicates inside reactions, etc. Pairs with {@see SubscriptionWriter}.
+ */
+interface SubscriptionReader
+{
+    /**
+     * Find a subscription by its Vatly ID.
+     */
+    public function findByVatlyId(string $vatlyId): ?SubscriptionInterface;
+
+    /**
+     * Find a subscription by owner and type.
+     */
+    public function findByOwnerAndType(BillableInterface $owner, string $type): ?SubscriptionInterface;
+
+    /**
+     * Find all subscriptions for an owner.
+     *
+     * @return SubscriptionInterface[]
+     */
+    public function findAllByOwner(BillableInterface $owner): array;
+
+    /**
+     * Check if owner has an active subscription of a given type.
+     */
+    public function ownerHasActiveSubscription(BillableInterface $owner, string $type): bool;
+}

--- a/src/Contracts/SubscriptionRepositoryInterface.php
+++ b/src/Contracts/SubscriptionRepositoryInterface.php
@@ -4,43 +4,14 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Contracts;
 
-use Vatly\Fluent\Data\StoreSubscriptionData;
-use Vatly\Fluent\Data\UpdateSubscriptionData;
-
 /**
- * Interface for subscription persistence.
+ * Full subscription repository — both read and write sides.
+ *
+ * Typehint this when a class needs both. Otherwise prefer the narrower
+ * {@see SubscriptionReader} or {@see SubscriptionWriter} so collaborators
+ * advertise the minimum capability they require.
  */
-interface SubscriptionRepositoryInterface
+interface SubscriptionRepositoryInterface extends SubscriptionReader, SubscriptionWriter
 {
-    /**
-     * Find a subscription by its Vatly ID.
-     */
-    public function findByVatlyId(string $vatlyId): ?SubscriptionInterface;
-
-    /**
-     * Find a subscription by owner and type.
-     */
-    public function findByOwnerAndType(BillableInterface $owner, string $type): ?SubscriptionInterface;
-
-    /**
-     * Find all subscriptions for an owner.
-     *
-     * @return SubscriptionInterface[]
-     */
-    public function findAllByOwner(BillableInterface $owner): array;
-
-    /**
-     * Check if owner has an active subscription of a given type.
-     */
-    public function ownerHasActiveSubscription(BillableInterface $owner, string $type): bool;
-
-    /**
-     * Store a new subscription from Vatly.
-     */
-    public function store(StoreSubscriptionData $data): SubscriptionInterface;
-
-    /**
-     * Update an existing subscription from Vatly.
-     */
-    public function update(SubscriptionInterface $subscription, UpdateSubscriptionData $data): SubscriptionInterface;
+    //
 }

--- a/src/Contracts/SubscriptionWriter.php
+++ b/src/Contracts/SubscriptionWriter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+use Vatly\Fluent\Data\StoreSubscriptionData;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+
+/**
+ * Write-side of the subscription repository contract.
+ *
+ * Typehint this from webhook reactions that only persist state —
+ * subscription-started, subscription-canceled. Pairs with
+ * {@see SubscriptionReader}.
+ */
+interface SubscriptionWriter
+{
+    /**
+     * Store a new subscription from Vatly.
+     */
+    public function store(StoreSubscriptionData $data): SubscriptionInterface;
+
+    /**
+     * Update an existing subscription from Vatly.
+     */
+    public function update(SubscriptionInterface $subscription, UpdateSubscriptionData $data): SubscriptionInterface;
+}

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -12,7 +12,7 @@ use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\BillableInterface;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
-use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\SubscriptionWriter;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
 
 /**
@@ -26,7 +26,7 @@ class SubscriptionHandle
 {
     public function __construct(
         private SubscriptionInterface $subscription,
-        private SubscriptionRepositoryInterface $subscriptions,
+        private SubscriptionWriter $subscriptions,
         private SwapSubscriptionPlan $swapAction,
         private CancelSubscription $cancelAction,
         private ResumeSubscription $resumeAction,


### PR DESCRIPTION
> Borrowed from `league/flysystem` (e.g. `FilesystemReader` + `FilesystemWriter` → `FilesystemOperator extends both`).

## What changes

Each entity-side repo contract gains a Reader / Writer pair. The existing combined interface still exists and extends both — drivers' impls don't change.

**New contracts** (all in `Vatly\Fluent\Contracts`):

| Combined (existing) | New Reader | New Writer |
|---|---|---|
| `CustomerRepositoryInterface` | `CustomerReader` (`findByVatlyId`, `findByVatlyIdOrFail`) | `CustomerWriter` (`save`) |
| `SubscriptionRepositoryInterface` | `SubscriptionReader` (`findByVatlyId`, `findByOwnerAndType`, `findAllByOwner`, `ownerHasActiveSubscription`) | `SubscriptionWriter` (`store`, `update`) |
| `OrderRepositoryInterface` | `OrderReader` (`findByVatlyId`, `findForOwnerOrFail`, `findAllByOwner`) | `OrderWriter` (`store`, `update`) |

`WebhookCallRepositoryInterface` is left as-is — has no read methods, splitting would create an empty interface for no benefit.

## Where the narrowing pays off

Consumers — including driver-side webhook reactions — typehint the narrowest role they actually need:

- A `SyncSubscriptionOnStarted`-style reaction that only persists state asks for `SubscriptionWriter`. It can't be coupled to query methods it doesn't use.
- A read-only admin / dashboard view asks for `SubscriptionReader`.
- The combined `*RepositoryInterface` is still there for the rare case where a class genuinely needs both. Driver-side wiring (and `Wiring` itself) keeps that combined hint to stay maximally permissive at the composition boundary.

## Internal narrowings landed in this PR

- `SubscriptionHandle::\$subscriptions` → `SubscriptionWriter` (only calls `update()`)
- `Billable::\$orders` → `OrderReader` (Billable never writes orders — webhook reactions own that path)
- `Billable::\$customers` → `CustomerWriter` (only calls `save()` during customer creation)
- `BillableFactory` matches Billable's narrower hints

Built-in webhook reactions (\`SyncSubscriptionOnStarted\`, \`CancelSubscriptionOnCanceled\`, \`StoreOrderOnPaid\`) keep the combined interface — they genuinely do find-then-store, so both sides are exercised.

## Test plan

- [x] `composer test` — 149/149 pass (no test changes needed; mocks of the combined interface satisfy the narrower role hints via standard variance)
- [x] `composer analyse` — clean

## Driver-side impact

None. Existing implementations of `*RepositoryInterface` automatically satisfy both Reader and Writer because they implement the combined. Drivers may *opt in* to typing their custom webhook reactions against the narrower roles in a follow-up — recommended but not required.
