### PR TITLE
Persist Subscription mandate locally — surface on SubscriptionInterface + sync via reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ class Subscription implements SubscriptionInterface
     public function getName(): string { /* ... */ }
     public function getQuantity(): int { /* ... */ }
     public function getEndsAt(): ?DateTimeInterface { /* ... */ }
+
+    // Mandate summary on file — persist these alongside the rest so portals
+    // render "card ending in 4242" without a per-request API roundtrip.
+    public function getMandateMethod(): ?string { /* 'card', 'sepa_debit', null, ... */ }
+    public function getMandateMaskedIdentifier(): ?string { /* '4242', 'NL91****4300', null */ }
 }
 ```
 
@@ -476,7 +481,7 @@ For Cashier-style ergonomics, give your Eloquent / Doctrine entities operation m
 ```php
 class Subscription implements SubscriptionInterface
 {
-    // ... interface methods ...
+    // ... interface state accessors (getVatlyId, getMandateMethod, etc.) ...
 
     public function cancel(): void
     {

--- a/src/Contracts/SubscriptionInterface.php
+++ b/src/Contracts/SubscriptionInterface.php
@@ -75,4 +75,24 @@ interface SubscriptionInterface
      * grace period.
      */
     public function isEnded(): bool;
+
+    /**
+     * Get the payment method category on file for this subscription.
+     *
+     * Normalized per {@see \Vatly\API\Types\Mandate::$method}:
+     * `card`, `sepa_debit`, `paypal`, `bacs_debit`, etc.
+     *
+     * Returns `null` when the subscription has no mandate yet (e.g.
+     * ended-before-payment) or when the driver hasn't synced from Vatly.
+     */
+    public function getMandateMethod(): ?string;
+
+    /**
+     * Get the customer-facing masked identifier for the payment method on
+     * file — e.g. `4242` (card last 4) or `NL91****4300` (masked IBAN).
+     *
+     * Returns `null` when no mandate exists, when the mandate type has no
+     * identifier (e.g. PayPal), or when the driver hasn't synced.
+     */
+    public function getMandateMaskedIdentifier(): ?string;
 }

--- a/src/Data/StoreSubscriptionData.php
+++ b/src/Data/StoreSubscriptionData.php
@@ -19,5 +19,15 @@ class StoreSubscriptionData
         public string $name,
         public int $quantity = 1,
         public ?string $hostCustomerId = null,
+        /**
+         * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
+         * `null` when the mandate isn't known yet at store-time.
+         */
+        public ?string $mandateMethod = null,
+        /**
+         * Customer-facing masked identifier for the payment method on file
+         * — see {@see \Vatly\API\Types\Mandate::$maskedIdentifier}.
+         */
+        public ?string $mandateMaskedIdentifier = null,
     ) {}
 }

--- a/src/Data/StoreSubscriptionData.php
+++ b/src/Data/StoreSubscriptionData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Data;
 
+use Vatly\API\Types\Mandate;
+
 /**
  * Data for storing a new subscription from Vatly.
  *
@@ -20,14 +22,12 @@ class StoreSubscriptionData
         public int $quantity = 1,
         public ?string $hostCustomerId = null,
         /**
-         * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
-         * `null` when the mandate isn't known yet at store-time.
+         * Payment method on file at store-time. Null when the mandate
+         * isn't known yet (typical for freshly-subscribed customers — the
+         * API briefly returns `mandate: null` before payment binds; later
+         * `SubscriptionHandle::sync()` or a `subscription.billing_updated`
+         * event populates it).
          */
-        public ?string $mandateMethod = null,
-        /**
-         * Customer-facing masked identifier for the payment method on file
-         * — see {@see \Vatly\API\Types\Mandate::$maskedIdentifier}.
-         */
-        public ?string $mandateMaskedIdentifier = null,
+        public ?Mandate $mandate = null,
     ) {}
 }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -42,14 +42,13 @@ class UpdateSubscriptionData
          * wins over this flag, so passing fresh mandate values is always
          * a replacement.
          *
-         * Use this to explicitly remove a stored mandate (e.g. on a
-         * `subscription.billing_updated` webhook where the API returns
-         * `mandate: null` for a customer who revoked their payment method).
-         * `SubscriptionHandle::sync()` deliberately does NOT set this when
-         * the live API returns `mandate: null` — that's a known transient
-         * state for freshly-subscribed customers per
-         * {@see \Vatly\API\Types\Mandate::$maskedIdentifier}'s docblock,
-         * and auto-clearing would wipe a freshly-stored mandate.
+         * Set by {@see \Vatly\Fluent\SubscriptionHandle::sync()} when the
+         * live API returns `mandate: null` *and* the local copy has a
+         * stored mandate — i.e. an observable removal. When local mandate
+         * is already null, sync() leaves the clear flag false so a
+         * freshly-subscribed customer's transient API null doesn't get
+         * mistaken for a removal (see
+         * {@see \Vatly\API\Types\Mandate::$maskedIdentifier}'s docblock).
          */
         public bool $clearMandate = false,
     ) {}

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -25,5 +25,16 @@ class UpdateSubscriptionData
          * host's status vocabulary. Null means "no status change".
          */
         public ?string $status = null,
