### PR TITLE
feat: WebhookReactionChain — variadic composite reaction (eventsauce-style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ In [src/Contracts](src/Contracts):
 - `WebhookCallRepositoryInterface` — webhook audit log
 - `EventDispatcherInterface` — fire domain events
 - `ConfigurationInterface` — API key, URL, version, webhook secret, redirect defaults
-- `WebhookReactionInterface` — extension point for adding your own webhook reactions
+- `WebhookReactionInterface` — extension point for adding your own webhook reactions. Compose multiple via `Webhooks\Reactions\WebhookReactionChain` (variadic constructor; the chain itself implements the same interface).
 
 ## Domain events
 

--- a/src/Webhooks/Reactions/WebhookReactionChain.php
+++ b/src/Webhooks/Reactions/WebhookReactionChain.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+
+/**
+ * A composite reaction that runs a list of inner reactions in order.
+ *
+ * Useful where the surrounding code wants exactly one
+ * {@see WebhookReactionInterface} but the driver needs to stack many —
+ * e.g. logging + audit + plugin-specific reactions. Each inner reaction's
+ * `supports()` is honored independently, so non-applicable reactions
+ * are skipped without affecting the rest.
+ *
+ * The chain itself `supports()` an event if *any* of its members do.
+ *
+ * Pattern borrowed from EventSauce's `MessageDispatcherChain`.
+ */
+final class WebhookReactionChain implements WebhookReactionInterface
+{
+    /** @var WebhookReactionInterface[] */
+    private array $reactions;
+
+    public function __construct(WebhookReactionInterface ...$reactions)
+    {
+        $this->reactions = $reactions;
+    }
+
+    public function supports(object $event): bool
+    {
+        foreach ($this->reactions as $reaction) {
+            if ($reaction->supports($event)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function handle(object $event): void
+    {
+        foreach ($this->reactions as $reaction) {
+            if ($reaction->supports($event)) {
+                $reaction->handle($event);
+            }
+        }
+    }
+}

--- a/tests/Webhooks/Reactions/WebhookReactionChainTest.php
+++ b/tests/Webhooks/Reactions/WebhookReactionChainTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use stdClass;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Webhooks\Reactions\WebhookReactionChain;
+
+class WebhookReactionChainTest extends TestCase
+{
+    public function test_chain_supports_event_when_any_member_does(): void
+    {
+        $event = new stdClass();
+
+        $supportingReaction = Mockery::mock(WebhookReactionInterface::class);
+        $supportingReaction->shouldReceive('supports')->with($event)->andReturn(true);
+
+        $nonSupportingReaction = Mockery::mock(WebhookReactionInterface::class);
+        $nonSupportingReaction->shouldReceive('supports')->with($event)->andReturn(false);
+
+        $chain = new WebhookReactionChain($nonSupportingReaction, $supportingReaction);
+
+        $this->assertTrue($chain->supports($event));
+    }
+
+    public function test_chain_does_not_support_event_when_no_members_do(): void
+    {
+        $event = new stdClass();
+
+        $a = Mockery::mock(WebhookReactionInterface::class);
+        $a->shouldReceive('supports')->with($event)->andReturn(false);
+
+        $b = Mockery::mock(WebhookReactionInterface::class);
+        $b->shouldReceive('supports')->with($event)->andReturn(false);
+
+        $chain = new WebhookReactionChain($a, $b);
+
+        $this->assertFalse($chain->supports($event));
+    }
+
+    public function test_handle_runs_supporting_members_in_order(): void
+    {
+        $event = new stdClass();
+        $sequence = [];
+
+        $a = Mockery::mock(WebhookReactionInterface::class);
+        $a->shouldReceive('supports')->with($event)->andReturn(true);
+        $a->shouldReceive('handle')->with($event)->andReturnUsing(function () use (&$sequence) {
+            $sequence[] = 'a';
+        });
+
+        $b = Mockery::mock(WebhookReactionInterface::class);
+        $b->shouldReceive('supports')->with($event)->andReturn(true);
+        $b->shouldReceive('handle')->with($event)->andReturnUsing(function () use (&$sequence) {
+            $sequence[] = 'b';
+        });
+
+        $chain = new WebhookReactionChain($a, $b);
+        $chain->handle($event);
+
+        $this->assertSame(['a', 'b'], $sequence);
+    }
+
+    public function test_handle_skips_non_supporting_members(): void
+    {
+        $event = new stdClass();
+
+        $supporting = Mockery::mock(WebhookReactionInterface::class);
+        $supporting->shouldReceive('supports')->with($event)->andReturn(true);
+        $supporting->shouldReceive('handle')->once()->with($event);
+
+        $nonSupporting = Mockery::mock(WebhookReactionInterface::class);
+        $nonSupporting->shouldReceive('supports')->with($event)->andReturn(false);
+        $nonSupporting->shouldNotReceive('handle');
+
+        $chain = new WebhookReactionChain($nonSupporting, $supporting);
+        $chain->handle($event);
+    }
+
+    public function test_empty_chain_is_inert(): void
+    {
+        $chain = new WebhookReactionChain();
+
+        $this->assertFalse($chain->supports(new stdClass()));
+        $chain->handle(new stdClass());  // no-op, no exception
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
> Borrowed from EventSauce's \`MessageDispatcherChain\`.

## What

A composite \`WebhookReactionInterface\` that wraps N other reactions and runs them in order. The chain implements the same interface it composes, so the surrounding code (\`WebhookProcessor\`, factories, etc.) keeps typehinting *one* reaction while drivers stack many underneath:

\`\`\`php
use Vatly\Fluent\Webhooks\Reactions\WebhookReactionChain;

new WebhookReactionChain(
    new LogEverythingReaction(\$logger),
    new MetricsReaction(\$statsd),
    new AssignMembershipLevelOnStarted(\$customerRepo),
);
\`\`\`

- \`supports(\$event)\` returns true if any member supports.
- \`handle(\$event)\` runs only supporting members, in declaration order.
- An empty chain is inert (no-op on \`handle()\`, \`supports()\` returns false).

## Why

\`WebhookProcessor\` already accepts an array of reactions, and the recent \`Wiring::\$additionalWebhookReactions\` extends that. The array works fine. The chain adds value when a driver wants to:

1. **Compose cross-cutting reactions** (logging, metrics, audit) ahead of plugin-specific ones without ad-hoc array-juggling at the call site.
2. **Pass a single first-class reaction collaborator** to something that only knows about \`WebhookReactionInterface\`. Today every consumer either takes \`array\` or a single reaction — uniform "one reaction" callers gain flexibility.
3. **Nest chains** — useful for testing or staged rollouts.

This is purely additive; nothing in the existing codebase changes shape. Drivers opt into the chain where it helps.

## Test plan

- [x] \`composer test\` — 154/154 pass (+5 new covering supports / handle / order / skipping non-supporting / empty chain)
- [x] \`composer analyse\` — clean
