### PR TITLE
feat(customers): $additionalPayload on createFor / createUnattributed

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,14 @@ $customer = $vatly->customers()->createFor(
 );
 // $customer->id is now bound to $user->id via your CustomerBindingRepository.
 
+// Forward extra create-customer API keys via $additionalPayload (locale,
+// metadata, or anything else the create-customer endpoint accepts).
+$customer = $vatly->customers()->createFor(
+    hostCustomerId:    (string) $user->id,
+    profile:           new CustomerProfile(email: $user->email, name: $user->name),
+    additionalPayload: ['locale' => 'nl_NL', 'metadata' => ['internal_id' => $user->id]],
+);
+
 // Look up later
 $existing = $vatly->customers()->findByHostCustomerId((string) $user->id);
 ```

--- a/src/CustomerService.php
+++ b/src/CustomerService.php
@@ -34,24 +34,35 @@ class CustomerService
      * `CustomerProfile` is ignored. Use {@see self::attribute()} to link
      * an existing Vatly customer to a host instead.
      *
+     * `$additionalPayload` keys are merged on top of the profile-derived
+     * payload sent to the API — pass things like `locale`, `metadata`,
+     * or any other field the create-customer endpoint accepts. Keys in
+     * `$additionalPayload` take precedence over the profile defaults.
+     *
+     * @param  array<string, mixed>  $additionalPayload  Extra create-customer API keys.
+     *
      * @throws CustomerAlreadyBoundException When the host customer id is already bound.
      */
-    public function createFor(string $hostCustomerId, CustomerProfile $profile): ApiCustomer
+    public function createFor(string $hostCustomerId, CustomerProfile $profile, array $additionalPayload = []): ApiCustomer
     {
         if (($existing = $this->bindings->vatlyCustomerIdFor($hostCustomerId)) !== null) {
             throw CustomerAlreadyBoundException::onCreate($hostCustomerId, $existing);
         }
 
-        $customer = $this->createCustomer->execute($profile->toPayload());
+        $customer = $this->createCustomer->execute(array_merge($profile->toPayload(), $additionalPayload));
         $this->bindings->bind($customer->id, $hostCustomerId);
 
         return $customer;
     }
 
-    /** Anonymous: create a Vatly customer with no host attribution. */
-    public function createUnattributed(CustomerProfile $profile): ApiCustomer
+    /**
+     * Anonymous: create a Vatly customer with no host attribution.
+     *
+     * @param  array<string, mixed>  $additionalPayload  Extra create-customer API keys (see {@see self::createFor()}).
+     */
+    public function createUnattributed(CustomerProfile $profile, array $additionalPayload = []): ApiCustomer
     {
-        $customer = $this->createCustomer->execute($profile->toPayload());
+        $customer = $this->createCustomer->execute(array_merge($profile->toPayload(), $additionalPayload));
         $this->bindings->record($customer->id);
 
         return $customer;

--- a/tests/CustomerServiceTest.php
+++ b/tests/CustomerServiceTest.php
@@ -81,6 +81,79 @@ class CustomerServiceTest extends TestCase
         $this->assertSame($apiCustomer, $result);
     }
 
+    public function test_create_for_forwards_additional_payload_keys_to_the_api(): void
+    {
+        $apiCustomer = $this->makeApiCustomer('cus_new');
+
+        $createCustomer = Mockery::mock(CreateCustomer::class);
+        $createCustomer->shouldReceive('execute')
+            ->once()
+            ->with([
+                'email' => 'host@example.test',
+                'name' => 'Host Name',
+                'locale' => 'nl_NL',
+                'metadata' => ['internal_id' => 42],
+            ])
+            ->andReturn($apiCustomer);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('vatlyCustomerIdFor')->with('host_1')->once()->andReturnNull();
+        $bindings->shouldReceive('bind')->with('cus_new', 'host_1')->once();
+
+        $customers = new CustomerService($createCustomer, Mockery::mock(GetCustomer::class), $bindings);
+        $profile = new CustomerProfile(email: 'host@example.test', name: 'Host Name');
+
+        $customers->createFor('host_1', $profile, [
+            'locale' => 'nl_NL',
+            'metadata' => ['internal_id' => 42],
+        ]);
+    }
+
+    public function test_create_for_additional_payload_overrides_profile_defaults(): void
+    {
+        $apiCustomer = $this->makeApiCustomer('cus_new');
+
+        $createCustomer = Mockery::mock(CreateCustomer::class);
+        // additionalPayload['email'] wins over profile.email
+        $createCustomer->shouldReceive('execute')
+            ->once()
+            ->with(['email' => 'override@example.test', 'name' => 'Host Name'])
+            ->andReturn($apiCustomer);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('vatlyCustomerIdFor')->andReturnNull();
+        $bindings->shouldReceive('bind');
+
+        $customers = new CustomerService($createCustomer, Mockery::mock(GetCustomer::class), $bindings);
+        $profile = new CustomerProfile(email: 'host@example.test', name: 'Host Name');
+
+        $customers->createFor('host_1', $profile, ['email' => 'override@example.test']);
+    }
+
+    public function test_create_unattributed_forwards_additional_payload_keys_to_the_api(): void
+    {
+        $apiCustomer = $this->makeApiCustomer('cus_anon');
+
+        $createCustomer = Mockery::mock(CreateCustomer::class);
+        $createCustomer->shouldReceive('execute')
+            ->once()
+            ->with([
+                'email' => 'anon@example.test',
+                'locale' => 'de_DE',
+            ])
+            ->andReturn($apiCustomer);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('record')->with('cus_anon')->once();
+
+        $customers = new CustomerService($createCustomer, Mockery::mock(GetCustomer::class), $bindings);
+
+        $customers->createUnattributed(
+            new CustomerProfile(email: 'anon@example.test'),
+            ['locale' => 'de_DE'],
+        );
+    }
+
     public function test_attribute_binds_when_host_is_unbound(): void
     {
         $bindings = Mockery::mock(CustomerBindingRepository::class);


### PR DESCRIPTION
## Summary

`CustomerService::createFor()` and `createUnattributed()` gain an optional `array \$additionalPayload = []` parameter merged on top of the `CustomerProfile`-derived payload before the API call. Lets callers forward arbitrary create-customer keys (`locale`, `metadata`, anything the endpoint accepts) through the helper instead of bypassing it.

## Why

PR #24 review on \`vatly-laravel\` flagged that the v0.7 → v0.8 trait refactor regressed \`\$user->createAsVatlyCustomer(\$options)\`: extra keys (e.g. \`locale\`, \`metadata\` per the package's own [docs/Customers.md](https://github.com/Vatly/vatly-laravel/blob/main/docs/Customers.md)) were silently dropped because \`CustomerProfile\` only models email / name / vatlyId. The fluent SDK has no other way to pass through extra create-customer keys without dropping out of the helper.

This patch restores the lossless path without bloating \`CustomerProfile\` itself — extras live in the parameter, the profile stays a tight VO.

## Precedence

\`\$additionalPayload\` keys win over \`\$profile->toPayload()\` keys on collision. The reasoning: callers passing an explicit \`email\` in \$additionalPayload almost always mean "override the host default."

## Test plan

- [x] \`composer test\` — 160 / 438 PASS (3 new tests covering: pass-through, override precedence, createUnattributed variant)
- [x] \`composer analyse\` — clean
- [x] BC for the existing happy path: \`createFor(\$hostId, \$profile)\` without \$additionalPayload behaves identically to before.