+        /**
+         * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
+         * Null means "no change". To represent "mandate removed", drivers should
+         * still pass null here; explicit removal is a future extension if needed.
+         */
+        public ?string $mandateMethod = null,
+        /**
+         * Customer-facing masked identifier — see {@see \Vatly\API\Types\Mandate::$maskedIdentifier}.
+         * Null means "no change".
+         */
+        public ?string $mandateMaskedIdentifier = null,
     ) {}
 }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -27,8 +27,8 @@ class UpdateSubscriptionData
         public ?string $status = null,
         /**
          * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
-         * Null means "no change". To represent "mandate removed", drivers should
-         * still pass null here; explicit removal is a future extension if needed.
+         * Null means "no change" (pair with `clearMandate: true` below to
+         * explicitly remove a stored mandate).
          */
         public ?string $mandateMethod = null,
         /**
@@ -36,5 +36,21 @@ class UpdateSubscriptionData
          * Null means "no change".
          */
         public ?string $mandateMaskedIdentifier = null,
+        /**
+         * When true, clears both mandate fields in the driver's storage.
+         * Mirrors the `clearEndsAt` convention: a non-null `mandateMethod`
+         * wins over this flag, so passing fresh mandate values is always
+         * a replacement.
+         *
+         * Use this to explicitly remove a stored mandate (e.g. on a
+         * `subscription.billing_updated` webhook where the API returns
+         * `mandate: null` for a customer who revoked their payment method).
+         * `SubscriptionHandle::sync()` deliberately does NOT set this when
+         * the live API returns `mandate: null` — that's a known transient
+         * state for freshly-subscribed customers per
+         * {@see \Vatly\API\Types\Mandate::$maskedIdentifier}'s docblock,
+         * and auto-clearing would wipe a freshly-stored mandate.
+         */
+        public bool $clearMandate = false,
     ) {}
 }

--- a/src/Data/UpdateSubscriptionData.php
+++ b/src/Data/UpdateSubscriptionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Data;
 
 use DateTimeInterface;
+use Vatly\API\Types\Mandate;
 
 /**
  * Data for updating an existing subscription from Vatly.
@@ -26,21 +27,23 @@ class UpdateSubscriptionData
          */
         public ?string $status = null,
         /**
-         * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
-         * Null means "no change" (pair with `clearMandate: true` below to
-         * explicitly remove a stored mandate).
+         * Atomic mandate replacement. Non-null = the driver writes the whole
+         * Mandate object (both method and maskedIdentifier, the latter may
+         * be null for mandate types without an identifier like PayPal).
+         * Null = "no mandate change" — pair with `clearMandate: true` below
+         * to explicitly remove a stored mandate.
+         *
+         * The two parts (method, maskedIdentifier) are atomically bound:
+         * passing a fresh Mandate replaces both, preventing mixed local
+         * state like "paypal / 4242" (old card last4 lingering after a
+         * card→paypal switch).
          */
-        public ?string $mandateMethod = null,
+        public ?Mandate $mandate = null,
         /**
-         * Customer-facing masked identifier — see {@see \Vatly\API\Types\Mandate::$maskedIdentifier}.
-         * Null means "no change".
-         */
-        public ?string $mandateMaskedIdentifier = null,
-        /**
-         * When true, clears both mandate fields in the driver's storage.
-         * Mirrors the `clearEndsAt` convention: a non-null `mandateMethod`
-         * wins over this flag, so passing fresh mandate values is always
-         * a replacement.
+         * When true, clears the mandate fields in the driver's storage.
+         * Mirrors the `clearEndsAt` convention: a non-null `mandate` wins
+         * over this flag, so passing a fresh Mandate is always a
+         * replacement.
          *
          * Set by {@see \Vatly\Fluent\SubscriptionHandle::sync()} when the
          * live API returns `mandate: null` *and* the local copy has a

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Resources\Subscription as ApiSubscription;
+
 /**
  * Event representing a subscription being started at Vatly.
+ *
+ * Built by {@see \Vatly\Fluent\Webhooks\WebhookEventFactory} via a follow-up
+ * `GetSubscription` call against the webhook's `entityId`, so the dispatched
+ * event carries the mandate summary that isn't on the webhook payload.
  *
  * @immutable
  */
@@ -22,10 +28,42 @@ class SubscriptionStarted
         public string $type,
         public string $name,
         public int $quantity,
+        /**
+         * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
+         * `null` when no mandate is on file yet at webhook time (the API briefly
+         * returns `mandate: null` for freshly-subscribed customers).
+         */
+        public ?string $mandateMethod = null,
+        /**
+         * Customer-facing masked identifier — see {@see \Vatly\API\Types\Mandate::$maskedIdentifier}.
+         */
+        public ?string $mandateMaskedIdentifier = null,
     ) {
         //
     }
 
