### PR TITLE
feat(subscriptions): default redirect URLs in updateBilling from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,12 @@ $vatly->order($localOrder)->invoiceUrl();
 
 // Billing address / VAT / company name changes go through a hosted Vatly
 // flow. Returns a fresh redirect URL per call — don't cache.
-// `redirectUrlSuccess` and `redirectUrlCanceled` are required; the SDK
-// does not fall back to the config defaults here. `billingAddress` is
-// an optional prefill.
+// `redirectUrlSuccess` and `redirectUrlCanceled` are filled in from the
+// config defaults when omitted; pass them in $prefillData to override.
+$url = $vatly->subscription($localSubscription)->updateBilling();
+
+// Optionally prefill the billing address:
 $url = $vatly->subscription($localSubscription)->updateBilling([
-    'redirectUrlSuccess'  => 'https://app.example.com/billing/updated',
-    'redirectUrlCanceled' => 'https://app.example.com/billing',
     'billingAddress' => [
         'streetAndNumber' => 'Damrak 1',
         'city'            => 'Amsterdam',

--- a/src/Actions/UpdateSubscriptionBilling.php
+++ b/src/Actions/UpdateSubscriptionBilling.php
@@ -7,6 +7,7 @@ namespace Vatly\Fluent\Actions;
 use Vatly\API\Types\Link;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Exceptions\IncompleteInformationException;
 
 class UpdateSubscriptionBilling extends BaseAction
 {
@@ -25,12 +26,15 @@ class UpdateSubscriptionBilling extends BaseAction
      * Missing `redirectUrlSuccess` / `redirectUrlCanceled` keys are filled in from
      * {@see ConfigurationInterface::getDefaultRedirectUrlSuccess()} and
      * {@see ConfigurationInterface::getDefaultRedirectUrlCanceled()}; caller-supplied
-     * values always win.
+     * values always win. If neither the caller nor the config provides a value,
+     * an {@see IncompleteInformationException} is thrown.
      *
      * @param string $subscriptionId The subscription ID (e.g., subscription_xxx)
      * @param array<string, mixed> $prefillData May override `redirectUrlSuccess` /
      *                                          `redirectUrlCanceled`, and may include
      *                                          `billingAddress` as an optional prefill.
+     *
+     * @throws IncompleteInformationException When a required redirect URL resolves to an empty string.
      */
     public function execute(string $subscriptionId, array $prefillData = []): Link
     {
@@ -38,6 +42,12 @@ class UpdateSubscriptionBilling extends BaseAction
             'redirectUrlSuccess' => $this->config->getDefaultRedirectUrlSuccess(),
             'redirectUrlCanceled' => $this->config->getDefaultRedirectUrlCanceled(),
         ];
+
+        foreach (['redirectUrlSuccess', 'redirectUrlCanceled'] as $required) {
+            if (($payload[$required] ?? '') === '') {
+                throw IncompleteInformationException::missingBillingRedirectUrl($required);
+            }
+        }
 
         return $this->vatlyApiClient->subscriptions->updateBilling(
             $subscriptionId,

--- a/src/Actions/UpdateSubscriptionBilling.php
+++ b/src/Actions/UpdateSubscriptionBilling.php
@@ -5,25 +5,43 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Actions;
 
 use Vatly\API\Types\Link;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
 
 class UpdateSubscriptionBilling extends BaseAction
 {
+    public function __construct(
+        VatlyApiClient $vatlyApiClient,
+        /** @readonly */
+        private ConfigurationInterface $config,
+    ) {
+        parent::__construct($vatlyApiClient);
+    }
+
     /**
      * Create a signed URL where the customer can update the billing details for a subscription
      * (billing address, VAT number, company name) via a hosted flow.
      *
+     * Missing `redirectUrlSuccess` / `redirectUrlCanceled` keys are filled in from
+     * {@see ConfigurationInterface::getDefaultRedirectUrlSuccess()} and
+     * {@see ConfigurationInterface::getDefaultRedirectUrlCanceled()}; caller-supplied
+     * values always win.
+     *
      * @param string $subscriptionId The subscription ID (e.g., subscription_xxx)
-     * @param array<string, mixed> $prefillData Must include `redirectUrlSuccess` and
-     *                                          `redirectUrlCanceled` (required by the API; the
-     *                                          SDK does not merge in config defaults here).
-     *                                          May include `billingAddress` as an optional
-     *                                          prefill.
+     * @param array<string, mixed> $prefillData May override `redirectUrlSuccess` /
+     *                                          `redirectUrlCanceled`, and may include
+     *                                          `billingAddress` as an optional prefill.
      */
     public function execute(string $subscriptionId, array $prefillData = []): Link
     {
+        $payload = $prefillData + [
+            'redirectUrlSuccess' => $this->config->getDefaultRedirectUrlSuccess(),
+            'redirectUrlCanceled' => $this->config->getDefaultRedirectUrlCanceled(),
+        ];
+
         return $this->vatlyApiClient->subscriptions->updateBilling(
             $subscriptionId,
-            $prefillData
+            $payload,
         );
     }
 }

--- a/src/Exceptions/IncompleteInformationException.php
+++ b/src/Exceptions/IncompleteInformationException.php
@@ -12,4 +12,12 @@ final class IncompleteInformationException extends RuntimeException implements V
     {
         return new self('No checkout items provided. At least one item should be set when creating a checkout.');
     }
+
+    public static function missingBillingRedirectUrl(string $key): self
+    {
+        return new self(
+            "Missing required '{$key}' for the subscription billing-update flow. "
+            . 'Pass it in $prefillData, or configure a default via ConfigurationInterface.'
+        );
+    }
 }

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -13,6 +13,7 @@ use Vatly\Fluent\Actions\SwapSubscriptionPlan;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
 use Vatly\Fluent\Contracts\SubscriptionWriter;
 use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Exceptions\IncompleteInformationException;
 
 /**
  * Framework-agnostic operations on a subscription.
@@ -213,10 +214,14 @@ class SubscriptionHandle
      * from the configured defaults
      * ({@see \Vatly\Fluent\Contracts\ConfigurationInterface::getDefaultRedirectUrlSuccess()}
      * and `getDefaultRedirectUrlCanceled()`); caller-supplied values always win.
+     * If neither the caller nor the config provides a value, an
+     * {@see IncompleteInformationException} is thrown.
      *
      * @param array<string, mixed> $prefillData May override `redirectUrlSuccess` /
      *                                          `redirectUrlCanceled`, and may include
      *                                          `billingAddress` as an optional prefill.
+     *
+     * @throws IncompleteInformationException When a required redirect URL resolves to an empty string.
      */
     public function updateBilling(array $prefillData = []): string
     {

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -209,13 +209,14 @@ class SubscriptionHandle
      *
      * Each call returns a fresh time-bounded link.
      *
-     * @param array<string, mixed> $prefillData Must include `redirectUrlSuccess`
-     *                                          and `redirectUrlCanceled` (the
-     *                                          API rejects the request without
-     *                                          them; the SDK does not merge in
-     *                                          config defaults here). May
-     *                                          include `billingAddress` as an
-     *                                          optional prefill.
+     * Missing `redirectUrlSuccess` / `redirectUrlCanceled` keys are filled in
+     * from the configured defaults
+     * ({@see \Vatly\Fluent\Contracts\ConfigurationInterface::getDefaultRedirectUrlSuccess()}
+     * and `getDefaultRedirectUrlCanceled()`); caller-supplied values always win.
+     *
+     * @param array<string, mixed> $prefillData May override `redirectUrlSuccess` /
+     *                                          `redirectUrlCanceled`, and may include
+     *                                          `billingAddress` as an optional prefill.
      */
     public function updateBilling(array $prefillData = []): string
     {

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -232,6 +232,9 @@ class Vatly
 
     public function updateSubscriptionBilling(): UpdateSubscriptionBilling
     {
-        return $this->updateSubscriptionBilling ??= new UpdateSubscriptionBilling($this->apiClient);
+        return $this->updateSubscriptionBilling ??= new UpdateSubscriptionBilling(
+            $this->apiClient,
+            $this->wiring->config,
+        );
     }
 }

--- a/tests/Actions/UpdateSubscriptionBillingTest.php
+++ b/tests/Actions/UpdateSubscriptionBillingTest.php
@@ -9,12 +9,14 @@ use Vatly\API\Endpoints\SubscriptionEndpoint;
 use Vatly\API\Types\Link;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
+use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Tests\TestCase;
 
 class UpdateSubscriptionBillingTest extends TestCase
 {
     private VatlyApiClient $mockApiClient;
     private SubscriptionEndpoint $mockSubscriptionEndpoint;
+    private ConfigurationInterface $mockConfig;
     private UpdateSubscriptionBilling $action;
 
     protected function setUp(): void
@@ -25,10 +27,16 @@ class UpdateSubscriptionBillingTest extends TestCase
         $this->mockSubscriptionEndpoint = Mockery::mock(SubscriptionEndpoint::class);
         $this->mockApiClient->subscriptions = $this->mockSubscriptionEndpoint;
 
-        $this->action = new UpdateSubscriptionBilling($this->mockApiClient);
+        $this->mockConfig = Mockery::mock(ConfigurationInterface::class);
+        $this->mockConfig->shouldReceive('getDefaultRedirectUrlSuccess')
+            ->andReturn('https://app.example.com/billing/updated');
+        $this->mockConfig->shouldReceive('getDefaultRedirectUrlCanceled')
+            ->andReturn('https://app.example.com/billing');
+
+        $this->action = new UpdateSubscriptionBilling($this->mockApiClient, $this->mockConfig);
     }
 
-    public function test_it_returns_the_billing_update_link(): void
+    public function test_it_fills_redirect_urls_from_config_defaults_when_caller_omits_them(): void
     {
         $subscriptionId = 'subscription_abc123';
         $expectedUrl = 'https://checkout.vatly.com/billing-update/abc123';
@@ -36,7 +44,10 @@ class UpdateSubscriptionBillingTest extends TestCase
         $this->mockSubscriptionEndpoint
             ->shouldReceive('updateBilling')
             ->once()
-            ->with($subscriptionId, [])
+            ->with($subscriptionId, [
+                'redirectUrlSuccess' => 'https://app.example.com/billing/updated',
+                'redirectUrlCanceled' => 'https://app.example.com/billing',
+            ])
             ->andReturn(new Link($expectedUrl, 'text/html'));
 
         $response = $this->action->execute($subscriptionId);
@@ -46,24 +57,52 @@ class UpdateSubscriptionBillingTest extends TestCase
         $this->assertSame('text/html', $response->type);
     }
 
-    public function test_it_passes_prefill_data_to_the_api(): void
+    public function test_it_merges_config_defaults_with_caller_supplied_billing_address(): void
     {
         $subscriptionId = 'subscription_xyz789';
-        $prefillData = [
+
+        $this->mockSubscriptionEndpoint
+            ->shouldReceive('updateBilling')
+            ->once()
+            ->with($subscriptionId, [
+                'billingAddress' => [
+                    'streetAndNumber' => '123 Main St',
+                    'city' => 'Amsterdam',
+                    'country' => 'NL',
+                ],
+                'redirectUrlSuccess' => 'https://app.example.com/billing/updated',
+                'redirectUrlCanceled' => 'https://app.example.com/billing',
+            ])
+            ->andReturn(new Link('https://checkout.vatly.com/billing-update/xyz', 'text/html'));
+
+        $response = $this->action->execute($subscriptionId, [
             'billingAddress' => [
                 'streetAndNumber' => '123 Main St',
                 'city' => 'Amsterdam',
                 'country' => 'NL',
             ],
-        ];
+        ]);
+
+        $this->assertInstanceOf(Link::class, $response);
+    }
+
+    public function test_caller_supplied_redirect_urls_win_over_config_defaults(): void
+    {
+        $subscriptionId = 'subscription_override';
 
         $this->mockSubscriptionEndpoint
             ->shouldReceive('updateBilling')
             ->once()
-            ->with($subscriptionId, $prefillData)
-            ->andReturn(new Link('https://checkout.vatly.com/billing-update/xyz', 'text/html'));
+            ->with($subscriptionId, [
+                'redirectUrlSuccess' => 'https://override.example.com/done',
+                'redirectUrlCanceled' => 'https://override.example.com/oops',
+            ])
+            ->andReturn(new Link('https://checkout.vatly.com/billing-update/override', 'text/html'));
 
-        $response = $this->action->execute($subscriptionId, $prefillData);
+        $response = $this->action->execute($subscriptionId, [
+            'redirectUrlSuccess' => 'https://override.example.com/done',
+            'redirectUrlCanceled' => 'https://override.example.com/oops',
+        ]);
 
         $this->assertInstanceOf(Link::class, $response);
     }

--- a/tests/Actions/UpdateSubscriptionBillingTest.php
+++ b/tests/Actions/UpdateSubscriptionBillingTest.php
@@ -10,6 +10,7 @@ use Vatly\API\Types\Link;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\UpdateSubscriptionBilling;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
+use Vatly\Fluent\Exceptions\IncompleteInformationException;
 use Vatly\Fluent\Tests\TestCase;
 
 class UpdateSubscriptionBillingTest extends TestCase
@@ -102,6 +103,63 @@ class UpdateSubscriptionBillingTest extends TestCase
         $response = $this->action->execute($subscriptionId, [
             'redirectUrlSuccess' => 'https://override.example.com/done',
             'redirectUrlCanceled' => 'https://override.example.com/oops',
+        ]);
+
+        $this->assertInstanceOf(Link::class, $response);
+    }
+
+    public function test_it_throws_when_redirect_url_success_resolves_to_empty(): void
+    {
+        $config = Mockery::mock(ConfigurationInterface::class);
+        $config->shouldReceive('getDefaultRedirectUrlSuccess')->andReturn('');
+        $config->shouldReceive('getDefaultRedirectUrlCanceled')->andReturn('https://app.example.com/billing');
+
+        $action = new UpdateSubscriptionBilling($this->mockApiClient, $config);
+
+        $this->mockSubscriptionEndpoint->shouldNotReceive('updateBilling');
+
+        $this->expectException(IncompleteInformationException::class);
+        $this->expectExceptionMessage("'redirectUrlSuccess'");
+
+        $action->execute('subscription_abc123');
+    }
+
+    public function test_it_throws_when_redirect_url_canceled_resolves_to_empty(): void
+    {
+        $config = Mockery::mock(ConfigurationInterface::class);
+        $config->shouldReceive('getDefaultRedirectUrlSuccess')->andReturn('https://app.example.com/billing/updated');
+        $config->shouldReceive('getDefaultRedirectUrlCanceled')->andReturn('');
+
+        $action = new UpdateSubscriptionBilling($this->mockApiClient, $config);
+
+        $this->mockSubscriptionEndpoint->shouldNotReceive('updateBilling');
+
+        $this->expectException(IncompleteInformationException::class);
+        $this->expectExceptionMessage("'redirectUrlCanceled'");
+
+        $action->execute('subscription_abc123');
+    }
+
+    public function test_caller_can_supply_redirect_urls_when_config_defaults_are_empty(): void
+    {
+        $config = Mockery::mock(ConfigurationInterface::class);
+        $config->shouldReceive('getDefaultRedirectUrlSuccess')->andReturn('');
+        $config->shouldReceive('getDefaultRedirectUrlCanceled')->andReturn('');
+
+        $action = new UpdateSubscriptionBilling($this->mockApiClient, $config);
+
+        $this->mockSubscriptionEndpoint
+            ->shouldReceive('updateBilling')
+            ->once()
+            ->with('subscription_abc123', [
+                'redirectUrlSuccess' => 'https://caller.example.com/done',
+                'redirectUrlCanceled' => 'https://caller.example.com/oops',
+            ])
+            ->andReturn(new Link('https://checkout.vatly.com/billing-update/abc', 'text/html'));
+
+        $response = $action->execute('subscription_abc123', [
+            'redirectUrlSuccess' => 'https://caller.example.com/done',
+            'redirectUrlCanceled' => 'https://caller.example.com/oops',
         ]);
 
         $this->assertInstanceOf(Link::class, $response);


### PR DESCRIPTION
## Summary

- `UpdateSubscriptionBilling::execute()` now fills `redirectUrlSuccess` / `redirectUrlCanceled` from `ConfigurationInterface` defaults when the caller omits them. Caller-supplied values still win.
- Brings the action in line with `SubscriptionBuilder`, which already reads the same config defaults.

## Why

The Vatly API marks both redirect URLs as required on the update-billing endpoint. Before this change, calling `\$handle->updateBilling()` with no args (or with only `billingAddress`) returned a 422 — the SDK passed the caller's array straight through without merging in the configured defaults. With this change, drivers configure redirect URLs once and call `\$handle->updateBilling()` cheaply, which matches how the SDK already behaves elsewhere.

## Changes

- `src/Actions/UpdateSubscriptionBilling.php` — constructor now accepts `ConfigurationInterface`; `execute()` merges defaults using `\$prefillData + [...]` so caller keys win.
- `src/Vatly.php` — passes `\$this->wiring->config` into the action.
- `src/SubscriptionHandle.php` — PHPDoc on `updateBilling()` flipped: explains that defaults are merged.
- `tests/Actions/UpdateSubscriptionBillingTest.php` — covers the three paths: defaults only, defaults + `billingAddress` prefill, and caller-override-wins.
- `README.md` (step 8) — common-case example is now just `\$vatly->subscription(\$sub)->updateBilling();`, with a second snippet showing the optional `billingAddress` prefill.

## Out of scope

- Payment-method update wrapper — still pending upstream API support (issue #2).

## Test plan

- [x] `vendor/bin/phpunit` — 181 tests, 535 assertions, all green.
- [ ] Reviewer: skim the README example to confirm the doc reads cleanly.
