### PR TITLE
chore(deps): bump vatly-api-php to ^0.1.0-alpha.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vatly/vatly-api-php": "^0.1.0-alpha.8"
+        "vatly/vatly-api-php": "^0.1.0-alpha.9"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
## Summary

Adopt the new \`vatly/vatly-api-php\` alpha.9 release. The upstream change adds transparent IDN email punycoding (RFC 3492) inside \`BaseEndpoint\`, so non-ASCII email domains like \`user@münchen.de\` are normalized to \`user@xn--mnchen-3ya.de\` on the wire automatically. Per the upstream release notes, downstream packages handing arrays to the SDK pick this up with no code change — confirmed by the fluent test suite (180 / 533 green against alpha.9).

\`ext-intl\` is a new upstream system requirement; Composer resolves it transitively and fluent itself doesn't call \`idn_to_ascii\` directly, so no need to repeat the declaration here.

Release notes: https://github.com/vatly/vatly-api-php/releases/tag/v0.1.0-alpha.9

## Test plan

- [x] \`composer test\` — 180 tests, 533 assertions, green
- [x] \`composer analyse\` — no PHPStan errors
- [ ] CI green across PHP 8.1 / 8.2 / 8.3 / 8.4