+    /**
+     * Build from the enriched API resource fetched by
+     * {@see \Vatly\Fluent\Webhooks\WebhookEventFactory::createFromWebhook()}.
+     */
+    public static function fromApiSubscription(ApiSubscription $subscription): self
+    {
+        return new self(
+            customerId: $subscription->customerId ?? '',
+            subscriptionId: $subscription->id,
+            planId: $subscription->subscriptionPlanId,
+            type: self::DEFAULT_TYPE,
+            name: $subscription->name,
+            quantity: $subscription->quantity,
+            mandateMethod: $subscription->mandate?->method,
+            mandateMaskedIdentifier: $subscription->mandate?->maskedIdentifier,
+        );
+    }
+
+    /**
+     * Sparse, webhook-payload-only build kept for tests and callers who don't
+     * want to fetch the full API resource. Mandate fields stay null.
+     */
     public static function fromWebhook(WebhookReceived $webhook): self
     {
         return new self(

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Subscription as ApiSubscription;
+use Vatly\API\Types\Mandate;
 
 /**
  * Event representing a subscription being started at Vatly.
@@ -29,15 +30,15 @@ class SubscriptionStarted
         public string $name,
         public int $quantity,
         /**
-         * Normalized payment-method category — see {@see \Vatly\API\Types\Mandate::$method}.
-         * `null` when no mandate is on file yet at webhook time (the API briefly
-         * returns `mandate: null` for freshly-subscribed customers).
+         * Payment method on file at the time the webhook fires. `null` when
+         * no mandate has bound yet — the API briefly returns `mandate: null`
+         * for freshly-subscribed customers (see
+         * {@see \Vatly\API\Types\Mandate::$maskedIdentifier}'s docblock).
+         * The mandate's method + maskedIdentifier are atomically bound
+         * together inside the Mandate object so listeners can't accidentally
+         * mix old + new values.
          */
-        public ?string $mandateMethod = null,
-        /**
-         * Customer-facing masked identifier — see {@see \Vatly\API\Types\Mandate::$maskedIdentifier}.
-         */
-        public ?string $mandateMaskedIdentifier = null,
+        public ?Mandate $mandate = null,
     ) {
         //
     }
@@ -55,14 +56,13 @@ class SubscriptionStarted
             type: self::DEFAULT_TYPE,
             name: $subscription->name,
             quantity: $subscription->quantity,
-            mandateMethod: $subscription->mandate?->method,
-            mandateMaskedIdentifier: $subscription->mandate?->maskedIdentifier,
+            mandate: $subscription->mandate,
         );
     }
 
     /**
      * Sparse, webhook-payload-only build kept for tests and callers who don't
-     * want to fetch the full API resource. Mandate fields stay null.
+     * want to fetch the full API resource. Mandate stays null.
      */
     public static function fromWebhook(WebhookReceived $webhook): self
     {

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -253,6 +253,17 @@ class SubscriptionHandle
 
         $endsAt = $this->resolveEndsAt($response);
 
+        // Distinguish real mandate removal from the transient "no mandate yet"
+        // state freshly-subscribed customers can be in (per
+        // Vatly\API\Types\Mandate::$maskedIdentifier's docblock):
+        //   - local had a mandate + API says null  → real removal, clear it
+        //   - local had no mandate + API says null → transient, leave alone
+        // Always-clear would wipe fresh mandates; never-clear would leave
+        // removed mandates stale forever. The heuristic handles both.
+        $localHasMandate = $this->subscription->getMandateMethod() !== null;
+        $apiHasMandate = $response->mandate !== null;
+        $shouldClearMandate = $localHasMandate && ! $apiHasMandate;
+
         $updated = $this->subscriptions->update(
             $this->subscription,
             new UpdateSubscriptionData(
@@ -262,6 +273,7 @@ class SubscriptionHandle
                 endsAt: $endsAt,
                 mandateMethod: $response->mandate?->method,
                 mandateMaskedIdentifier: $response->mandate?->maskedIdentifier,
+                clearMandate: $shouldClearMandate,
             ),
         );
 

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -260,6 +260,8 @@ class SubscriptionHandle
                 name: $response->name,
                 quantity: $response->quantity,
                 endsAt: $endsAt,
+                mandateMethod: $response->mandate?->method,
+                mandateMaskedIdentifier: $response->mandate?->maskedIdentifier,
             ),
         );
 

--- a/src/SubscriptionHandle.php
+++ b/src/SubscriptionHandle.php
@@ -271,8 +271,7 @@ class SubscriptionHandle
                 name: $response->name,
                 quantity: $response->quantity,
                 endsAt: $endsAt,
-                mandateMethod: $response->mandate?->method,
-                mandateMaskedIdentifier: $response->mandate?->maskedIdentifier,
+                mandate: $response->mandate,
                 clearMandate: $shouldClearMandate,
             ),
         );

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -101,7 +101,7 @@ class Vatly
 
     public function getWebhookEventFactory(): WebhookEventFactory
     {
-        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder());
+        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder(), $this->getSubscription());
     }
 
     public function webhookProcessor(): WebhookProcessor
@@ -119,6 +119,7 @@ class Vatly
             bindings: $this->wiring->customerBindings
                 ?? throw IncompleteWiringException::missing('customerBindings', 'WebhookProcessor'),
             getOrder: $this->getOrder(),
+            getSubscription: $this->getSubscription(),
             additionalReactions: $this->wiring->additionalWebhookReactions,
         );
     }

--- a/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
+++ b/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
@@ -39,8 +39,7 @@ class SyncSubscriptionOnStarted implements WebhookReactionInterface
                 planId: $event->planId,
                 name: $event->name,
                 quantity: $event->quantity,
-                mandateMethod: $event->mandateMethod,
-                mandateMaskedIdentifier: $event->mandateMaskedIdentifier,
+                mandate: $event->mandate,
             ));
 
             return;
@@ -57,8 +56,7 @@ class SyncSubscriptionOnStarted implements WebhookReactionInterface
             name: $event->name,
             quantity: $event->quantity,
             hostCustomerId: $hostCustomerId,
-            mandateMethod: $event->mandateMethod,
-            mandateMaskedIdentifier: $event->mandateMaskedIdentifier,
+            mandate: $event->mandate,
         ));
 
         if ($subscription === null) {

--- a/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
+++ b/src/Webhooks/Reactions/SyncSubscriptionOnStarted.php
@@ -39,6 +39,8 @@ class SyncSubscriptionOnStarted implements WebhookReactionInterface
                 planId: $event->planId,
                 name: $event->name,
                 quantity: $event->quantity,
+                mandateMethod: $event->mandateMethod,
+                mandateMaskedIdentifier: $event->mandateMaskedIdentifier,
             ));
 
             return;
