### PR TITLE
feat: enrich Store*Data with metadata; nullable store(); subscription status

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,21 @@ Methods that need persistence or event dispatching (`customers()`, `webhookProce
 
 ## Step-by-step — building a framework driver
 
-A driver is a thin glue package (e.g. `vatly-laravel`) that supplies fluent with concrete implementations of its contracts and exposes the API surface idiomatically for its framework. Steps:
+A driver is a thin glue package (e.g. `vatly-laravel`) that supplies fluent with concrete implementations of its contracts and exposes the API surface idiomatically for its framework.
+
+### Webhook pipeline at a glance
+
+For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in reaction that calls back into your repos. A driver author only needs to implement the repo methods — the wiring is fixed:
+
+| Vatly event              | Dispatched event class                                            | Built-in reaction              | Repo method(s) called                                |
+|--------------------------|-------------------------------------------------------------------|--------------------------------|------------------------------------------------------|
+| `order.paid`             | `OrderPaid`                                                       | `StoreOrderOnPaid`             | `OrderWriter::store` (new) / `OrderWriter::update` (existing) |
+| `subscription.started`   | `SubscriptionStarted`                                             | `SyncSubscriptionOnStarted`    | `SubscriptionWriter::store` (new) / `::update` (existing) |
+| `subscription.cancelled` | `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update`                         |
+
+Both `OrderWriter::store` and `SubscriptionWriter::store` may return `null` if your driver can't route the data (see the adapter recipe below). Built-in reactions tolerate null — `SyncSubscriptionOnStarted` skips its follow-up `LocalSubscriptionCreated` dispatch when store returns null.
+
+`additionalWebhookReactions` (on `WebhookProcessorFactory::create`) lets you append driver-specific reactions without losing the built-ins.
 
 ### 1. Implement `ConfigurationInterface`
 
@@ -226,6 +240,54 @@ class Order implements OrderInterface
 }
 ```
 
+<details>
+<summary><strong>What if my host already has Order / Subscription tables?</strong> — bolting onto an ecosystem plugin (FluentCart, PMPro, MemberPress, EDD…)</summary>
+
+This is the common case for ecosystem-plugin drivers: the host already models orders and subscriptions, and you can't (or shouldn't) add a parallel set. **Adapt, don't duplicate.** Write a thin wrapper that implements fluent's interface against the host's record:
+
+```php
+use Vatly\Fluent\Contracts\OrderInterface;
+
+final class FluentCartOrder implements OrderInterface
+{
+    public function __construct(private OrderTransaction $txn) {}
+
+    public function getVatlyId(): string       { return $this->txn->vatly_id; }
+    public function getStatus(): string        { return $this->txn->status; }
+    public function getInvoiceNumber(): ?string{ return $this->txn->invoice_no; }
+    public function getTotal(): int            { return (int) $this->txn->total; }
+    public function getCurrency(): string      { return $this->txn->currency; }
+    public function getPaymentMethod(): ?string{ return $this->txn->payment_method; }
+    public function isPaid(): bool             { return $this->txn->status === 'paid'; }
+}
+```
+
+Your `OrderRepositoryInterface::store` then routes the incoming `StoreOrderData` to the right host record — typically by reading `$data->metadata` to find a host-side id the original checkout stamped onto the Vatly order. When the routing legitimately doesn't match (metadata is missing, host record was deleted, etc.), return `null`:
+
+```php
+public function store(StoreOrderData $data): ?OrderInterface
+{
+    $txnId = $data->metadata['fluentcart_transaction_id'] ?? null;
+    if ($txnId === null) {
+        return null; // anonymous / audit-only — nothing to attach to
+    }
+
+    $txn = OrderTransaction::find($txnId);
+    if ($txn === null) {
+        return null;
+    }
+
+    $txn->vatly_id = $data->vatlyId;
+    $txn->save();
+
+    return new FluentCartOrder($txn);
+}
+```
+
+Same shape for `SubscriptionRepositoryInterface::store`. Built-in reactions tolerate null returns.
+
+</details>
+
 ### 5. Implement the three repository contracts
 
 Each entity-side contract has three methods. See [src/Contracts](src/Contracts) for signatures.
