### PR TITLE
chore(deps): bump vatly-api-php to ^0.1.0-alpha.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vatly/vatly-api-php": "^0.1.0-alpha.10"
+        "vatly/vatly-api-php": "^0.1.0-alpha.11"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
Adopts the latest `vatly/vatly-api-php` release, **v0.1.0-alpha.11**, which adds recognition of the `webhook.setup` verification event.

Dependency bump only — no fluent source changes required.

## Verification
- `composer test` → 184 tests, 543 assertions, all passing
- `composer analyse` (PHPStan) → no errors