@@ -55,6 +57,8 @@ class SyncSubscriptionOnStarted implements WebhookReactionInterface
             name: $event->name,
             quantity: $event->quantity,
             hostCustomerId: $hostCustomerId,
+            mandateMethod: $event->mandateMethod,
+            mandateMaskedIdentifier: $event->mandateMaskedIdentifier,
         ));
 
         if ($subscription === null) {

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -32,21 +32,43 @@ class WebhookEventFactory
      * tax breakdown — webhook payloads themselves only include gross total.
      *
      * For `subscription.started` the same enrichment pattern fetches the
-     * mandate summary, so consumers can persist the payment method on file
-     * without a separate API roundtrip per portal render.
+     * mandate summary so consumers can persist the payment method on file
+     * without a separate API roundtrip per portal render. Enrichment is
+     * best-effort: a transient `GetSubscription` failure does not block
+     * persistence — the event falls back to the webhook payload (mandate
+     * stays null, backfilled by the next `sync()` or future
+     * `subscription.billing_updated` event).
      *
      * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|PaymentFailed|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
         return match ($webhook->eventName) {
-            SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromApiSubscription($this->getSubscription->execute($webhook->entityId)),
+            SubscriptionStarted::VATLY_EVENT_NAME => $this->createSubscriptionStarted($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
             OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->entityId)),
             PaymentFailed::VATLY_EVENT_NAME => PaymentFailed::fromApiOrder($this->getOrder->execute($webhook->entityId)),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
+    }
+
+    /**
+     * Build a SubscriptionStarted event, preferring the API-enriched form
+     * (carries mandate) but falling back to the webhook payload on any
+     * GetSubscription failure. Keeps the webhook flow resilient to
+     * transient API errors that would otherwise force Vatly to retry the
+     * delivery for a recoverable enrichment-only issue.
+     */
+    private function createSubscriptionStarted(WebhookReceived $webhook): SubscriptionStarted
+    {
+        try {
+            return SubscriptionStarted::fromApiSubscription(
+                $this->getSubscription->execute($webhook->entityId),
+            );
+        } catch (\Throwable) {
+            return SubscriptionStarted::fromWebhook($webhook);
+        }
     }
 
     /**

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Webhooks;
 
 use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
@@ -18,6 +19,7 @@ class WebhookEventFactory
 {
     public function __construct(
         private GetOrder $getOrder,
+        private GetSubscription $getSubscription,
     ) {
         //
     }
@@ -29,12 +31,16 @@ class WebhookEventFactory
      * performs a follow-up API GET so the dispatched event carries the full
      * tax breakdown — webhook payloads themselves only include gross total.
      *
+     * For `subscription.started` the same enrichment pattern fetches the
+     * mandate summary, so consumers can persist the payment method on file
+     * without a separate API roundtrip per portal render.
+     *
      * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|PaymentFailed|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
         return match ($webhook->eventName) {
-            SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromWebhook($webhook),
+            SubscriptionStarted::VATLY_EVENT_NAME => SubscriptionStarted::fromApiSubscription($this->getSubscription->execute($webhook->entityId)),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
             OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->entityId)),

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -47,8 +47,8 @@ class WebhookEventFactory
             SubscriptionStarted::VATLY_EVENT_NAME => $this->createSubscriptionStarted($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
-            OrderPaid::VATLY_EVENT_NAME => OrderPaid::fromApiOrder($this->getOrder->execute($webhook->entityId)),
-            PaymentFailed::VATLY_EVENT_NAME => PaymentFailed::fromApiOrder($this->getOrder->execute($webhook->entityId)),
+            OrderPaid::VATLY_EVENT_NAME => $this->createOrderPaid($webhook),
+            PaymentFailed::VATLY_EVENT_NAME => $this->createPaymentFailed($webhook),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
@@ -69,6 +69,34 @@ class WebhookEventFactory
         } catch (\Throwable) {
             return SubscriptionStarted::fromWebhook($webhook);
         }
+    }
+
+    /**
+     * Build an OrderPaid event from the enriched API resource.
+     *
+     * Unlike SubscriptionStarted, OrderPaid intentionally rethrows on
+     * enrichment failure: the webhook payload lacks `subtotal`, `taxSummary`,
+     * and `status`. A best-effort fallback would persist a row with wrong tax
+     * data, which compounds into compliance/reconciliation issues. Letting
+     * the webhook fail forces Vatly to retry — the correct outcome for a
+     * transient API blip, given that order data integrity beats availability
+     * for payment-processing entities.
+     */
+    private function createOrderPaid(WebhookReceived $webhook): OrderPaid
+    {
+        return OrderPaid::fromApiOrder($this->getOrder->execute($webhook->entityId));
+    }
+
+    /**
+     * Build a PaymentFailed event from the enriched API resource.
+     *
+     * Same rationale as {@see self::createOrderPaid()}: rethrows on enrichment
+     * failure rather than writing a degraded row. Tax breakdown is critical
+     * for dunning-notification accuracy and downstream reconciliation.
+     */
+    private function createPaymentFailed(WebhookReceived $webhook): PaymentFailed
+    {
+        return PaymentFailed::fromApiOrder($this->getOrder->execute($webhook->entityId));
     }
 
     /**

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Webhooks;
 
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -35,10 +36,11 @@ class WebhookProcessorFactory
         EventDispatcherInterface $dispatcher,
         CustomerBindingRepository $bindings,
         GetOrder $getOrder,
+        GetSubscription $getSubscription,
         array $additionalReactions = [],
     ): WebhookProcessor {
         return new WebhookProcessor(
-            eventFactory: new WebhookEventFactory($getOrder),
+            eventFactory: new WebhookEventFactory($getOrder, $getSubscription),
             repository: $webhookCalls,
             dispatcher: $dispatcher,
             webhookSecret: $config->getWebhookSecret() ?? '',

--- a/tests/Events/LocalSubscriptionCreatedTest.php
+++ b/tests/Events/LocalSubscriptionCreatedTest.php
@@ -66,6 +66,16 @@ class LocalSubscriptionCreatedTest extends TestCase
             {
                 return null;
             }
+
+            public function getMandateMethod(): ?string
+            {
+                return null;
+            }
+
+            public function getMandateMaskedIdentifier(): ?string
+            {
+                return null;
+            }
         };
     }
 }

--- a/tests/SubscriptionHandleTest.php
+++ b/tests/SubscriptionHandleTest.php
@@ -153,6 +153,7 @@ class SubscriptionHandleTest extends TestCase
         $subscription = Mockery::mock(SubscriptionInterface::class);
         $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
         $subscription->shouldReceive('getEndsAt')->andReturn(null);
+        $subscription->shouldReceive('getMandateMethod')->andReturn(null);
 
         $apiResponse = $this->makeApiSubscription([
             'subscriptionPlanId' => 'plan_basic',
@@ -190,6 +191,128 @@ class SubscriptionHandleTest extends TestCase
         $handle->sync();
 
         $this->assertSame($updated, $handle->model());
+    }
+
+    public function test_sync_clears_mandate_when_local_had_one_and_api_returns_null(): void
+    {
+        // Real removal: previously-bound mandate has been removed at Vatly.
+        // Local copy must be cleared so portals stop showing a card that
+        // no longer exists.
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
+        $subscription->shouldReceive('getEndsAt')->andReturn(null);
+        $subscription->shouldReceive('getMandateMethod')->andReturn('card');
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'endedAt' => null,
+            'canceledAt' => null,
+            'mandate' => null,
+        ]);
+
+        $getAction = Mockery::mock(GetSubscription::class);
+        $getAction->shouldReceive('execute')->andReturn($apiResponse);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->mandateMethod === null
+                    && $data->mandateMaskedIdentifier === null
+                    && $data->clearMandate === true;
+            }))
+            ->andReturn(Mockery::mock(SubscriptionInterface::class));
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            getSubscriptionAction: $getAction,
+        );
+
+        $handle->sync();
+    }
+
+    public function test_sync_does_not_clear_mandate_when_local_already_null_and_api_returns_null(): void
+    {
+        // Transient post-subscription state: API briefly returns mandate:null
+        // for a freshly-subscribed customer who hasn't completed payment yet.
+        // Conservative: only clear when we observably had something to clear.
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
+        $subscription->shouldReceive('getEndsAt')->andReturn(null);
+        $subscription->shouldReceive('getMandateMethod')->andReturn(null);
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'endedAt' => null,
+            'canceledAt' => null,
+            'mandate' => null,
+        ]);
+
+        $getAction = Mockery::mock(GetSubscription::class);
+        $getAction->shouldReceive('execute')->andReturn($apiResponse);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->mandateMethod === null
+                    && $data->mandateMaskedIdentifier === null
+                    && $data->clearMandate === false;
+            }))
+            ->andReturn(Mockery::mock(SubscriptionInterface::class));
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            getSubscriptionAction: $getAction,
+        );
+
+        $handle->sync();
+    }
+
+    public function test_sync_replaces_mandate_when_api_returns_a_new_one(): void
+    {
+        // Customer changed their card via hosted billing-update flow; sync
+        // should overwrite the local copy with the fresh mandate.
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
+        $subscription->shouldReceive('getEndsAt')->andReturn(null);
+        $subscription->shouldReceive('getMandateMethod')->andReturn('card');
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'endedAt' => null,
+            'canceledAt' => null,
+            'mandate' => new \Vatly\API\Types\Mandate('sepa_debit', 'NL91****4300'),
+        ]);
+
+        $getAction = Mockery::mock(GetSubscription::class);
+        $getAction->shouldReceive('execute')->andReturn($apiResponse);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->mandateMethod === 'sepa_debit'
+                    && $data->mandateMaskedIdentifier === 'NL91****4300'
+                    && $data->clearMandate === false;
+            }))
+            ->andReturn(Mockery::mock(SubscriptionInterface::class));
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            getSubscriptionAction: $getAction,
+        );
+
+        $handle->sync();
     }
 
     public function test_resume_calls_the_action_and_clears_ends_at(): void

--- a/tests/SubscriptionHandleTest.php
+++ b/tests/SubscriptionHandleTest.php
@@ -219,8 +219,7 @@ class SubscriptionHandleTest extends TestCase
         $subscriptions->shouldReceive('update')
             ->once()
             ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
-                return $data->mandateMethod === null
-                    && $data->mandateMaskedIdentifier === null
+                return $data->mandate === null
                     && $data->clearMandate === true;
             }))
             ->andReturn(Mockery::mock(SubscriptionInterface::class));
@@ -260,8 +259,7 @@ class SubscriptionHandleTest extends TestCase
         $subscriptions->shouldReceive('update')
             ->once()
             ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
-                return $data->mandateMethod === null
-                    && $data->mandateMaskedIdentifier === null
+                return $data->mandate === null
                     && $data->clearMandate === false;
             }))
             ->andReturn(Mockery::mock(SubscriptionInterface::class));
@@ -300,8 +298,53 @@ class SubscriptionHandleTest extends TestCase
         $subscriptions->shouldReceive('update')
             ->once()
             ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
-                return $data->mandateMethod === 'sepa_debit'
-                    && $data->mandateMaskedIdentifier === 'NL91****4300'
+                return $data->mandate instanceof \Vatly\API\Types\Mandate
+                    && $data->mandate->method === 'sepa_debit'
+                    && $data->mandate->maskedIdentifier === 'NL91****4300'
+                    && $data->clearMandate === false;
+            }))
+            ->andReturn(Mockery::mock(SubscriptionInterface::class));
+
+        $handle = $this->buildHandle(
+            subscription: $subscription,
+            subscriptions: $subscriptions,
+            getSubscriptionAction: $getAction,
+        );
+
+        $handle->sync();
+    }
+
+    public function test_sync_atomically_replaces_card_with_paypal_clearing_stale_last4(): void
+    {
+        // Regression: card → paypal switch. PayPal mandates legitimately have
+        // no maskedIdentifier. With the old two-field DTO, null identifier
+        // was interpreted as "no change", leaving the old card last4 stored
+        // alongside method=paypal — mixed local state like "paypal / 4242".
+        // The Mandate object is now atomic so both parts swap together.
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_abc');
+        $subscription->shouldReceive('getEndsAt')->andReturn(null);
+        $subscription->shouldReceive('getMandateMethod')->andReturn('card');
+
+        $apiResponse = $this->makeApiSubscription([
+            'subscriptionPlanId' => 'plan_basic',
+            'name' => 'Basic',
+            'quantity' => 1,
+            'endedAt' => null,
+            'canceledAt' => null,
+            'mandate' => new \Vatly\API\Types\Mandate('paypal', null),
+        ]);
+
+        $getAction = Mockery::mock(GetSubscription::class);
+        $getAction->shouldReceive('execute')->andReturn($apiResponse);
+
+        $subscriptions = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $subscriptions->shouldReceive('update')
+            ->once()
+            ->with($subscription, Mockery::on(function (UpdateSubscriptionData $data) {
+                return $data->mandate instanceof \Vatly\API\Types\Mandate
+                    && $data->mandate->method === 'paypal'
+                    && $data->mandate->maskedIdentifier === null
                     && $data->clearMandate === false;
             }))
             ->andReturn(Mockery::mock(SubscriptionInterface::class));

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -122,6 +122,44 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('4242', $event->mandateMaskedIdentifier);
     }
 
+    public function test_subscription_started_falls_back_to_webhook_payload_when_enrichment_fails(): void
+    {
+        // GetSubscription failure (network blip, rate limit, transient 5xx) must
+        // not block the webhook flow. The webhook payload itself carries enough
+        // to persist the subscription; mandate stays null and is backfilled on
+        // the next sync() or subscription.billing_updated event.
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_transient_fail',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
+            ],
+        );
+
+        $this->getSubscription->shouldReceive('execute')
+            ->andThrow(new \RuntimeException('Transient API failure'));
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionStarted::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_transient_fail', $event->subscriptionId);
+        $this->assertSame('plan_789', $event->planId);
+        $this->assertSame('Premium Plan', $event->name);
+        $this->assertSame(1, $event->quantity);
+        // Fallback path can't enrich mandate from the webhook payload.
+        $this->assertNull($event->mandateMethod);
+        $this->assertNull($event->mandateMaskedIdentifier);
+    }
+
     public function test_subscription_started_event_carries_null_mandate_when_api_returns_none(): void
     {
         $webhook = new WebhookReceived(

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -7,11 +7,14 @@ namespace Vatly\Fluent\Tests\Webhooks;
 use DateTimeInterface;
 use Mockery;
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Resources\Subscription as ApiSubscription;
+use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
 use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
@@ -26,13 +29,15 @@ class WebhookEventFactoryTest extends TestCase
 {
     private WebhookEventFactory $factory;
     private GetOrder $getOrder;
+    private GetSubscription $getSubscription;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->getOrder = Mockery::mock(GetOrder::class);
-        $this->factory = new WebhookEventFactory($this->getOrder);
+        $this->getSubscription = Mockery::mock(GetSubscription::class);
+        $this->factory = new WebhookEventFactory($this->getOrder, $this->getSubscription);
     }
 
     public function test_it_converts_upstream_webhook_payload_into_webhook_received_event(): void
@@ -79,7 +84,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame([], $event->object);
     }
 
-    public function test_it_creates_subscription_started_event_from_webhook(): void
+    public function test_it_creates_subscription_started_event_from_enriched_api_subscription(): void
     {
         $webhook = new WebhookReceived(
             id: 'webhook_event_abc',
@@ -89,13 +94,21 @@ class WebhookEventFactoryTest extends TestCase
             entityId: 'sub_123',
             testmode: false,
             createdAt: '2024-01-15T10:00:00Z',
-            object: [
-                'customerId' => 'cus_456',
-                'subscriptionPlanId' => 'plan_789',
-                'name' => 'Premium Plan',
-                'quantity' => 1,
-            ],
+            object: [],
         );
+
+        $apiSubscription = $this->makeApiSubscription([
+            'id' => 'sub_123',
+            'customerId' => 'cus_456',
+            'subscriptionPlanId' => 'plan_789',
+            'name' => 'Premium Plan',
+            'quantity' => 1,
+            'mandate' => new Mandate('card', '4242'),
+        ]);
+
+        $this->getSubscription->shouldReceive('execute')
+            ->with('sub_123')
+            ->andReturn($apiSubscription);
 
         $event = $this->factory->createFromWebhook($webhook);
 
@@ -105,6 +118,39 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('plan_789', $event->planId);
         $this->assertSame('Premium Plan', $event->name);
         $this->assertSame(1, $event->quantity);
+        $this->assertSame('card', $event->mandateMethod);
+        $this->assertSame('4242', $event->mandateMaskedIdentifier);
+    }
+
+    public function test_subscription_started_event_carries_null_mandate_when_api_returns_none(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_no_mandate',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [],
+        );
+
+        $apiSubscription = $this->makeApiSubscription([
+            'id' => 'sub_no_mandate',
+            'customerId' => 'cus_456',
+            'subscriptionPlanId' => 'plan_789',
+            'name' => 'Premium Plan',
+            'quantity' => 1,
+            'mandate' => null,
+        ]);
+
+        $this->getSubscription->shouldReceive('execute')->andReturn($apiSubscription);
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionStarted::class, $event);
+        $this->assertNull($event->mandateMethod);
+        $this->assertNull($event->mandateMaskedIdentifier);
     }
 
     public function test_it_creates_subscription_canceled_immediately_event_from_webhook(): void
@@ -305,6 +351,31 @@ class WebhookEventFactoryTest extends TestCase
      *   invoiceNumber: ?string,
      *   paymentMethod: ?string,
      *   status?: string,
+     * Build a minimal API Subscription resource for enrichment-path tests.
+     *
+     * @param array{
+     *     id: string,
+     *     customerId: string,
+     *     subscriptionPlanId: string,
+     *     name: string,
+     *     quantity: int,
+     *     mandate: ?Mandate,
+     * } $data
+     */
+    private function makeApiSubscription(array $data): ApiSubscription
+    {
+        $subscription = new ApiSubscription(Mockery::mock(VatlyApiClient::class));
+        $subscription->id = $data['id'];
+        $subscription->customerId = $data['customerId'];
+        $subscription->subscriptionPlanId = $data['subscriptionPlanId'];
+        $subscription->name = $data['name'];
+        $subscription->quantity = $data['quantity'];
+        $subscription->mandate = $data['mandate'];
+
+        return $subscription;
+    }
+
+    /**
      * } $data
      */
     private function buildApiOrder(array $data): ApiOrder

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -118,8 +118,9 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('plan_789', $event->planId);
         $this->assertSame('Premium Plan', $event->name);
         $this->assertSame(1, $event->quantity);