@@ -256,6 +318,8 @@ public function store(StoreSubscriptionData $data): SubscriptionInterface
 ```
 
 > Each entity-side repo is also exposed as a Reader / Writer pair (`SubscriptionReader` + `SubscriptionWriter`, etc.). The combined interface extends both. Typehint the narrowest role you actually need.
+
+> **If your repo needs to call back into the SDK** — e.g. `GetOrder` to read fresh metadata from a partial webhook payload — don't inject `Vatly` directly. `Vatly` is being constructed *with* your repo, so a direct dependency is circular. Instead, inject a lazy resolver (your host's container, a singleton accessor, or a closure that returns `Vatly`) and resolve at call time.
 
 ### 6. Implement `EventDispatcherInterface`
 

--- a/src/Contracts/OrderWriter.php
+++ b/src/Contracts/OrderWriter.php
@@ -17,8 +17,12 @@ interface OrderWriter
 {
     /**
      * Store a new order from Vatly.
+     *
+     * Returns `null` when the driver legitimately cannot route the store
+     * (e.g. the metadata doesn't match any host record the driver knows
+     * how to persist against). Built-in reactions tolerate null.
      */
-    public function store(StoreOrderData $data): OrderInterface;
+    public function store(StoreOrderData $data): ?OrderInterface;
 
     /**
      * Update an existing order from Vatly.

--- a/src/Contracts/SubscriptionWriter.php
+++ b/src/Contracts/SubscriptionWriter.php
@@ -18,8 +18,13 @@ interface SubscriptionWriter
 {
     /**
      * Store a new subscription from Vatly.
+     *
+     * Returns `null` when the driver legitimately cannot route the store
+     * (e.g. the metadata doesn't match any host record the driver knows
+     * how to persist against). Built-in reactions tolerate null and skip
+     * any follow-up dispatches that depend on a stored entity.
      */
-    public function store(StoreSubscriptionData $data): SubscriptionInterface;
+    public function store(StoreSubscriptionData $data): ?SubscriptionInterface;
 
     /**
      * Update an existing subscription from Vatly.

--- a/src/Data/StoreOrderData.php
+++ b/src/Data/StoreOrderData.php
@@ -24,5 +24,7 @@ class StoreOrderData
         public ?int $subtotal = null,
         public ?TaxSummary $taxSummary = null,
         public ?string $hostCustomerId = null,
+        /** @var array<string, mixed>|null */
+        public ?array $metadata = null,
     ) {}
 }

--- a/src/Data/UpdateOrderData.php
+++ b/src/Data/UpdateOrderData.php
@@ -21,5 +21,7 @@ class UpdateOrderData
         public ?string $paymentMethod = null,
         public ?int $subtotal = null,
         public ?TaxSummary $taxSummary = null,
+        /** @var array<string, mixed>|null */
+        public ?array $metadata = null,
     ) {}
 }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -19,5 +19,11 @@ class UpdateSubscriptionData
         public ?int $quantity = null,
         public ?DateTimeInterface $endsAt = null,
         public bool $clearEndsAt = false,
+        /**
+         * Raw Vatly status (e.g. "trialing", "active", "past_due"). Passed
+         * through verbatim — drivers are responsible for mapping to their
+         * host's status vocabulary. Null means "no status change".
+         */
+        public ?string $status = null,
     ) {}
 }

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -30,6 +30,8 @@ class OrderPaid
         public string $currency,
         public ?string $invoiceNumber,
         public ?string $paymentMethod,
+        /** @var array<string, mixed>|null */
+        public ?array $metadata = null,
     ) {
         //
     }
@@ -45,6 +47,31 @@ class OrderPaid
             currency: $order->total->currency,
             invoiceNumber: $order->invoiceNumber,
             paymentMethod: $order->paymentMethod,
+            metadata: self::normalizeMetadata($order->metadata),
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function normalizeMetadata(mixed $metadata): ?array
+    {
+        if ($metadata === null) {
+            return null;
+        }
+
+        if (is_array($metadata)) {
+            /** @var array<string, mixed> $metadata */
+            return $metadata;
+        }
+
+        if (is_object($metadata)) {
+            /** @var array<string, mixed> $decoded */
+            $decoded = (array) json_decode((string) json_encode($metadata), true);
+
+            return $decoded;
+        }
+
+        return null;
     }
 }

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -40,6 +40,7 @@ class StoreOrderOnPaid implements WebhookReactionInterface
                 paymentMethod: $event->paymentMethod,
                 subtotal: $event->subtotal,
                 taxSummary: $event->taxSummary,
+                metadata: $event->metadata,
             ));
 
             return;
@@ -59,6 +60,7 @@ class StoreOrderOnPaid implements WebhookReactionInterface
             subtotal: $event->subtotal,
             taxSummary: $event->taxSummary,
             hostCustomerId: $hostCustomerId,
+            metadata: $event->metadata,
         ));
     }
 }

--- a/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
+++ b/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
@@ -57,6 +57,10 @@ class SyncSubscriptionOnStarted implements WebhookReactionInterface
             hostCustomerId: $hostCustomerId,
         ));
 
+        if ($subscription === null) {
+            return;
+        }
+
         $this->dispatcher->dispatch(new LocalSubscriptionCreated($subscription));
     }
 }

--- a/tests/Events/OrderPaidTest.php
+++ b/tests/Events/OrderPaidTest.php
@@ -96,5 +96,44 @@ class OrderPaidTest extends TestCase
         $this->assertNull($event->invoiceNumber);
         $this->assertNull($event->paymentMethod);
         $this->assertCount(0, $event->taxSummary);
+        $this->assertNull($event->metadata);
+    }
+
+    public function test_it_carries_metadata_from_api_order_array(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->metadata = ['fluentcart_transaction_id' => 'tx_42', 'source' => 'checkout'];
+
+        $event = OrderPaid::fromApiOrder($apiOrder);
+
+        $this->assertSame(
+            ['fluentcart_transaction_id' => 'tx_42', 'source' => 'checkout'],
+            $event->metadata,
+        );
+    }
+
+    public function test_it_normalizes_object_metadata_from_api_order(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->metadata = (object) ['fluentcart_transaction_id' => 'tx_42'];
+
+        $event = OrderPaid::fromApiOrder($apiOrder);
+
+        $this->assertSame(['fluentcart_transaction_id' => 'tx_42'], $event->metadata);
+    }
+
+    private function makeApiOrder(): ApiOrder
+    {
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_meta';
+        $apiOrder->customerId = 'cus_meta';
+        $apiOrder->total = new Money('EUR', '10.00');
+        $apiOrder->subtotal = new Money('EUR', '8.26');
+        $apiOrder->invoiceNumber = null;
+        $apiOrder->paymentMethod = null;
+        $apiOrder->status = 'paid';
+        $apiOrder->taxSummary = new TaxSummaryCollection([]);
+
+        return $apiOrder;
     }
 }

--- a/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
@@ -94,6 +94,43 @@ class StoreOrderOnPaidTest extends TestCase
         $reaction->handle($event);
     }
 
+    public function test_it_plumbs_metadata_through_store_and_update_paths(): void
+    {
+        $metadata = ['fluentcart_transaction_id' => 'tx_42'];
+        $event = new OrderPaid(
+            customerId: 'cus_1',
+            orderId: 'ord_1',
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: 'INV-001',
+            paymentMethod: 'card',
+            metadata: $metadata,
+        );
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(
+            fn (StoreOrderData $data) => $data->metadata === $metadata,
+        ))->andReturn(Mockery::mock(OrderInterface::class));
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->andReturn(null);
+        $bindings->shouldReceive('record')->once();
+
+        (new StoreOrderOnPaid($repo, $bindings))->handle($event);
+
+        $existing = Mockery::mock(OrderInterface::class);
+        $updateRepo = Mockery::mock(OrderRepositoryInterface::class);
+        $updateRepo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
+        $updateRepo->shouldReceive('update')->once()->with($existing, Mockery::on(
+            fn (UpdateOrderData $data) => $data->metadata === $metadata,
+        ))->andReturn($existing);
+
+        (new StoreOrderOnPaid($updateRepo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
+    }
+
     private function makeEvent(?TaxSummary $taxSummary = null): OrderPaid
     {
         return new OrderPaid(

--- a/tests/Webhooks/Reactions/SyncSubscriptionOnStartedTest.php
+++ b/tests/Webhooks/Reactions/SyncSubscriptionOnStartedTest.php
@@ -97,6 +97,23 @@ class SyncSubscriptionOnStartedTest extends TestCase
         $reaction->handle(new SubscriptionStarted('cus_1', 'sub_1', 'plan_1', 'default', 'Monthly', 1));
     }
 
+    public function test_it_does_not_dispatch_local_subscription_created_when_store_returns_null(): void
+    {
+        $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->andReturnNull();
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->with('cus_1')->once()->andReturnNull();
+        $bindings->shouldReceive('record')->with('cus_1')->once();
+
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        $reaction = new SyncSubscriptionOnStarted($repo, $bindings, $dispatcher);
+        $reaction->handle(new SubscriptionStarted('cus_1', 'sub_1', 'plan_1', 'default', 'Monthly', 1));
+    }
+
     public function test_it_updates_an_existing_subscription_without_consulting_bindings(): void
     {
         $existing = Mockery::mock(SubscriptionInterface::class);


### PR DESCRIPTION
Closes #42.

Tactical v0.8 follow-up. Each item below closes a friction point surfaced while migrating [vatly-fluentcart-wp](https://github.com/vatly/vatly-fluentcart-wp) to v0.8 — together they were forcing an extra API round-trip, a synthetic wrapper, or a custom reaction in the downstream driver.

## Summary

- **Orders carry `metadata` end-to-end.** `Order::$metadata` from the upstream API resource is now plumbed through `OrderPaid` → `StoreOrderData` / `UpdateOrderData` → the built-in `StoreOrderOnPaid` reaction. Drivers no longer have to issue a second `GetOrder` to read host-side ids the original checkout stamped on the Vatly order. Handles both array and `stdClass` shapes of the untyped upstream field.
- **`store()` is nullable on both writers.** `OrderWriter::store(): ?OrderInterface` and `SubscriptionWriter::store(): ?SubscriptionInterface`. Drivers can return `null` when routing legitimately fails (metadata doesn't match a host record) instead of fabricating a synthetic detached wrapper just to satisfy the type. `SyncSubscriptionOnStarted` skips its follow-up `LocalSubscriptionCreated` dispatch when store returns null — no local subscription, no event.
- **`UpdateSubscriptionData::$status` added.** Raw Vatly status passed through; drivers map to their host vocabulary. Lets reactions express transitions like `trialing → active` without a manual repo update outside the reaction path.

## README additions

- Event → reaction → repo-method table at the top of \"Step-by-step — building a framework driver\". Single-glance discovery of which repo method each Vatly event ends up calling, including the nullable behavior.
- `<details>` recipe under step 4: **\"What if my host already has Order / Subscription tables?\"** — sanctions the adapter pattern (wrap the host's record rather than build a parallel model) with a concrete `store(): ?OrderInterface` example showing metadata-based routing and the null-on-miss case. This is the common ecosystem-plugin adoption mode (FluentCart, PMPro, MemberPress, EDD).
- Three-line note in step 5: if a repo needs to call back into the SDK (e.g. `GetOrder` for fresh metadata), inject a lazy resolver — don't inject `Vatly` directly. `Vatly` is being constructed with your repo, so it'd be circular.

## Breaking change consideration

`store()` returning `?T` instead of `T` is technically a contract widening — existing implementations that already return a concrete `OrderInterface` / `SubscriptionInterface` keep working unchanged. New implementations gain the option to return `null`. Documented as the sanctioned pattern in the new recipe.

## Deferred (out of scope)

Captured in conversation but intentionally not in this PR:

- Subscription-side `metadata` — needs upstream `vatly-api-php` decision (resource currently has no `metadata` field; `subscription.started` doesn't do an enrichment GET).
- Driver-testing recipe — fixtures / `WebhookProcessorTester` helper / raw-payload generators.
- `UPGRADING.md` — should land before 1.0.
- Non-ORM (raw `\$wpdb`) driver example — relevant when PMPro / MemberPress integrations land.

## Test plan

- [x] `vendor/bin/phpunit` — 161 tests, 445 assertions, all passing
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] New tests: `OrderPaidTest` covers `metadata` plumbing from API resource (both array and `stdClass` shapes); `StoreOrderOnPaidTest` covers `metadata` flowing through both store and update paths; `SyncSubscriptionOnStartedTest` covers the null-return-suppresses-dispatch case
- [ ] Reviewer to confirm the README adapter recipe matches the intended downstream usage shape
