### PR TITLE
docs(updateBilling) + deps: bump vatly-api-php to alpha.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,10 @@ $vatly->subscription($localSubscription)->cancel();
 $vatly->order($localOrder)->invoiceUrl();
 
 // Billing address / VAT / company name changes go through a hosted Vatly
-// flow. Returns a fresh redirect URL per call — don't cache. All keys in
-// the prefill array are optional.
+// flow. Returns a fresh redirect URL per call — don't cache.
+// `redirectUrlSuccess` and `redirectUrlCanceled` are required; the SDK
+// does not fall back to the config defaults here. `billingAddress` is
+// an optional prefill.
 $url = $vatly->subscription($localSubscription)->updateBilling([
     'redirectUrlSuccess'  => 'https://app.example.com/billing/updated',
     'redirectUrlCanceled' => 'https://app.example.com/billing',

--- a/README.md
+++ b/README.md
@@ -397,6 +397,19 @@ $checkout = $vatly
 // Operate on a stored Subscription / Order
 $vatly->subscription($localSubscription)->cancel();
 $vatly->order($localOrder)->invoiceUrl();
+
+// Billing address / VAT / company name changes go through a hosted Vatly
+// flow. Returns a fresh redirect URL per call — don't cache. All keys in
+// the prefill array are optional.
+$url = $vatly->subscription($localSubscription)->updateBilling([
+    'redirectUrlSuccess'  => 'https://app.example.com/billing/updated',
+    'redirectUrlCanceled' => 'https://app.example.com/billing',
+    'billingAddress' => [
+        'streetAndNumber' => 'Damrak 1',
+        'city'            => 'Amsterdam',
+        'country'         => 'NL',
+    ],
+]);
 ```
 
 **Customer helper.** For host-first flows where you create a Vatly customer for a known host entity and want the link recorded automatically:
@@ -472,6 +485,13 @@ class Subscription implements SubscriptionInterface
     {
         $container->get(Vatly::class)->subscription($this)->swap($planId);
         return $this;
+    }
+
+    public function billingUpdateUrl(array $prefillData = []): string
+    {
+        return $container->get(Vatly::class)
+            ->subscription($this)
+            ->updateBilling($prefillData);
     }
 }
 ```

--- a/src/Actions/UpdateSubscriptionBilling.php
+++ b/src/Actions/UpdateSubscriptionBilling.php
@@ -13,8 +13,11 @@ class UpdateSubscriptionBilling extends BaseAction
      * (billing address, VAT number, company name) via a hosted flow.
      *
      * @param string $subscriptionId The subscription ID (e.g., subscription_xxx)
-     * @param array<string, mixed> $prefillData Optional pre-fill data (`redirectUrlSuccess`,
-     *                                          `redirectUrlCanceled`, `billingAddress`)
+     * @param array<string, mixed> $prefillData Must include `redirectUrlSuccess` and
+     *                                          `redirectUrlCanceled` (required by the API; the
+     *                                          SDK does not merge in config defaults here).
+     *                                          May include `billingAddress` as an optional
+     *                                          prefill.
      */
     public function execute(string $subscriptionId, array $prefillData = []): Link
     {

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -209,7 +209,13 @@ class SubscriptionHandle
      *
      * Each call returns a fresh time-bounded link.
      *
-     * @param array<string, mixed> $prefillData Optional pre-fill data.
+     * @param array<string, mixed> $prefillData Must include `redirectUrlSuccess`
+     *                                          and `redirectUrlCanceled` (the
+     *                                          API rejects the request without
+     *                                          them; the SDK does not merge in
+     *                                          config defaults here). May
+     *                                          include `billingAddress` as an
+     *                                          optional prefill.
      */
     public function updateBilling(array $prefillData = []): string
     {


### PR DESCRIPTION
Two related changes batched together:

## 1. README: document billing-update flow (closes README criterion on #2)

The \`updateBilling()\` action and the \`SubscriptionHandle\` method have been implemented for some time; this just makes the usage visible to driver authors reading the README.

**Step 8 (Use the SDK — two paths).** Extends the action-driven code block with a billing-update example: the prefill array (\`redirectUrlSuccess\`, \`redirectUrlCanceled\`, \`billingAddress\`) and the caveats that matter at call time — returns a fresh URL per call, don't cache, and the two redirect URLs are required (the SDK does not merge config defaults here, unlike \`SubscriptionBuilder\`). Folded into the existing block rather than added as a sibling section so the "two paths" structure stays intact.

**Step 10 (Expose operations on local models).** Adds a \`billingUpdateUrl()\` example next to \`cancel()\`/\`swap()\`. Name mirrors \`OrderHandle::invoiceUrl()\`'s noun-y URL-returning convention.

Same correction applied to PHPDoc on \`SubscriptionHandle::updateBilling()\` and \`UpdateSubscriptionBilling::execute()\` (both previously said "Optional pre-fill data" — misleading per the OpenAPI \`UpdateSubscriptionBillingRequest\` which marks both redirect URLs as required).

## 2. chore(deps): bump vatly-api-php to ^0.1.0-alpha.9

Upstream alpha.9 adds transparent IDN email punycoding (RFC 3492). Per the release notes, downstream packages handing arrays to the SDK pick this up automatically — no fluent code changes needed. \`ext-intl\` is a new upstream requirement; Composer resolves it transitively.

Release notes: https://github.com/vatly/vatly-api-php/releases/tag/v0.1.0-alpha.9

## Out of scope (tracked on #2)

- Payment method update wrapper — pending upstream support
- Direct customer field updates (email, locale, metadata) — not planned per the redirect-flow architecture
- Default-redirect-URL merging in \`updateBilling()\` (asymmetry with \`SubscriptionBuilder\`) — tracked as a follow-up

## Test plan

- [x] \`composer test\` — 164 tests, 451 assertions, green against alpha.9
- [x] \`composer analyse\` — no PHPStan errors
- [x] CI green across PHP 8.1 / 8.2 / 8.3 / 8.4