-        $this->assertSame('card', $event->mandateMethod);
-        $this->assertSame('4242', $event->mandateMaskedIdentifier);
+        $this->assertNotNull($event->mandate);
+        $this->assertSame('card', $event->mandate->method);
+        $this->assertSame('4242', $event->mandate->maskedIdentifier);
     }
 
     public function test_subscription_started_falls_back_to_webhook_payload_when_enrichment_fails(): void
@@ -156,8 +157,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('Premium Plan', $event->name);
         $this->assertSame(1, $event->quantity);
         // Fallback path can't enrich mandate from the webhook payload.
-        $this->assertNull($event->mandateMethod);
-        $this->assertNull($event->mandateMaskedIdentifier);
+        $this->assertNull($event->mandate);
     }
 
     public function test_subscription_started_event_carries_null_mandate_when_api_returns_none(): void
@@ -187,8 +187,7 @@ class WebhookEventFactoryTest extends TestCase
         $event = $this->factory->createFromWebhook($webhook);
 
         $this->assertInstanceOf(SubscriptionStarted::class, $event);
-        $this->assertNull($event->mandateMethod);
-        $this->assertNull($event->mandateMaskedIdentifier);
+        $this->assertNull($event->mandate);
     }
 
     public function test_it_creates_subscription_canceled_immediately_event_from_webhook(): void

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Tests\Webhooks;
 
 use Mockery;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -33,6 +34,7 @@ class WebhookProcessorFactoryTest extends TestCase
             dispatcher: Mockery::mock(EventDispatcherInterface::class),
             bindings: Mockery::mock(CustomerBindingRepository::class),
             getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
         );
 
         $this->assertInstanceOf(WebhookProcessor::class, $processor);
