### PR TITLE
refactor: VatlyException as marker interface + final concrete exceptions

### DIFF
--- a/src/Exceptions/CustomerAlreadyCreatedException.php
+++ b/src/Exceptions/CustomerAlreadyCreatedException.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
+use RuntimeException;
 use Vatly\Fluent\Contracts\BillableInterface;
 
-class CustomerAlreadyCreatedException extends VatlyException
+final class CustomerAlreadyCreatedException extends RuntimeException implements VatlyException
 {
     public static function exists(BillableInterface $owner): self
     {

--- a/src/Exceptions/FeatureUnavailableException.php
+++ b/src/Exceptions/FeatureUnavailableException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
-class FeatureUnavailableException extends VatlyException
+use RuntimeException;
+
+final class FeatureUnavailableException extends RuntimeException implements VatlyException
 {
     public static function notImplementedOnApi(): self
     {

--- a/src/Exceptions/IncompleteInformationException.php
+++ b/src/Exceptions/IncompleteInformationException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
-class IncompleteInformationException extends VatlyException
+use RuntimeException;
+
+final class IncompleteInformationException extends RuntimeException implements VatlyException
 {
     public static function noCheckoutItems(): self
     {

--- a/src/Exceptions/IncompleteWiring.php
+++ b/src/Exceptions/IncompleteWiring.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
+use RuntimeException;
+
 /**
  * Thrown when {@see \Vatly\Fluent\Vatly} is asked for a service whose
  * required dependency was not provided to the {@see \Vatly\Fluent\Wiring} DTO.
@@ -15,7 +17,7 @@ namespace Vatly\Fluent\Exceptions;
  * The exception names the missing dependency and the feature being requested
  * so the fix is mechanical: add the dependency to your Wiring construction.
  */
-class IncompleteWiring extends VatlyException
+final class IncompleteWiring extends RuntimeException implements VatlyException
 {
     public static function missing(string $dependency, string $forFeature): self
     {

--- a/src/Exceptions/InvalidCustomerException.php
+++ b/src/Exceptions/InvalidCustomerException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
-class InvalidCustomerException extends VatlyException
+use RuntimeException;
+
+final class InvalidCustomerException extends RuntimeException implements VatlyException
 {
     public static function notYetCreated(object $owner): self
     {

--- a/src/Exceptions/InvalidOrderException.php
+++ b/src/Exceptions/InvalidOrderException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
-class InvalidOrderException extends VatlyException
+use RuntimeException;
+
+final class InvalidOrderException extends RuntimeException implements VatlyException
 {
     public static function notFound(string $vatlyId): self
     {

--- a/src/Exceptions/InvalidWebhookSignatureException.php
+++ b/src/Exceptions/InvalidWebhookSignatureException.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
-class InvalidWebhookSignatureException extends VatlyException
+use RuntimeException;
+
+final class InvalidWebhookSignatureException extends RuntimeException implements VatlyException
 {
     public static function missingSignature(): self
     {

--- a/src/Exceptions/VatlyException.php
+++ b/src/Exceptions/VatlyException.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Exceptions;
 
-use Exception;
+use Throwable;
 
 /**
- * Base exception for all Vatly exceptions.
+ * Marker interface for all exceptions thrown by `vatly/vatly-fluent-php`.
+ *
+ * `catch (VatlyException $e)` catches every fluent-thrown exception
+ * regardless of subclass. Catch a concrete class (e.g.
+ * {@see InvalidCustomerException}) to target one failure mode. Each
+ * concrete is a `final class` extending one of PHP's SPL exception
+ * classes (typically `\RuntimeException` or `\InvalidArgumentException`)
+ * and implementing this marker.
+ *
+ * Pattern borrowed from `league/flysystem`'s `FilesystemException`.
  */
-abstract class VatlyException extends Exception
+interface VatlyException extends Throwable
 {
 }


### PR DESCRIPTION
> Borrowed from `league/flysystem`'s exception design: marker interface + final concrete classes.

## Why

Today \`VatlyException\` is an empty abstract class; concretes \`extends VatlyException\`. The "marker" idea (catch the umbrella, catch the specific) only half-works because the abstract is a class — it locks the concretes into a single inheritance slot they can't otherwise use, and offers nothing in return.

Switching to an interface is what flysystem does (\`FilesystemException extends Throwable\`, \`final class UnableToWriteFile extends RuntimeException implements FilesystemException\`). It gives consumers a clean two-axis catch surface and frees the concretes to inherit from semantically-meaningful SPL bases.

## What changes

| Before | After |
|---|---|
| \`abstract class VatlyException extends Exception\` | \`interface VatlyException extends Throwable\` |
| \`class CustomerAlreadyCreatedException extends VatlyException\` | \`final class CustomerAlreadyCreatedException extends RuntimeException implements VatlyException\` |
| \`class FeatureUnavailableException extends VatlyException\` | \`final class FeatureUnavailableException extends RuntimeException implements VatlyException\` |
| \`class IncompleteInformationException extends VatlyException\` | \`final class IncompleteInformationException extends RuntimeException implements VatlyException\` |
| \`class IncompleteWiring extends VatlyException\` | \`final class IncompleteWiring extends RuntimeException implements VatlyException\` |
| \`class InvalidCustomerException extends VatlyException\` | \`final class InvalidCustomerException extends RuntimeException implements VatlyException\` |
| \`class InvalidOrderException extends VatlyException\` | \`final class InvalidOrderException extends RuntimeException implements VatlyException\` |
| \`class InvalidWebhookSignatureException extends VatlyException\` | \`final class InvalidWebhookSignatureException extends RuntimeException implements VatlyException\` |

Named static constructors (\`InvalidOrderException::notFound(\$id)\` etc.) are unchanged.

## Consumer impact

| Pattern | Before | After |
|---|---|---|
| \`catch (VatlyException \$e)\` | catches all | still catches all (interface-typed catch works) |
| \`assertInstanceOf(VatlyException::class, \$e)\` | passes | still passes (instanceof against interface) |
| \`throw new VatlyException(...)\` | impossible (abstract) | impossible (interface) — unchanged |
| \`extends VatlyException\` from outside the package | possible | breaks |

No live consumers; the last bullet doesn't affect anyone.

## Test plan

- [x] \`composer test\` — 149/149 pass (no test changes needed; \`assertInstanceOf\` already works against the interface)
- [x] \`composer analyse\` — clean

## Future work

Once more failure modes get specific catch targets, we'll add new concretes alongside existing ones (e.g. \`UnableToCancelSubscription::forVatlyId(\$id, \$reason)\` when subscription cancellation grows specific error UX). The interface + final classes shape makes that additive.
