### PR TITLE
feat(webhooks): typed PaymentFailed event for payment.failed

### DIFF
--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -24,6 +24,7 @@ class OrderPaid
     public function __construct(
         public string $customerId,
         public string $orderId,
+        public string $status,
         public int $total,
         public int $subtotal,
         public TaxSummary $taxSummary,
@@ -41,6 +42,7 @@ class OrderPaid
         return new self(
             customerId: $order->customerId ?? '',
             orderId: $order->id,
+            status: $order->status,
             total: Money::fromApiMoneyToCents($order->total),
             subtotal: Money::fromApiMoneyToCents($order->subtotal),
             taxSummary: TaxSummary::fromApiResource($order->taxSummary),

--- a/src/Events/PaymentFailed.php
+++ b/src/Events/PaymentFailed.php
@@ -29,6 +29,7 @@ class PaymentFailed
     public function __construct(
         public string $customerId,
         public string $orderId,
+        public string $status,
         public int $total,
         public int $subtotal,
         public TaxSummary $taxSummary,
@@ -46,6 +47,7 @@ class PaymentFailed
         return new self(
             customerId: $order->customerId ?? '',
             orderId: $order->id,
+            status: $order->status,
             total: Money::fromApiMoneyToCents($order->total),
             subtotal: Money::fromApiMoneyToCents($order->subtotal),
             taxSummary: TaxSummary::fromApiResource($order->taxSummary),

--- a/src/Events/PaymentFailed.php
+++ b/src/Events/PaymentFailed.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Event representing a failed payment attempt against an order at Vatly —
+ * typically the start of dunning.
+ *
+ * The webhook is order-scoped; consumers that need to identify the affected
+ * subscription should resolve it via their own customer/subscription map
+ * (the same pattern as for renewal `order.paid`).
+ *
+ * Carries the full order shape (mirroring {@see OrderPaid}) so consumers can
+ * surface failure details without a follow-up API call. The webhook payload
+ * itself is sparse; the WebhookEventFactory enriches via `GetOrder`.
+ *
+ * @immutable
+ */
+class PaymentFailed
+{
+    public const VATLY_EVENT_NAME = 'payment.failed';
+
+    public function __construct(
+        public string $customerId,
+        public string $orderId,
+        public int $total,
+        public int $subtotal,
+        public TaxSummary $taxSummary,
+        public string $currency,
+        public ?string $invoiceNumber,
+        public ?string $paymentMethod,
+        /** @var array<string, mixed>|null */
+        public ?array $metadata = null,
+    ) {
+        //
+    }
+
+    public static function fromApiOrder(ApiOrder $order): self
+    {
+        return new self(
+            customerId: $order->customerId ?? '',
+            orderId: $order->id,
+            total: Money::fromApiMoneyToCents($order->total),
+            subtotal: Money::fromApiMoneyToCents($order->subtotal),
+            taxSummary: TaxSummary::fromApiResource($order->taxSummary),
+            currency: $order->total->currency,
+            invoiceNumber: $order->invoiceNumber,
+            paymentMethod: $order->paymentMethod,
+            metadata: self::normalizeMetadata($order->metadata),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function normalizeMetadata(mixed $metadata): ?array
+    {
+        if ($metadata === null) {
+            return null;
+        }
+
+        if (is_array($metadata)) {
+            /** @var array<string, mixed> $metadata */
+            return $metadata;
+        }
+
+        if (is_object($metadata)) {
+            /** @var array<string, mixed> $decoded */
+            $decoded = (array) json_decode((string) json_encode($metadata), true);
+
+            return $decoded;
+        }
+
+        return null;
+    }
+}

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -33,7 +33,7 @@ class StoreOrderOnPaid implements WebhookReactionInterface
 
         if ($existing !== null) {
             $this->orders->update($existing, new UpdateOrderData(
-                status: 'paid',
+                status: $event->status,
                 total: $event->total,
                 currency: $event->currency,
                 invoiceNumber: $event->invoiceNumber,
@@ -58,7 +58,7 @@ class StoreOrderOnPaid implements WebhookReactionInterface
         $this->orders->store(new StoreOrderData(
             vatlyId: $event->orderId,
             customerId: $event->customerId,
-            status: 'paid',
+            status: $event->status,
             total: $event->total,
             currency: $event->currency,
             invoiceNumber: $event->invoiceNumber,

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -46,8 +46,14 @@ class StoreOrderOnPaid implements WebhookReactionInterface
             return;
         }
 
-        $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
-        $this->bindings->record($event->customerId);
+        // Order may be unattributed (no Vatly customer id) — skip bindings rather
+        // than write/lookup against an empty string, which would either create an
+        // invalid binding row or trip a non-empty-id constraint downstream.
+        $hostCustomerId = null;
+        if ($event->customerId !== '') {
+            $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
+            $this->bindings->record($event->customerId);
+        }
 
         $this->orders->store(new StoreOrderData(
             vatlyId: $event->orderId,

--- a/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Data\StoreOrderData;
+use Vatly\Fluent\Data\UpdateOrderData;
+use Vatly\Fluent\Events\PaymentFailed;
+
+/**
+ * Mirrors {@see StoreOrderOnPaid}: ensures the local order row reflects the
+ * upstream `payment.failed` outcome (status `'failed'`). Without this, a
+ * driver using the fixed wiring would leave previously-paid renewal orders
+ * looking paid locally, and never store a first-time order that fails.
+ *
+ * @immutable
+ */
+class StoreOrderOnPaymentFailed implements WebhookReactionInterface
+{
+    public function __construct(
+        private OrderRepositoryInterface $orders,
+        private CustomerBindingRepository $bindings,
+    ) {}
+
+    public function supports(object $event): bool
+    {
+        return $event instanceof PaymentFailed;
+    }
+
+    public function handle(object $event): void
+    {
+        /** @var PaymentFailed $event */
+        $existing = $this->orders->findByVatlyId($event->orderId);
+
+        if ($existing !== null) {
+            $this->orders->update($existing, new UpdateOrderData(
+                status: 'failed',
+                total: $event->total,
+                currency: $event->currency,
+                invoiceNumber: $event->invoiceNumber,
+                paymentMethod: $event->paymentMethod,
+                subtotal: $event->subtotal,
+                taxSummary: $event->taxSummary,
+                metadata: $event->metadata,
+            ));
+
+            return;
+        }
+
+        $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
+        $this->bindings->record($event->customerId);
+
+        $this->orders->store(new StoreOrderData(
+            vatlyId: $event->orderId,
+            customerId: $event->customerId,
+            status: 'failed',
+            total: $event->total,
+            currency: $event->currency,
+            invoiceNumber: $event->invoiceNumber,
+            paymentMethod: $event->paymentMethod,
+            subtotal: $event->subtotal,
+            taxSummary: $event->taxSummary,
+            hostCustomerId: $hostCustomerId,
+            metadata: $event->metadata,
+        ));
+    }
+}

--- a/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
@@ -13,9 +13,11 @@ use Vatly\Fluent\Events\PaymentFailed;
 
 /**
  * Mirrors {@see StoreOrderOnPaid}: ensures the local order row reflects the
- * upstream `payment.failed` outcome (status `'failed'`). Without this, a
- * driver using the fixed wiring would leave previously-paid renewal orders
- * looking paid locally, and never store a first-time order that fails.
+ * upstream order state after a `payment.failed` webhook. The persisted status
+ * is whatever Vatly's enriched Order resource currently reports (typically
+ * `pending` during dunning) — we deliberately don't synthesise a
+ * driver-specific status like `'failed'`, so `OrderInterface::getStatus()`
+ * stays a faithful mirror of upstream.
  *
  * @immutable
  */
@@ -38,7 +40,7 @@ class StoreOrderOnPaymentFailed implements WebhookReactionInterface
 
         if ($existing !== null) {
             $this->orders->update($existing, new UpdateOrderData(
-                status: 'failed',
+                status: $event->status,
                 total: $event->total,
                 currency: $event->currency,
                 invoiceNumber: $event->invoiceNumber,
@@ -63,7 +65,7 @@ class StoreOrderOnPaymentFailed implements WebhookReactionInterface
         $this->orders->store(new StoreOrderData(
             vatlyId: $event->orderId,
             customerId: $event->customerId,
-            status: 'failed',
+            status: $event->status,
             total: $event->total,
             currency: $event->currency,
             invoiceNumber: $event->invoiceNumber,

--- a/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
@@ -51,8 +51,14 @@ class StoreOrderOnPaymentFailed implements WebhookReactionInterface
             return;
         }
 
-        $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
-        $this->bindings->record($event->customerId);
+        // Order may be unattributed (no Vatly customer id) — skip bindings rather
+        // than write/lookup against an empty string, which would either create an
+        // invalid binding row or trip a non-empty-id constraint downstream.
+        $hostCustomerId = null;
+        if ($event->customerId !== '') {
+            $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
+            $this->bindings->record($event->customerId);
+        }
 
         $this->orders->store(new StoreOrderData(
             vatlyId: $event->orderId,

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -7,6 +7,7 @@ namespace Vatly\Fluent\Webhooks;
 use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
 use Vatly\Fluent\Events\SubscriptionStarted;
@@ -24,11 +25,11 @@ class WebhookEventFactory
     /**
      * Create a typed event from a raw webhook.
      *
-     * For `order.paid` the factory performs a follow-up API GET so the
-     * dispatched event carries the full tax breakdown — webhook payloads
-     * themselves only include gross total.
+     * For order-scoped events (`order.paid`, `payment.failed`) the factory
+     * performs a follow-up API GET so the dispatched event carries the full
+     * tax breakdown — webhook payloads themselves only include gross total.
      *
-     * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|UnsupportedWebhookReceived
+     * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|PaymentFailed|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
@@ -37,6 +38,7 @@ class WebhookEventFactory
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
             OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->entityId)),
+            PaymentFailed::VATLY_EVENT_NAME => PaymentFailed::fromApiOrder($this->getOrder->execute($webhook->entityId)),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
@@ -76,6 +78,7 @@ class WebhookEventFactory
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME,
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME,
             OrderPaid::VATLY_EVENT_NAME,
+            PaymentFailed::VATLY_EVENT_NAME,
         ];
     }
 

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -14,6 +14,7 @@ use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
 
 class WebhookProcessorFactory
@@ -45,6 +46,7 @@ class WebhookProcessorFactory
                 new SyncSubscriptionOnStarted($subscriptions, $bindings, $dispatcher),
                 new CancelSubscriptionOnCanceled($subscriptions),
                 new StoreOrderOnPaid($orders, $bindings),
+                new StoreOrderOnPaymentFailed($orders, $bindings),
                 ...$additionalReactions,
             ],
         );

--- a/tests/Events/OrderPaidTest.php
+++ b/tests/Events/OrderPaidTest.php
@@ -25,6 +25,7 @@ class OrderPaidTest extends TestCase
         $event = new OrderPaid(
             customerId: 'cus_123',
             orderId: 'ord_456',
+            status: 'paid',
             total: 9900,
             subtotal: 8182,
             taxSummary: TaxSummary::empty(),
@@ -35,6 +36,7 @@ class OrderPaidTest extends TestCase
 
         $this->assertSame('cus_123', $event->customerId);
         $this->assertSame('ord_456', $event->orderId);
+        $this->assertSame('paid', $event->status);
         $this->assertSame(9900, $event->total);
         $this->assertSame(8182, $event->subtotal);
         $this->assertCount(0, $event->taxSummary);
@@ -64,6 +66,7 @@ class OrderPaidTest extends TestCase
 
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('paid', $event->status);
         $this->assertSame(4999, $event->total);
         $this->assertSame(4131, $event->subtotal);
         $this->assertSame('USD', $event->currency);
@@ -90,6 +93,7 @@ class OrderPaidTest extends TestCase
 
         $this->assertSame('', $event->customerId);
         $this->assertSame('ord_789', $event->orderId);
+        $this->assertSame('paid', $event->status);
         $this->assertSame(1500, $event->total);
         $this->assertSame(1240, $event->subtotal);
         $this->assertSame('GBP', $event->currency);

--- a/tests/Events/PaymentFailedTest.php
+++ b/tests/Events/PaymentFailedTest.php
@@ -25,6 +25,7 @@ class PaymentFailedTest extends TestCase
         $event = new PaymentFailed(
             customerId: 'cus_123',
             orderId: 'ord_456',
+            status: 'pending',
             total: 9900,
             subtotal: 8182,
             taxSummary: TaxSummary::empty(),
@@ -35,6 +36,7 @@ class PaymentFailedTest extends TestCase
 
         $this->assertSame('cus_123', $event->customerId);
         $this->assertSame('ord_456', $event->orderId);
+        $this->assertSame('pending', $event->status);
         $this->assertSame(9900, $event->total);
         $this->assertSame(8182, $event->subtotal);
         $this->assertCount(0, $event->taxSummary);
@@ -52,7 +54,7 @@ class PaymentFailedTest extends TestCase
         $apiOrder->subtotal = new Money('USD', '41.31');
         $apiOrder->invoiceNumber = 'INV-2024-002';
         $apiOrder->paymentMethod = 'ideal';
-        $apiOrder->status = 'open';
+        $apiOrder->status = 'pending';
         $apiOrder->taxSummary = new TaxSummaryCollection([
             [
                 'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
@@ -64,6 +66,7 @@ class PaymentFailedTest extends TestCase
 
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('pending', $event->status);
         $this->assertSame(4999, $event->total);
         $this->assertSame(4131, $event->subtotal);
         $this->assertSame('USD', $event->currency);
@@ -83,13 +86,14 @@ class PaymentFailedTest extends TestCase
         $apiOrder->subtotal = new Money('GBP', '12.40');
         $apiOrder->invoiceNumber = null;
         $apiOrder->paymentMethod = null;
-        $apiOrder->status = 'open';
+        $apiOrder->status = 'pending';
         $apiOrder->taxSummary = new TaxSummaryCollection([]);
 
         $event = PaymentFailed::fromApiOrder($apiOrder);
 
         $this->assertSame('', $event->customerId);
         $this->assertSame('ord_789', $event->orderId);
+        $this->assertSame('pending', $event->status);
         $this->assertSame(1500, $event->total);
         $this->assertSame(1240, $event->subtotal);
         $this->assertSame('GBP', $event->currency);
@@ -131,7 +135,7 @@ class PaymentFailedTest extends TestCase
         $apiOrder->subtotal = new Money('EUR', '8.26');
         $apiOrder->invoiceNumber = null;
         $apiOrder->paymentMethod = null;
-        $apiOrder->status = 'open';
+        $apiOrder->status = 'pending';
         $apiOrder->taxSummary = new TaxSummaryCollection([]);
 
         return $apiOrder;

--- a/tests/Events/PaymentFailedTest.php
+++ b/tests/Events/PaymentFailedTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Mockery;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Events\PaymentFailed;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+
+class PaymentFailedTest extends TestCase
+{
+    public function test_it_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('payment.failed', PaymentFailed::VATLY_EVENT_NAME);
+    }
+
+    public function test_it_can_be_instantiated_with_all_properties(): void
+    {
+        $event = new PaymentFailed(
+            customerId: 'cus_123',
+            orderId: 'ord_456',
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: 'INV-2024-001',
+            paymentMethod: 'credit_card',
+        );
+
+        $this->assertSame('cus_123', $event->customerId);
+        $this->assertSame('ord_456', $event->orderId);
+        $this->assertSame(9900, $event->total);
+        $this->assertSame(8182, $event->subtotal);
+        $this->assertCount(0, $event->taxSummary);
+        $this->assertSame('EUR', $event->currency);
+        $this->assertSame('INV-2024-001', $event->invoiceNumber);
+        $this->assertSame('credit_card', $event->paymentMethod);
+    }
+
+    public function test_it_builds_from_api_order_resource_with_tax_breakdown(): void
+    {
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_123';
+        $apiOrder->customerId = 'cus_456';
+        $apiOrder->total = new Money('USD', '49.99');
+        $apiOrder->subtotal = new Money('USD', '41.31');
+        $apiOrder->invoiceNumber = 'INV-2024-002';
+        $apiOrder->paymentMethod = 'ideal';
+        $apiOrder->status = 'open';
+        $apiOrder->taxSummary = new TaxSummaryCollection([
+            [
+                'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                'amount' => ['currency' => 'USD', 'value' => '8.68'],
+            ],
+        ]);
+
+        $event = PaymentFailed::fromApiOrder($apiOrder);
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame(4999, $event->total);
+        $this->assertSame(4131, $event->subtotal);
+        $this->assertSame('USD', $event->currency);
+        $this->assertSame('INV-2024-002', $event->invoiceNumber);
+        $this->assertSame('ideal', $event->paymentMethod);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame(868, $event->taxSummary->items[0]->amount);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
+    }
+
+    public function test_it_builds_from_api_order_with_no_customer_or_invoice(): void
+    {
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_789';
+        $apiOrder->customerId = null;
+        $apiOrder->total = new Money('GBP', '15.00');
+        $apiOrder->subtotal = new Money('GBP', '12.40');
+        $apiOrder->invoiceNumber = null;
+        $apiOrder->paymentMethod = null;
+        $apiOrder->status = 'open';
+        $apiOrder->taxSummary = new TaxSummaryCollection([]);
+
+        $event = PaymentFailed::fromApiOrder($apiOrder);
+
+        $this->assertSame('', $event->customerId);
+        $this->assertSame('ord_789', $event->orderId);
+        $this->assertSame(1500, $event->total);
+        $this->assertSame(1240, $event->subtotal);
+        $this->assertSame('GBP', $event->currency);
+        $this->assertNull($event->invoiceNumber);
+        $this->assertNull($event->paymentMethod);
+        $this->assertCount(0, $event->taxSummary);
+        $this->assertNull($event->metadata);
+    }
+
+    public function test_it_carries_metadata_from_api_order_array(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->metadata = ['fluentcart_transaction_id' => 'tx_42', 'source' => 'checkout'];
+
+        $event = PaymentFailed::fromApiOrder($apiOrder);
+
+        $this->assertSame(
+            ['fluentcart_transaction_id' => 'tx_42', 'source' => 'checkout'],
+            $event->metadata,
+        );
+    }
+
+    public function test_it_normalizes_object_metadata_from_api_order(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->metadata = (object) ['fluentcart_transaction_id' => 'tx_42'];
+
+        $event = PaymentFailed::fromApiOrder($apiOrder);
+
+        $this->assertSame(['fluentcart_transaction_id' => 'tx_42'], $event->metadata);
+    }
+
+    private function makeApiOrder(): ApiOrder
+    {
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_meta';
+        $apiOrder->customerId = 'cus_meta';
+        $apiOrder->total = new Money('EUR', '10.00');
+        $apiOrder->subtotal = new Money('EUR', '8.26');
+        $apiOrder->invoiceNumber = null;
+        $apiOrder->paymentMethod = null;
+        $apiOrder->status = 'open';
+        $apiOrder->taxSummary = new TaxSummaryCollection([]);
+
+        return $apiOrder;
+    }
+}

--- a/tests/VatlyTest.php
+++ b/tests/VatlyTest.php
@@ -187,8 +187,8 @@ class VatlyTest extends TestCase
         $reactions = $ref->getValue($processor);
 
         $this->assertContains($customReaction, $reactions);
-        // The 3 standard reactions stay on top, plus our extra one = 4.
-        $this->assertCount(4, $reactions);
+        // The 4 standard reactions stay on top, plus our extra one = 5.
+        $this->assertCount(5, $reactions);
     }
 
     public function test_subscription_handle_wraps_the_given_subscription(): void

--- a/tests/Webhooks/Reactions/CancelSubscriptionOnCanceledTest.php
+++ b/tests/Webhooks/Reactions/CancelSubscriptionOnCanceledTest.php
@@ -43,7 +43,7 @@ class CancelSubscriptionOnCanceledTest extends TestCase
         $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
         $reaction = new CancelSubscriptionOnCanceled($repo);
 
-        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
     }
 
     public function test_it_persists_the_event_ends_at_for_immediate_cancellation(): void

--- a/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
@@ -99,6 +99,7 @@ class StoreOrderOnPaidTest extends TestCase
         $event = new OrderPaid(
             customerId: '',
             orderId: 'ord_anon',
+            status: 'paid',
             total: 9900,
             subtotal: 8182,
             taxSummary: TaxSummary::empty(),
@@ -128,6 +129,7 @@ class StoreOrderOnPaidTest extends TestCase
         $event = new OrderPaid(
             customerId: 'cus_1',
             orderId: 'ord_1',
+            status: 'paid',
             total: 9900,
             subtotal: 8182,
             taxSummary: TaxSummary::empty(),
@@ -164,6 +166,7 @@ class StoreOrderOnPaidTest extends TestCase
         return new OrderPaid(
             customerId: 'cus_1',
             orderId: 'ord_1',
+            status: 'paid',
             total: 9900,
             subtotal: 8182,
             taxSummary: $taxSummary ?? TaxSummary::empty(),

--- a/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
@@ -94,6 +94,34 @@ class StoreOrderOnPaidTest extends TestCase
         $reaction->handle($event);
     }
 
+    public function test_it_skips_bindings_when_customer_id_is_empty(): void
+    {
+        $event = new OrderPaid(
+            customerId: '',
+            orderId: 'ord_anon',
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: 'INV-001',
+            paymentMethod: 'card',
+        );
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_anon')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(
+            fn (StoreOrderData $data) => $data->customerId === ''
+                && $data->hostCustomerId === null
+                && $data->status === 'paid',
+        ))->andReturn(Mockery::mock(OrderInterface::class));
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('hostCustomerIdFor');
+        $bindings->shouldNotReceive('record');
+
+        (new StoreOrderOnPaid($repo, $bindings))->handle($event);
+    }
+
     public function test_it_plumbs_metadata_through_store_and_update_paths(): void
     {
         $metadata = ['fluentcart_transaction_id' => 'tx_42'];

--- a/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
@@ -40,6 +40,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $orderPaid = new OrderPaid(
             customerId: 'cus_1',
             orderId: 'ord_1',
+            status: 'paid',
             total: 9900,
             subtotal: 8182,
             taxSummary: TaxSummary::empty(),
@@ -61,7 +62,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreOrderData $data) use ($taxSummary) {
             return $data->vatlyId === 'ord_1'
                 && $data->customerId === 'cus_1'
-                && $data->status === 'failed'
+                && $data->status === 'pending'
                 && $data->total === 4900
                 && $data->subtotal === 4050
                 && $data->taxSummary === $taxSummary
@@ -88,7 +89,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $repo = Mockery::mock(OrderRepositoryInterface::class);
         $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
         $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateOrderData $data) use ($taxSummary) {
-            return $data->status === 'failed'
+            return $data->status === 'pending'
                 && $data->total === 4900
                 && $data->subtotal === 4050
                 && $data->taxSummary === $taxSummary
@@ -104,11 +105,29 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $reaction->handle($event);
     }
 
+    public function test_it_persists_whatever_status_the_enriched_order_carries(): void
+    {
+        // Regression: an earlier version of this reaction hardcoded `'failed'`,
+        // which diverged from the real Vatly order state ('pending' during
+        // dunning, sometimes 'canceled' after the process ends). We mirror,
+        // not synthesise.
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $existing = Mockery::mock(OrderInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(
+            fn (UpdateOrderData $data) => $data->status === 'canceled',
+        ))->andReturn($existing);
+
+        (new StoreOrderOnPaymentFailed($repo, Mockery::mock(CustomerBindingRepository::class)))
+            ->handle($this->makeEvent(status: 'canceled'));
+    }
+
     public function test_it_skips_bindings_when_customer_id_is_empty(): void
     {
         $event = new PaymentFailed(
             customerId: '',
             orderId: 'ord_anon',
+            status: 'pending',
             total: 4900,
             subtotal: 4050,
             taxSummary: TaxSummary::empty(),
@@ -122,7 +141,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $repo->shouldReceive('store')->once()->with(Mockery::on(
             fn (StoreOrderData $data) => $data->customerId === ''
                 && $data->hostCustomerId === null
-                && $data->status === 'failed',
+                && $data->status === 'pending',
         ))->andReturn(Mockery::mock(OrderInterface::class));
 
         $bindings = Mockery::mock(CustomerBindingRepository::class);
@@ -138,6 +157,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $event = new PaymentFailed(
             customerId: 'cus_1',
             orderId: 'ord_1',
+            status: 'pending',
             total: 4900,
             subtotal: 4050,
             taxSummary: TaxSummary::empty(),
@@ -169,11 +189,12 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         (new StoreOrderOnPaymentFailed($updateRepo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
     }
 
-    private function makeEvent(?TaxSummary $taxSummary = null): PaymentFailed
+    private function makeEvent(?TaxSummary $taxSummary = null, string $status = 'pending'): PaymentFailed
     {
         return new PaymentFailed(
             customerId: 'cus_1',
             orderId: 'ord_1',
+            status: $status,
             total: 4900,
             subtotal: 4050,
             taxSummary: $taxSummary ?? TaxSummary::empty(),

--- a/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Data\StoreOrderData;
+use Vatly\Fluent\Data\UpdateOrderData;
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\PaymentFailed;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Types\TaxSummaryItem;
+use Vatly\Fluent\Types\TaxSummaryRate;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
+
+class StoreOrderOnPaymentFailedTest extends TestCase
+{
+    public function test_it_supports_payment_failed_events(): void
+    {
+        $reaction = new StoreOrderOnPaymentFailed(
+            Mockery::mock(OrderRepositoryInterface::class),
+            Mockery::mock(CustomerBindingRepository::class),
+        );
+
+        $this->assertTrue($reaction->supports($this->makeEvent()));
+    }
+
+    public function test_it_does_not_support_order_paid_or_other_events(): void
+    {
+        $reaction = new StoreOrderOnPaymentFailed(
+            Mockery::mock(OrderRepositoryInterface::class),
+            Mockery::mock(CustomerBindingRepository::class),
+        );
+
+        $orderPaid = new OrderPaid(
+            customerId: 'cus_1',
+            orderId: 'ord_1',
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: null,
+            paymentMethod: null,
+        );
+
+        $this->assertFalse($reaction->supports($orderPaid));
+    }
+
+    public function test_it_stores_a_failed_order_with_host_customer_id_from_bindings_when_none_exists(): void
+    {
+        $taxSummary = $this->makeTaxSummary();
+        $event = $this->makeEvent(taxSummary: $taxSummary);
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreOrderData $data) use ($taxSummary) {
+            return $data->vatlyId === 'ord_1'
+                && $data->customerId === 'cus_1'
+                && $data->status === 'failed'
+                && $data->total === 4900
+                && $data->subtotal === 4050
+                && $data->taxSummary === $taxSummary
+                && $data->currency === 'EUR'
+                && $data->invoiceNumber === null
+                && $data->paymentMethod === 'sepa_direct_debit'
+                && $data->hostCustomerId === 'host_7';
+        }))->andReturn(Mockery::mock(OrderInterface::class));
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->with('cus_1')->once()->andReturn('host_7');
+        $bindings->shouldReceive('record')->with('cus_1')->once();
+
+        $reaction = new StoreOrderOnPaymentFailed($repo, $bindings);
+        $reaction->handle($event);
+    }
+
+    public function test_it_updates_an_existing_order_to_failed_without_consulting_bindings(): void
+    {
+        $taxSummary = $this->makeTaxSummary();
+        $event = $this->makeEvent(taxSummary: $taxSummary);
+
+        $existing = Mockery::mock(OrderInterface::class);
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateOrderData $data) use ($taxSummary) {
+            return $data->status === 'failed'
+                && $data->total === 4900
+                && $data->subtotal === 4050
+                && $data->taxSummary === $taxSummary
+                && $data->paymentMethod === 'sepa_direct_debit';
+        }))->andReturn($existing);
+        $repo->shouldNotReceive('store');
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('hostCustomerIdFor');
+        $bindings->shouldNotReceive('record');
+
+        $reaction = new StoreOrderOnPaymentFailed($repo, $bindings);
+        $reaction->handle($event);
+    }
+
+    public function test_it_plumbs_metadata_through_store_and_update_paths(): void
+    {
+        $metadata = ['fluentcart_transaction_id' => 'tx_42'];
+        $event = new PaymentFailed(
+            customerId: 'cus_1',
+            orderId: 'ord_1',
+            total: 4900,
+            subtotal: 4050,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: null,
+            paymentMethod: 'sepa_direct_debit',
+            metadata: $metadata,
+        );
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(
+            fn (StoreOrderData $data) => $data->metadata === $metadata,
+        ))->andReturn(Mockery::mock(OrderInterface::class));
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->andReturn(null);
+        $bindings->shouldReceive('record')->once();
+
+        (new StoreOrderOnPaymentFailed($repo, $bindings))->handle($event);
+
+        $existing = Mockery::mock(OrderInterface::class);
+        $updateRepo = Mockery::mock(OrderRepositoryInterface::class);
+        $updateRepo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
+        $updateRepo->shouldReceive('update')->once()->with($existing, Mockery::on(
+            fn (UpdateOrderData $data) => $data->metadata === $metadata,
+        ))->andReturn($existing);
+
+        (new StoreOrderOnPaymentFailed($updateRepo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
+    }
+
+    private function makeEvent(?TaxSummary $taxSummary = null): PaymentFailed
+    {
+        return new PaymentFailed(
+            customerId: 'cus_1',
+            orderId: 'ord_1',
+            total: 4900,
+            subtotal: 4050,
+            taxSummary: $taxSummary ?? TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: null,
+            paymentMethod: 'sepa_direct_debit',
+        );
+    }
+
+    private function makeTaxSummary(): TaxSummary
+    {
+        return new TaxSummary([
+            new TaxSummaryItem(
+                rate: new TaxSummaryRate('VAT', 21.0, 100.0),
+                amount: 850,
+                currency: 'EUR',
+            ),
+        ]);
+    }
+}

--- a/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
@@ -104,6 +104,34 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         $reaction->handle($event);
     }
 
+    public function test_it_skips_bindings_when_customer_id_is_empty(): void
+    {
+        $event = new PaymentFailed(
+            customerId: '',
+            orderId: 'ord_anon',
+            total: 4900,
+            subtotal: 4050,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: null,
+            paymentMethod: 'sepa_direct_debit',
+        );
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_anon')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(
+            fn (StoreOrderData $data) => $data->customerId === ''
+                && $data->hostCustomerId === null
+                && $data->status === 'failed',
+        ))->andReturn(Mockery::mock(OrderInterface::class));
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('hostCustomerIdFor');
+        $bindings->shouldNotReceive('record');
+
+        (new StoreOrderOnPaymentFailed($repo, $bindings))->handle($event);
+    }
+
     public function test_it_plumbs_metadata_through_store_and_update_paths(): void
     {
         $metadata = ['fluentcart_transaction_id' => 'tx_42'];

--- a/tests/Webhooks/Reactions/SyncSubscriptionOnStartedTest.php
+++ b/tests/Webhooks/Reactions/SyncSubscriptionOnStartedTest.php
@@ -41,7 +41,7 @@ class SyncSubscriptionOnStartedTest extends TestCase
             Mockery::mock(EventDispatcherInterface::class),
         );
 
-        $event = new OrderPaid('cus_1', 'ord_1', 9900, 8182, TaxSummary::empty(), 'EUR', null, null);
+        $event = new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null);
 
         $this->assertFalse($reaction->supports($event));
     }

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -194,6 +194,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertInstanceOf(OrderPaid::class, $event);
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('paid', $event->status);
         $this->assertSame(9900, $event->total);
         $this->assertSame(8182, $event->subtotal);
         $this->assertSame('EUR', $event->currency);
@@ -218,6 +219,7 @@ class WebhookEventFactoryTest extends TestCase
             ],
             'invoiceNumber' => null,
             'paymentMethod' => 'sepa_direct_debit',
+            'status' => 'pending',
         ]);
 
         $this->getOrder->shouldReceive('execute')
@@ -244,6 +246,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertInstanceOf(PaymentFailed::class, $event);
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_dunning_1', $event->orderId);
+        $this->assertSame('pending', $event->status);
         $this->assertSame(4900, $event->total);
         $this->assertSame(4050, $event->subtotal);
         $this->assertSame('EUR', $event->currency);
@@ -301,6 +304,7 @@ class WebhookEventFactoryTest extends TestCase
      *   taxRates: array<int, array{name: string, percentage: float, taxablePercentage: float, amount: string}>,
      *   invoiceNumber: ?string,
      *   paymentMethod: ?string,
+     *   status?: string,
      * } $data
      */
     private function buildApiOrder(array $data): ApiOrder
@@ -312,7 +316,7 @@ class WebhookEventFactoryTest extends TestCase
         $order->subtotal = new Money($data['subtotal']['currency'], $data['subtotal']['value']);
         $order->invoiceNumber = $data['invoiceNumber'];
         $order->paymentMethod = $data['paymentMethod'];
-        $order->status = 'paid';
+        $order->status = $data['status'] ?? 'paid';
 
         $taxItems = array_map(
             fn (array $rate) => [

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -13,6 +13,7 @@ use Vatly\API\VatlyApiClient;
 use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
 use Vatly\Fluent\Events\SubscriptionStarted;
@@ -205,6 +206,54 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('EUR', $event->taxSummary->items[0]->currency);
     }
 
+    public function test_it_creates_payment_failed_event_from_webhook_with_enriched_order(): void
+    {
+        $apiOrder = $this->buildApiOrder([
+            'id' => 'ord_dunning_1',
+            'customerId' => 'cus_456',
+            'total' => ['currency' => 'EUR', 'value' => '49.00'],
+            'subtotal' => ['currency' => 'EUR', 'value' => '40.50'],
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '8.50'],
+            ],
+            'invoiceNumber' => null,
+            'paymentMethod' => 'sepa_direct_debit',
+        ]);
+
+        $this->getOrder->shouldReceive('execute')
+            ->once()
+            ->with('ord_dunning_1')
+            ->andReturn($apiOrder);
+
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_pf',
+            resource: 'webhook_event',
+            eventName: 'payment.failed',
+            entityType: 'order',
+            entityId: 'ord_dunning_1',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'total' => ['currency' => 'EUR', 'value' => '49.00'],
+            ],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(PaymentFailed::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('ord_dunning_1', $event->orderId);
+        $this->assertSame(4900, $event->total);
+        $this->assertSame(4050, $event->subtotal);
+        $this->assertSame('EUR', $event->currency);
+        $this->assertNull($event->invoiceNumber);
+        $this->assertSame('sepa_direct_debit', $event->paymentMethod);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
+        $this->assertSame(850, $event->taxSummary->items[0]->amount);
+    }
+
     public function test_it_creates_unsupported_webhook_received_for_unknown_events(): void
     {
         $webhook = new WebhookReceived(
@@ -232,12 +281,14 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertContains('subscription.canceled_immediately', $supported);
         $this->assertContains('subscription.canceled_with_grace_period', $supported);
         $this->assertContains('order.paid', $supported);
+        $this->assertContains('payment.failed', $supported);
     }
 
     public function test_it_checks_if_event_is_supported(): void
     {
         $this->assertTrue($this->factory->isSupported('subscription.started'));
         $this->assertTrue($this->factory->isSupported('order.paid'));
+        $this->assertTrue($this->factory->isSupported('payment.failed'));
         $this->assertFalse($this->factory->isSupported('unknown.event'));
     }
 

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -16,6 +16,7 @@ use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\Fluent\Tests\TestCase;
 use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
+use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
@@ -38,10 +39,11 @@ class WebhookProcessorFactoryTest extends TestCase
 
         $reactions = $processor->getReactions();
 
-        $this->assertCount(3, $reactions);
+        $this->assertCount(4, $reactions);
         $this->assertInstanceOf(SyncSubscriptionOnStarted::class, $reactions[0]);
         $this->assertInstanceOf(CancelSubscriptionOnCanceled::class, $reactions[1]);
         $this->assertInstanceOf(StoreOrderOnPaid::class, $reactions[2]);
+        $this->assertInstanceOf(StoreOrderOnPaymentFailed::class, $reactions[3]);
     }
 
     public function test_it_appends_additional_reactions_after_the_standard_ones(): void
@@ -61,8 +63,8 @@ class WebhookProcessorFactoryTest extends TestCase
 
         $reactions = $processor->getReactions();
 
-        $this->assertCount(4, $reactions);
-        $this->assertSame($custom, $reactions[3]);
+        $this->assertCount(5, $reactions);
+        $this->assertSame($custom, $reactions[4]);
     }
 
     public function test_it_tolerates_a_null_webhook_secret(): void

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -166,7 +166,7 @@ class WebhookProcessorTest extends TestCase
         $apiOrder->subtotal = new Money('EUR', '40.50');
         $apiOrder->invoiceNumber = null;
         $apiOrder->paymentMethod = 'sepa_direct_debit';
-        $apiOrder->status = 'open';
+        $apiOrder->status = 'pending';
         $apiOrder->taxSummary = new TaxSummaryCollection([
             [
                 'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
@@ -188,6 +188,7 @@ class WebhookProcessorTest extends TestCase
                 return $event instanceof PaymentFailed
                     && $event->customerId === 'cus_456'
                     && $event->orderId === 'ord_dunning_1'
+                    && $event->status === 'pending'
                     && $event->total === 4900
                     && $event->subtotal === 4050
                     && $event->currency === 'EUR'

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Tests\Webhooks;
 
 use Mockery;
+use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
@@ -19,6 +24,7 @@ use Vatly\Fluent\Webhooks\WebhookProcessor;
 class WebhookProcessorTest extends TestCase
 {
     private string $secret;
+    private GetOrder $getOrder;
     private WebhookEventFactory $eventFactory;
     private WebhookCallRepositoryInterface $repository;
     private EventDispatcherInterface $dispatcher;
@@ -29,7 +35,8 @@ class WebhookProcessorTest extends TestCase
         parent::setUp();
 
         $this->secret = 'test-webhook-secret';
-        $this->eventFactory = new WebhookEventFactory(Mockery::mock(GetOrder::class));
+        $this->getOrder = Mockery::mock(GetOrder::class);
+        $this->eventFactory = new WebhookEventFactory($this->getOrder);
         $this->repository = Mockery::mock(WebhookCallRepositoryInterface::class);
         $this->dispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -135,6 +142,60 @@ class WebhookProcessorTest extends TestCase
         );
 
         $processor->handle($payload, $signature);
+    }
+
+    public function test_it_processes_a_payment_failed_webhook_end_to_end(): void
+    {
+        $payload = $this->makePayload(
+            id: 'webhook_event_pf',
+            eventName: 'payment.failed',
+            entityType: 'order',
+            entityId: 'ord_dunning_1',
+            object: [
+                'customerId' => 'cus_456',
+                'total' => ['currency' => 'EUR', 'value' => '49.00'],
+            ],
+        );
+
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
+
+        $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
+        $apiOrder->id = 'ord_dunning_1';
+        $apiOrder->customerId = 'cus_456';
+        $apiOrder->total = new Money('EUR', '49.00');
+        $apiOrder->subtotal = new Money('EUR', '40.50');
+        $apiOrder->invoiceNumber = null;
+        $apiOrder->paymentMethod = 'sepa_direct_debit';
+        $apiOrder->status = 'open';
+        $apiOrder->taxSummary = new TaxSummaryCollection([
+            [
+                'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                'amount' => ['currency' => 'EUR', 'value' => '8.50'],
+            ],
+        ]);
+
+        $this->getOrder->shouldReceive('execute')
+            ->once()
+            ->with('ord_dunning_1')
+            ->andReturn($apiOrder);
+
+        $this->repository->shouldReceive('record')->once();
+
+        $this->dispatcher
+            ->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function (object $event) {
+                return $event instanceof PaymentFailed
+                    && $event->customerId === 'cus_456'
+                    && $event->orderId === 'ord_dunning_1'
+                    && $event->total === 4900
+                    && $event->subtotal === 4050
+                    && $event->currency === 'EUR'
+                    && $event->paymentMethod === 'sepa_direct_debit'
+                    && $event->taxSummary->items[0]->amount === 850;
+            });
+
+        $this->processor->handle($payload, $signature);
     }
 
     public function test_it_throws_exception_for_invalid_signature(): void


### PR DESCRIPTION
## Summary

Adds a typed `Vatly\Fluent\Events\PaymentFailed` event so consumers can react to `payment.failed` webhooks without string-matching on `UnsupportedWebhookReceived::eventName`. Mirrors `OrderPaid`'s shape since the webhook payload is order-scoped and sparse — same `GetOrder` enrichment pattern.

Closes #47 (which replaced the leaky #29).

## What changed

- **`src/Events/PaymentFailed.php`** (new) — `VATLY_EVENT_NAME = 'payment.failed'`; constructor mirrors `OrderPaid` (`customerId`, `orderId`, `total`, `subtotal`, `taxSummary`, `currency`, `invoiceNumber`, `paymentMethod`, `metadata`); `fromApiOrder()` factory.
- **`src/Webhooks/WebhookEventFactory.php`** — added match arm routing `payment.failed` through `GetOrder` enrichment; added to `getSupportedEvents()`; updated return-type docblock and the enrichment comment to cover both order-scoped events.
- **`tests/Events/PaymentFailedTest.php`** (new) — 5 tests mirroring `OrderPaidTest` (event name constant, constructor, `fromApiOrder` with tax breakdown, no-customer/no-invoice path, array + object metadata normalization).
- **`tests/Webhooks/WebhookEventFactoryTest.php`** — factory branch test for `payment.failed` enrichment; `getSupportedEvents`/`isSupported` assertions extended.
- **`tests/Webhooks/WebhookProcessorTest.php`** — end-to-end test routing a `payment.failed` fixture through `WebhookProcessor` with the GetOrder mock wired (satisfies the integration AC).

## Subscription resolution

The webhook is order-scoped — a `payment.failed` delivery doesn't directly identify which subscription failed. Consumers needing this should resolve it via their own customer/subscription map (same pattern `RecordRenewalOnPaid`-style reactions already use). A separate upstream issue tracks whether `OrderPayload` should grow a subscription reference long-term.

## Acceptance criteria (from #47)

- [x] `Vatly\Fluent\Events\PaymentFailed` class added
- [x] `WebhookEventFactory` routes `payment.failed` to it and enriches via `GetOrder`
- [x] `getSupportedEvents()` includes `payment.failed`
- [x] Unit test covering factory branch
- [x] Integration test routing a webhook fixture through `WebhookProcessor`

## Test plan

- [x] `composer test` — 172 passing, 498 assertions
- [x] `composer analyse` — phpstan clean