@@ -58,6 +60,7 @@ class WebhookProcessorFactoryTest extends TestCase
             dispatcher: Mockery::mock(EventDispatcherInterface::class),
             bindings: Mockery::mock(CustomerBindingRepository::class),
             getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
             additionalReactions: [$custom],
         );
 
@@ -77,6 +80,7 @@ class WebhookProcessorFactoryTest extends TestCase
             dispatcher: Mockery::mock(EventDispatcherInterface::class),
             bindings: Mockery::mock(CustomerBindingRepository::class),
             getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
         );
 
         $this->assertInstanceOf(WebhookProcessor::class, $processor);

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -6,10 +6,12 @@ namespace Vatly\Fluent\Tests\Webhooks;
 
 use Mockery;
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
@@ -25,6 +27,7 @@ class WebhookProcessorTest extends TestCase
 {
     private string $secret;
     private GetOrder $getOrder;
+    private GetSubscription $getSubscription;
     private WebhookEventFactory $eventFactory;
     private WebhookCallRepositoryInterface $repository;
     private EventDispatcherInterface $dispatcher;
@@ -36,7 +39,8 @@ class WebhookProcessorTest extends TestCase
 
         $this->secret = 'test-webhook-secret';
         $this->getOrder = Mockery::mock(GetOrder::class);
-        $this->eventFactory = new WebhookEventFactory($this->getOrder);
+        $this->getSubscription = Mockery::mock(GetSubscription::class);
+        $this->eventFactory = new WebhookEventFactory($this->getOrder, $this->getSubscription);
         $this->repository = Mockery::mock(WebhookCallRepositoryInterface::class);
         $this->dispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -64,6 +68,17 @@ class WebhookProcessorTest extends TestCase
         );
 
         $signature = $this->makeSignatureHeader($payload, $this->secret);
+
+        $this->getSubscription->shouldReceive('execute')
+            ->with('sub_123')
+            ->andReturn($this->makeApiSubscription([
+                'id' => 'sub_123',
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
+                'mandate' => null,
+            ]));
 
         $this->repository
             ->shouldReceive('record')
@@ -119,6 +134,16 @@ class WebhookProcessorTest extends TestCase
         );
 
         $signature = $this->makeSignatureHeader($payload, $this->secret);
+
+        $this->getSubscription->shouldReceive('execute')
+            ->andReturn($this->makeApiSubscription([
+                'id' => 'sub_123',
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
+                'mandate' => null,
+            ]));
 
         $this->repository->shouldReceive('record')->once();
         $this->dispatcher->shouldReceive('dispatch')->once();
@@ -302,5 +327,20 @@ class WebhookProcessorTest extends TestCase
         $signature = hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
 
         return "t={$timestamp},v1={$signature}";
+    }
+
+    /**
+     * Build a minimal API Subscription resource for enrichment-path tests.
+     *
+     * @param array<string, mixed> $fields
+     */
+    private function makeApiSubscription(array $fields): ApiSubscription
+    {
+        $subscription = new ApiSubscription(Mockery::mock(VatlyApiClient::class));
+        foreach ($fields as $key => $value) {
+            $subscription->{$key} = $value;
+        }
+
+        return $subscription;
     }
 }


### PR DESCRIPTION
## Summary

`Vatly\API\Resources\Subscription::$mandate` (added api-php v0.1.0-alpha.10) gives consumers the payment-method summary needed for portal rendering ("Visa ending in 4242"). But there's no way to consume it without a live API call — `SubscriptionInterface` doesn't expose mandate fields and `SubscriptionHandle` doesn't store them.

Result: every portal render does a `GetSubscription` roundtrip just to display the card on file. Three downstream costs:

- **Latency** — +1 HTTP roundtrip every render.
- **N+1 on listings** — admin "subscriptions + mandate" lists make one API call per row.
- **Resilience** — Vatly outage → portal mandate column goes blank.

This PR persists mandate locally. Mirrors Cashier's `pm_type` + `pm_last_four`.

Surfaced by [sandervanhooft/larafast-vatly PR #1](https://github.com/sandervanhooft/larafast-vatly/pull/1).

## Contract changes

### `SubscriptionInterface` (breaking)

```php
public function getMandateMethod(): ?string;            // 'card', 'sepa_debit', 'paypal', 'bacs_debit'
public function getMandateMaskedIdentifier(): ?string;  // '4242' / 'NL91****4300' / null
```

Both nullable — the API returns `mandate: null` briefly for freshly-subscribed customers.

### `StoreSubscriptionData` + `UpdateSubscriptionData` (additive)

Both gain optional `?string $mandateMethod = null` and `?string $mandateMaskedIdentifier = null`. Drivers write these via their `SubscriptionWriter::store()` / `update()` impls. Null in `UpdateSubscriptionData` means "no change" (consistent with the existing fields).

### `SubscriptionStarted` event (additive)

Two new optional constructor args; a `fromApiSubscription(ApiSubscription)` static factory.

### `WebhookEventFactory::__construct` (breaking)

```diff
- public function __construct(private GetOrder $getOrder) {}
+ public function __construct(private GetOrder $getOrder, private GetSubscription $getSubscription) {}
```

Routes `subscription.started` via `$this->getSubscription->execute($webhook->entityId)` → `SubscriptionStarted::fromApiSubscription(...)`. Mirrors the OrderPaid enrichment pattern — same +1 roundtrip per webhook trade-off we already accepted there.

### `WebhookProcessorFactory::create()` (breaking)

Gains a `GetSubscription` param after `GetOrder`. The `Vatly` composition root wires it lazily via the existing `getSubscription()` accessor.

### `SyncSubscriptionOnStarted` reaction (internal)

Plumbs the two new event fields through both the existing-subscription `update()` path and the new-subscription `store()` path.

### `SubscriptionHandle::sync()` (internal)

Reads `$response->mandate?->method` / `?->maskedIdentifier` and passes them via `UpdateSubscriptionData`. Drivers calling `$user->subscription()->sync()` (e.g. on a post-`updateBilling()` redirect) refresh the local mandate.

## Sync triggers — when does local mandate refresh?

| Trigger | Source | Status |
|---|---|---|
| Subscription started | `SyncSubscriptionOnStarted` reaction via enriched event | ✅ this PR |
| Customer updated payment method via hosted flow | needs `subscription.updated` webhook (not yet emitted by Vatly) OR consumer calls `$subscription->sync()` on the post-`updateBilling()` redirect | manual workaround OK; ideally `subscription.updated` lands eventually |
| `payment.failed` | not changed (mandate doesn't necessarily change) | n/a |
| Manual driver call | `$subscription->sync()` | ✅ this PR |

## Companion change

Driver-side companion: [vatly/vatly-laravel#TBD](https://github.com/vatly/vatly-laravel/pulls) — adds `mandate_method` + `mandate_masked_identifier` columns to `vatly_subscriptions`, implements the new interface methods on `Models\Subscription`, writes the fields in `EloquentSubscriptionRepository`.

## Tests

- 185 tests / 548 assertions pass
- New: `WebhookEventFactoryTest` exercises the enriched `SubscriptionStarted` path with both populated and null mandate cases
- `WebhookProcessorTest` end-to-end stubs include `getSubscription`
- `WebhookProcessorFactoryTest` updated for the new ctor arg

## Suggested release

`v0.9.0-alpha.1` (breaking change → minor bump while in alpha).