### PR TITLE
feat(webhooks): cover refunds, chargebacks, order.canceled, billing_updated & resumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,22 @@ For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in
 | Vatly event              | Dispatched event class                                            | Built-in reaction              | Repo method(s) called                                |
 |--------------------------|-------------------------------------------------------------------|--------------------------------|------------------------------------------------------|
 | `order.paid`             | `OrderPaid`                                                       | `StoreOrderOnPaid`             | `OrderWriter::store` (new) / `OrderWriter::update` (existing) |
+| `order.canceled`         | `OrderCanceled`                                                   | `CancelOrderOnCanceled`        | `OrderWriter::update` (mirrors `canceled` status)    |
+| `order.chargeback_received` | `OrderChargebackReceived`                                      | — (dispatched only)            | none — driver-handled                                |
+| `order.chargeback_reversed` | `OrderChargebackReversed`                                      | — (dispatched only)            | none — driver-handled                                |
+| `refund.completed` / `refund.failed` / `refund.canceled` | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | `SyncRefundOnStatusChange` *(opt-in)* | `RefundWriter::store` (new) / `::update` (existing) |
 | `subscription.started`   | `SubscriptionStarted`                                             | `SyncSubscriptionOnStarted`    | `SubscriptionWriter::store` (new) / `::update` (existing) |
+| `subscription.billing_updated` | `SubscriptionBillingUpdated`                               | `SyncSubscriptionOnBillingUpdated` | `SubscriptionWriter::update` (refreshes mandate)    |
+| `subscription.resumed`   | `SubscriptionResumed`                                             | `ResumeSubscriptionOnResumed`  | `SubscriptionWriter::update` (clears end date)       |
 | `subscription.canceled`  | `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update`                         |
 
-Both `OrderWriter::store` and `SubscriptionWriter::store` may return `null` if your driver can't route the data (see the adapter recipe below). Built-in reactions tolerate null — `SyncSubscriptionOnStarted` skips its follow-up `LocalSubscriptionCreated` dispatch when store returns null.
+`OrderWriter::store`, `SubscriptionWriter::store`, and `RefundWriter::store` may return `null` if your driver can't route the data (see the adapter recipe below). Built-in reactions tolerate null — `SyncSubscriptionOnStarted` skips its follow-up `LocalSubscriptionCreated` dispatch when store returns null.
+
+`subscription.billing_updated`, `subscription.resumed`, and `order.canceled` are find-or-skip: they update an existing local record but never create one. `subscription.billing_updated` re-fetches the subscription to keep the stored mandate (card last-4, masked IBAN) in step with the payment method on file; `subscription.resumed` clears the stored end date so a resume reactivates the derived state; `order.canceled` mirrors Vatly's `canceled` status onto the local order.
+
+**Refunds** are opt-in: supply a `RefundRepositoryInterface` via `Wiring(refunds: …)` and the built-in `SyncRefundOnStatusChange` reaction persists `refund.*` webhooks (store-or-update, like orders) — unblocking terminal-state refund reconciliation. Omit it and the typed refund events are still dispatched for you to handle. Refund events are enriched via `GetRefund` so they carry the full tax breakdown, mirroring `order.paid`.
+
+**Chargebacks** ship no built-in reaction: Vatly's public order status doesn't change on a chargeback, so fluent doesn't synthesize one. Instead `OrderChargebackReceived` / `OrderChargebackReversed` are dispatched (with the affected order's ID as `orderId`) for your driver to react to — e.g. suspend access on receipt, reinstate on reversal.
 
 `additionalWebhookReactions` (on `WebhookProcessorFactory::create`) lets you append driver-specific reactions without losing the built-ins.
 
@@ -299,6 +311,7 @@ Each entity-side contract has three methods. See [src/Contracts](src/Contracts) 
 
 - `SubscriptionRepositoryInterface` — `findByVatlyId`, `store`, `update`
 - `OrderRepositoryInterface` — `findByVatlyId`, `store`, `update`
+- `RefundRepositoryInterface` — `findByVatlyId`, `store`, `update` (**optional** — only needed to persist `refund.*` webhooks)
 - `WebhookCallRepositoryInterface` — record received webhook calls (audit log)
 
 `StoreSubscriptionData` and `StoreOrderData` both carry an optional `hostCustomerId` resolved from the binding repo when fluent persists from a webhook reaction. Use it to fill your host-side owner column when it's set, and accept `null` for the anonymous-checkout flow.
@@ -541,6 +554,7 @@ In [src/Contracts](src/Contracts):
 - `CustomerBindingRepository` — bidirectional mapping between Vatly customer ids and host ids
 - `SubscriptionRepositoryInterface` — subscription persistence (3 methods). Splits into `SubscriptionReader` (find) + `SubscriptionWriter` (store/update).
 - `OrderRepositoryInterface` — order persistence (3 methods). Splits into `OrderReader` (find) + `OrderWriter` (store/update).
+- `RefundRepositoryInterface` — refund persistence (optional; 3 methods). Splits into `RefundReader` (find) + `RefundWriter` (store/update).
 - `WebhookCallRepositoryInterface` — webhook audit log (write-only by nature)
 - `EventDispatcherInterface` — fire domain events
 - `ConfigurationInterface` — API key, URL, version, webhook secret, redirect defaults
@@ -552,7 +566,12 @@ Dispatched by webhook reactions through your `EventDispatcherInterface`. Subscri
 
 - `WebhookReceived` — raw webhook envelope (typed shape; `object` is the resource payload)
 - `OrderPaid` — order with full `taxSummary` breakdown, ready to materialize local invoices
+- `OrderCanceled`
+- `OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId`
+- `RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary` breakdown
 - `SubscriptionStarted`
+- `SubscriptionBillingUpdated` — billing/mandate changed; carries the refreshed mandate summary
+- `SubscriptionResumed`
 - `SubscriptionCanceledImmediately`
 - `SubscriptionCanceledWithGracePeriod`
 - `LocalSubscriptionCreated`

--- a/src/Actions/GetRefund.php
+++ b/src/Actions/GetRefund.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Actions;
+
+use Vatly\API\Resources\Refund;
+
+class GetRefund extends BaseAction
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function execute(string $refundId, array $parameters = []): Refund
+    {
+        $refund = $this->vatlyApiClient->refunds->get($refundId, $parameters);
+
+        assert($refund instanceof Refund);
+
+        return $refund;
+    }
+}

--- a/src/Contracts/RefundInterface.php
+++ b/src/Contracts/RefundInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Interface for refund entities.
+ *
+ * Mirrors {@see OrderInterface}: a thin read surface over the driver's own
+ * persisted refund row, populated from Vatly's `refund.*` webhooks.
+ */
+interface RefundInterface
+{
+    /**
+     * Get the Vatly refund ID.
+     */
+    public function getVatlyId(): string;
+
+    /**
+     * Get the raw Vatly refund status (e.g. "refunded", "failed", "canceled").
+     */
+    public function getStatus(): string;
+
+    /**
+     * Get the refund total, in integer cents.
+     */
+    public function getTotal(): int;
+
+    /**
+     * Get the currency.
+     */
+    public function getCurrency(): string;
+
+    /**
+     * Get the Vatly ID of the order the refund was issued against.
+     */
+    public function getOriginalOrderId(): string;
+
+    /**
+     * Whether the refund has completed (funds returned to the customer).
+     */
+    public function isCompleted(): bool;
+}

--- a/src/Contracts/RefundReader.php
+++ b/src/Contracts/RefundReader.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Read-side of the refund repository contract.
+ *
+ * Pairs with {@see RefundWriter}.
+ */
+interface RefundReader
+{
+    /**
+     * Find a refund by its Vatly ID.
+     */
+    public function findByVatlyId(string $vatlyId): ?RefundInterface;
+}

--- a/src/Contracts/RefundRepositoryInterface.php
+++ b/src/Contracts/RefundRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Full refund repository — both read and write sides.
+ *
+ * Supplying this to {@see \Vatly\Fluent\Wiring} is optional: when present the
+ * built-in {@see \Vatly\Fluent\Webhooks\Reactions\SyncRefundOnStatusChange}
+ * reaction persists `refund.*` webhooks; when absent the typed refund events
+ * are still dispatched for drivers to handle themselves.
+ */
+interface RefundRepositoryInterface extends RefundReader, RefundWriter
+{
+    //
+}

--- a/src/Contracts/RefundWriter.php
+++ b/src/Contracts/RefundWriter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+use Vatly\Fluent\Data\StoreRefundData;
+use Vatly\Fluent\Data\UpdateRefundData;
+
+/**
+ * Write-side of the refund repository contract.
+ *
+ * Pairs with {@see RefundReader}.
+ */
+interface RefundWriter
+{
+    /**
+     * Store a new refund from Vatly.
+     *
+     * Returns `null` when the driver legitimately cannot route the store
+     * (e.g. it can't locate the original order locally). Built-in reactions
+     * tolerate null.
+     */
+    public function store(StoreRefundData $data): ?RefundInterface;
+
+    /**
+     * Update an existing refund from Vatly.
+     */
+    public function update(RefundInterface $refund, UpdateRefundData $data): RefundInterface;
+}

--- a/src/Data/StoreRefundData.php
+++ b/src/Data/StoreRefundData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Data;
+
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Data for storing a new refund from Vatly.
+ *
+ * @immutable
+ */
+class StoreRefundData
+{
+    public function __construct(
+        public string $vatlyId,
+        public string $customerId,
+        public string $status,
+        public int $total,
+        public string $currency,
+        public string $originalOrderId,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
+        public ?string $hostCustomerId = null,
+    ) {}
+}

--- a/src/Data/UpdateRefundData.php
+++ b/src/Data/UpdateRefundData.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Data;
+
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Data for updating an existing refund from Vatly.
+ *
+ * @immutable
+ */
+class UpdateRefundData
+{
+    public function __construct(
+        public ?string $status = null,
+        public ?int $total = null,
+        public ?string $currency = null,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
+    ) {}
+}

--- a/src/Events/OrderCanceled.php
+++ b/src/Events/OrderCanceled.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+/**
+ * Event representing an order being canceled at Vatly.
+ *
+ * The `order.canceled` webhook carries the full order payload including the
+ * new `status` ("canceled"), so — unlike `order.paid` — no API enrichment is
+ * needed: the built-in reaction only mirrors the status onto the local row.
+ *
+ * @immutable
+ */
+class OrderCanceled
+{
+    public const VATLY_EVENT_NAME = 'order.canceled';
+
+    public function __construct(
+        public string $customerId,
+        public string $orderId,
+        public string $status,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            customerId: $webhook->object['customerId'] ?? '',
+            orderId: $webhook->entityId,
+            status: $webhook->object['status'] ?? 'canceled',
+        );
+    }
+}

--- a/src/Events/OrderChargebackReceived.php
+++ b/src/Events/OrderChargebackReceived.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+/**
+ * Event representing a chargeback being received against an order at Vatly.
+ *
+ * Vatly's public order status does not change on a chargeback, so fluent ships
+ * no built-in reaction that mutates local state (mirroring Vatly rather than
+ * synthesizing a status it never returns). Instead this typed event is
+ * dispatched so drivers can react — e.g. suspend access tied to the order and
+ * open the dispute window. The envelope's `entityId` is the order ID, so the
+ * driver can locate the affected order directly.
+ *
+ * @immutable
+ */
+class OrderChargebackReceived
+{
+    public const VATLY_EVENT_NAME = 'order.chargeback_received';
+
+    public function __construct(
+        public string $orderId,
+        public string $chargebackId,
+        public string $originalOrderId,
+        public ?string $reason = null,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            orderId: $webhook->entityId,
+            chargebackId: $webhook->object['id'] ?? '',
+            originalOrderId: $webhook->object['originalOrderId'] ?? $webhook->entityId,
+            reason: $webhook->object['reason'] ?? null,
+        );
+    }
+}

--- a/src/Events/OrderChargebackReversed.php
+++ b/src/Events/OrderChargebackReversed.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+/**
+ * Event representing a previously-received chargeback being reversed at Vatly.
+ *
+ * Counterpart to {@see OrderChargebackReceived}: dispatched so drivers can
+ * reinstate access they suspended on the original chargeback. As with the
+ * received event, Vatly's public order status is unchanged, so fluent ships no
+ * built-in state-mutating reaction. The envelope's `entityId` is the order ID.
+ *
+ * @immutable
+ */
+class OrderChargebackReversed
+{
+    public const VATLY_EVENT_NAME = 'order.chargeback_reversed';
+
+    public function __construct(
+        public string $orderId,
+        public string $chargebackId,
+        public string $originalOrderId,
+        public ?string $reason = null,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            orderId: $webhook->entityId,
+            chargebackId: $webhook->object['id'] ?? '',
+            originalOrderId: $webhook->object['originalOrderId'] ?? $webhook->entityId,
+            reason: $webhook->object['reason'] ?? null,
+        );
+    }
+}

--- a/src/Events/RefundCanceled.php
+++ b/src/Events/RefundCanceled.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Event representing a pending refund being canceled before it is sent at Vatly.
+ *
+ * Carries the full tax breakdown so consumers can reconcile a local refund row
+ * without a follow-up API call. The {@see \Vatly\Fluent\Webhooks\WebhookEventFactory}
+ * enriches via `GetRefund` before dispatching — mirroring the `order.paid`
+ * pattern, since refund tax data is compliance-critical and must be authoritative.
+ *
+ * @immutable
+ */
+class RefundCanceled
+{
+    public const VATLY_EVENT_NAME = 'refund.canceled';
+
+    public function __construct(
+        public string $customerId,
+        public string $refundId,
+        public string $status,
+        public int $total,
+        public int $subtotal,
+        public TaxSummary $taxSummary,
+        public string $currency,
+        public string $originalOrderId,
+    ) {
+        //
+    }
+
+    public static function fromApiRefund(ApiRefund $refund): self
+    {
+        return new self(
+            customerId: $refund->customerId,
+            refundId: $refund->id,
+            status: $refund->status,
+            total: Money::fromApiMoneyToCents($refund->total),
+            subtotal: Money::fromApiMoneyToCents($refund->subtotal),
+            taxSummary: TaxSummary::fromApiResource($refund->taxSummary),
+            currency: $refund->total->currency,
+            originalOrderId: $refund->originalOrderId,
+        );
+    }
+}

--- a/src/Events/RefundCompleted.php
+++ b/src/Events/RefundCompleted.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Event representing a refund completing (funds returned to the customer) at Vatly.
+ *
+ * Carries the full tax breakdown so consumers can reconcile a local refund row
+ * without a follow-up API call. The {@see \Vatly\Fluent\Webhooks\WebhookEventFactory}
+ * enriches via `GetRefund` before dispatching — mirroring the `order.paid`
+ * pattern, since refund tax data is compliance-critical and must be authoritative.
+ *
+ * @immutable
+ */
+class RefundCompleted
+{
+    public const VATLY_EVENT_NAME = 'refund.completed';
+
+    public function __construct(
+        public string $customerId,
+        public string $refundId,
+        public string $status,
+        public int $total,
+        public int $subtotal,
+        public TaxSummary $taxSummary,
+        public string $currency,
+        public string $originalOrderId,
+    ) {
+        //
+    }
+
+    public static function fromApiRefund(ApiRefund $refund): self
+    {
+        return new self(
+            customerId: $refund->customerId,
+            refundId: $refund->id,
+            status: $refund->status,
+            total: Money::fromApiMoneyToCents($refund->total),
+            subtotal: Money::fromApiMoneyToCents($refund->subtotal),
+            taxSummary: TaxSummary::fromApiResource($refund->taxSummary),
+            currency: $refund->total->currency,
+            originalOrderId: $refund->originalOrderId,
+        );
+    }
+}

--- a/src/Events/RefundFailed.php
+++ b/src/Events/RefundFailed.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Event representing a refund failing after processing at Vatly.
+ *
+ * Carries the full tax breakdown so consumers can reconcile a local refund row
+ * without a follow-up API call. The {@see \Vatly\Fluent\Webhooks\WebhookEventFactory}
+ * enriches via `GetRefund` before dispatching — mirroring the `order.paid`
+ * pattern, since refund tax data is compliance-critical and must be authoritative.
+ *
+ * @immutable
+ */
+class RefundFailed
+{
+    public const VATLY_EVENT_NAME = 'refund.failed';
+
+    public function __construct(
+        public string $customerId,
+        public string $refundId,
+        public string $status,
+        public int $total,
+        public int $subtotal,
+        public TaxSummary $taxSummary,
+        public string $currency,
+        public string $originalOrderId,
+    ) {
+        //
+    }
+
+    public static function fromApiRefund(ApiRefund $refund): self
+    {
+        return new self(
+            customerId: $refund->customerId,
+            refundId: $refund->id,
+            status: $refund->status,
+            total: Money::fromApiMoneyToCents($refund->total),
+            subtotal: Money::fromApiMoneyToCents($refund->subtotal),
+            taxSummary: TaxSummary::fromApiResource($refund->taxSummary),
+            currency: $refund->total->currency,
+            originalOrderId: $refund->originalOrderId,
+        );
+    }
+}

--- a/src/Events/SubscriptionBillingUpdated.php
+++ b/src/Events/SubscriptionBillingUpdated.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Resources\Subscription as ApiSubscription;
+use Vatly\API\Types\Mandate;
+
+/**
+ * Event representing a subscription's billing details — most importantly the
+ * payment method on file — being updated at Vatly.
+ *
+ * Fired when a customer completes the hosted "update billing" flow (or the
+ * mandate otherwise changes server-side). Built by
+ * {@see \Vatly\Fluent\Webhooks\WebhookEventFactory} via a follow-up
+ * `GetSubscription` call against the webhook's `entityId`, so the dispatched
+ * event carries the fresh mandate summary that isn't on the webhook payload.
+ *
+ * This is the companion to {@see SubscriptionStarted}: `started` captures the
+ * initial mandate, this event keeps it current. Without it, a mandate
+ * persisted at subscription start goes stale the moment the customer switches
+ * cards or payment methods.
+ *
+ * @immutable
+ */
+class SubscriptionBillingUpdated
+{
+    public const VATLY_EVENT_NAME = 'subscription.billing_updated';
+
+    public function __construct(
+        public string $customerId,
+        public string $subscriptionId,
+        public string $planId,
+        public string $name,
+        public int $quantity,
+        /**
+         * Payment method on file after the update. `null` when enrichment
+         * fell back to the webhook payload (which doesn't carry the mandate)
+         * — in that case {@see \Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnBillingUpdated}
+         * leaves the stored mandate untouched rather than wiping it, and the
+         * next `sync()` backfills the change. The mandate's method +
+         * maskedIdentifier are atomically bound together inside the Mandate
+         * object so listeners can't mix old + new values.
+         */
+        public ?Mandate $mandate = null,
+    ) {
+        //
+    }
+
+    /**
+     * Build from the enriched API resource fetched by
+     * {@see \Vatly\Fluent\Webhooks\WebhookEventFactory::createFromWebhook()}.
+     */
+    public static function fromApiSubscription(ApiSubscription $subscription): self
+    {
+        return new self(
+            customerId: $subscription->customerId ?? '',
+            subscriptionId: $subscription->id,
+            planId: $subscription->subscriptionPlanId,
+            name: $subscription->name,
+            quantity: $subscription->quantity,
+            mandate: $subscription->mandate,
+        );
+    }
+
+    /**
+     * Sparse, webhook-payload-only build used when API enrichment fails.
+     * Mandate stays null — the whole point of this event — so the reaction
+     * deliberately makes no mandate change and defers to the next sync().
+     */
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            customerId: $webhook->object['customerId'],
+            subscriptionId: $webhook->entityId,
+            planId: $webhook->object['subscriptionPlanId'],
+            name: $webhook->object['name'],
+            quantity: $webhook->object['quantity'],
+        );
+    }
+}

--- a/src/Events/SubscriptionResumed.php
+++ b/src/Events/SubscriptionResumed.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+/**
+ * Event representing a previously-canceled subscription being resumed at Vatly.
+ *
+ * The inverse of the cancellation events: where
+ * {@see SubscriptionCanceledImmediately} / {@see SubscriptionCanceledWithGracePeriod}
+ * stamp an end date onto the local record,
+ * {@see \Vatly\Fluent\Webhooks\Reactions\ResumeSubscriptionOnResumed} clears it,
+ * re-activating the derived state. Carries no mandate/plan changes — resume
+ * doesn't touch billing — so it's built straight from the webhook payload
+ * without an enriching API roundtrip.
+ *
+ * @immutable
+ */
+class SubscriptionResumed
+{
+    public const VATLY_EVENT_NAME = 'subscription.resumed';
+
+    public function __construct(
+        public string $customerId,
+        public string $subscriptionId,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            customerId: $webhook->object['customerId'],
+            subscriptionId: $webhook->entityId,
+        );
+    }
+}

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -10,6 +10,7 @@ use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Actions\ResumeSubscription;
 use Vatly\Fluent\Actions\SwapSubscriptionPlan;
@@ -44,6 +45,7 @@ class Vatly
     private ?CreateCustomer $createCustomer = null;
     private ?GetCustomer $getCustomer = null;
     private ?GetOrder $getOrder = null;
+    private ?GetRefund $getRefund = null;
     private ?CreateCheckout $createCheckout = null;
     private ?GetSubscription $getSubscription = null;
     private ?CancelSubscription $cancelSubscription = null;
@@ -101,7 +103,7 @@ class Vatly
 
     public function getWebhookEventFactory(): WebhookEventFactory
     {
-        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder(), $this->getSubscription());
+        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder(), $this->getSubscription(), $this->getRefund());
     }
 
     public function webhookProcessor(): WebhookProcessor
@@ -120,6 +122,8 @@ class Vatly
                 ?? throw IncompleteWiringException::missing('customerBindings', 'WebhookProcessor'),
             getOrder: $this->getOrder(),
             getSubscription: $this->getSubscription(),
+            getRefund: $this->getRefund(),
+            refunds: $this->wiring->refunds,
             additionalReactions: $this->wiring->additionalWebhookReactions,
         );
     }
@@ -204,6 +208,11 @@ class Vatly
     public function getOrder(): GetOrder
     {
         return $this->getOrder ??= new GetOrder($this->apiClient);
+    }
+
+    public function getRefund(): GetRefund
+    {
+        return $this->getRefund ??= new GetRefund($this->apiClient);
     }
 
     public function createCheckout(): CreateCheckout

--- a/src/Webhooks/Reactions/CancelOrderOnCanceled.php
+++ b/src/Webhooks/Reactions/CancelOrderOnCanceled.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Data\UpdateOrderData;
+use Vatly\Fluent\Events\OrderCanceled;
+
+/**
+ * Mirrors an order cancellation from Vatly onto the local order row.
+ *
+ * Find-or-skip: a cancellation for an order we never recorded is a no-op
+ * (we don't fabricate a canceled row from nothing). The status is taken
+ * verbatim from the event — fluent mirrors Vatly's status vocabulary rather
+ * than synthesizing its own.
+ *
+ * @immutable
+ */
+class CancelOrderOnCanceled implements WebhookReactionInterface
+{
+    public function __construct(
+        private OrderRepositoryInterface $orders,
+    ) {}
+
+    public function supports(object $event): bool
+    {
+        return $event instanceof OrderCanceled;
+    }
+
+    public function handle(object $event): void
+    {
+        if (! $event instanceof OrderCanceled) {
+            return;
+        }
+
+        $order = $this->orders->findByVatlyId($event->orderId);
+
+        if ($order === null) {
+            return;
+        }
+
+        $this->orders->update($order, new UpdateOrderData(
+            status: $event->status,
+        ));
+    }
+}

--- a/src/Webhooks/Reactions/ResumeSubscriptionOnResumed.php
+++ b/src/Webhooks/Reactions/ResumeSubscriptionOnResumed.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Events\SubscriptionResumed;
+
+/**
+ * Clears the stored end date when a subscription is resumed at Vatly,
+ * re-activating the local record.
+ *
+ * The inverse of {@see CancelSubscriptionOnCanceled}: that stamps `endsAt`,
+ * this clears it via `UpdateSubscriptionData::clearEndsAt`. With `endsAt`
+ * null the {@see \Vatly\Fluent\Concerns\DerivesSubscriptionState} predicates
+ * report the subscription as active/recurring again. Matters most for resumes
+ * that happen out-of-band (hosted portal, dashboard) rather than through the
+ * SDK's own `SubscriptionHandle::resume()`, where the local record would
+ * otherwise keep showing the prior cancellation's end date.
+ *
+ * Find-or-skip: a resume for an untracked subscription is a no-op.
+ *
+ * @immutable
+ */
+class ResumeSubscriptionOnResumed implements WebhookReactionInterface
+{
+    public function __construct(
+        private SubscriptionRepositoryInterface $subscriptions,
+    ) {}
+
+    public function supports(object $event): bool
+    {
+        return $event instanceof SubscriptionResumed;
+    }
+
+    public function handle(object $event): void
+    {
+        if (! $event instanceof SubscriptionResumed) {
+            return;
+        }
+
+        $subscription = $this->subscriptions->findByVatlyId($event->subscriptionId);
+
+        if ($subscription === null) {
+            return;
+        }
+
+        $this->subscriptions->update($subscription, new UpdateSubscriptionData(
+            clearEndsAt: true,
+        ));
+    }
+}

--- a/src/Webhooks/Reactions/SyncRefundOnStatusChange.php
+++ b/src/Webhooks/Reactions/SyncRefundOnStatusChange.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Data\StoreRefundData;
+use Vatly\Fluent\Data\UpdateRefundData;
+use Vatly\Fluent\Events\RefundCanceled;
+use Vatly\Fluent\Events\RefundCompleted;
+use Vatly\Fluent\Events\RefundFailed;
+
+/**
+ * Persists `refund.*` webhooks onto the driver's local refund row — the piece
+ * that unblocks terminal-state refund reconciliation for consumers that record
+ * refunds in a pending state when they're initiated.
+ *
+ * Store-or-update, mirroring {@see StoreOrderOnPaid}: if the refund is already
+ * tracked locally it's updated with the new status/totals; otherwise it's
+ * stored (resolving the host customer via bindings). Registered only when a
+ * {@see RefundRepositoryInterface} is wired — without one, the typed refund
+ * events are still dispatched for drivers to handle.
+ *
+ * @immutable
+ */
+class SyncRefundOnStatusChange implements WebhookReactionInterface
+{
+    public function __construct(
+        private RefundRepositoryInterface $refunds,
+        private CustomerBindingRepository $bindings,
+    ) {}
+
+    public function supports(object $event): bool
+    {
+        return $event instanceof RefundCompleted
+            || $event instanceof RefundFailed
+            || $event instanceof RefundCanceled;
+    }
+
+    public function handle(object $event): void
+    {
+        if (! $event instanceof RefundCompleted
+            && ! $event instanceof RefundFailed
+            && ! $event instanceof RefundCanceled) {
+            return;
+        }
+
+        $existing = $this->refunds->findByVatlyId($event->refundId);
+
+        if ($existing !== null) {
+            $this->refunds->update($existing, new UpdateRefundData(
+                status: $event->status,
+                total: $event->total,
+                currency: $event->currency,
+                subtotal: $event->subtotal,
+                taxSummary: $event->taxSummary,
+            ));
+
+            return;
+        }
+
+        $hostCustomerId = null;
+        if ($event->customerId !== '') {
+            $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
+            $this->bindings->record($event->customerId);
+        }
+
+        $this->refunds->store(new StoreRefundData(
+            vatlyId: $event->refundId,
+            customerId: $event->customerId,
+            status: $event->status,
+            total: $event->total,
+            currency: $event->currency,
+            originalOrderId: $event->originalOrderId,
+            subtotal: $event->subtotal,
+            taxSummary: $event->taxSummary,
+            hostCustomerId: $hostCustomerId,
+        ));
+    }
+}

--- a/src/Webhooks/Reactions/SyncSubscriptionOnBillingUpdated.php
+++ b/src/Webhooks/Reactions/SyncSubscriptionOnBillingUpdated.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Events\SubscriptionBillingUpdated;
+
+/**
+ * Refreshes the locally-stored subscription when its billing details change
+ * at Vatly — keeping the persisted mandate (card last-4, masked IBAN, …) in
+ * step with the payment method actually on file.
+ *
+ * Unlike {@see SyncSubscriptionOnStarted} this never *creates* a local record:
+ * a billing update for a subscription we've never seen means we missed its
+ * `subscription.started`, and fabricating a half-known row from a
+ * billing-update payload would be wrong. It mirrors
+ * {@see CancelSubscriptionOnCanceled}'s find-or-skip stance instead.
+ *
+ * A null mandate on the event (enrichment fell back to the webhook payload)
+ * is treated as "no mandate change" — `UpdateSubscriptionData`'s default —
+ * so a transient API blip never wipes a good stored mandate; the next
+ * `sync()` reconciles.
+ *
+ * @immutable
+ */
+class SyncSubscriptionOnBillingUpdated implements WebhookReactionInterface
+{
+    public function __construct(
+        private SubscriptionRepositoryInterface $subscriptions,
+    ) {}
+
+    public function supports(object $event): bool
+    {
+        return $event instanceof SubscriptionBillingUpdated;
+    }
+
+    public function handle(object $event): void
+    {
+        if (! $event instanceof SubscriptionBillingUpdated) {
+            return;
+        }
+
+        $subscription = $this->subscriptions->findByVatlyId($event->subscriptionId);
+
+        if ($subscription === null) {
+            return;
+        }
+
+        $this->subscriptions->update($subscription, new UpdateSubscriptionData(
+            planId: $event->planId,
+            name: $event->name,
+            quantity: $event->quantity,
+            mandate: $event->mandate,
+        ));
+    }
+}

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -6,11 +6,20 @@ namespace Vatly\Fluent\Webhooks;
 
 use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Events\OrderCanceled;
+use Vatly\Fluent\Events\OrderChargebackReceived;
+use Vatly\Fluent\Events\OrderChargebackReversed;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\PaymentFailed;
+use Vatly\Fluent\Events\RefundCanceled;
+use Vatly\Fluent\Events\RefundCompleted;
+use Vatly\Fluent\Events\RefundFailed;
+use Vatly\Fluent\Events\SubscriptionBillingUpdated;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
+use Vatly\Fluent\Events\SubscriptionResumed;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
 use Vatly\Fluent\Events\WebhookReceived;
@@ -20,6 +29,7 @@ class WebhookEventFactory
     public function __construct(
         private GetOrder $getOrder,
         private GetSubscription $getSubscription,
+        private GetRefund $getRefund,
     ) {
         //
     }
@@ -31,24 +41,39 @@ class WebhookEventFactory
      * performs a follow-up API GET so the dispatched event carries the full
      * tax breakdown — webhook payloads themselves only include gross total.
      *
-     * For `subscription.started` the same enrichment pattern fetches the
-     * mandate summary so consumers can persist the payment method on file
-     * without a separate API roundtrip per portal render. Enrichment is
-     * best-effort: a transient `GetSubscription` failure does not block
-     * persistence — the event falls back to the webhook payload (mandate
-     * stays null, backfilled by the next `sync()` or future
-     * `subscription.billing_updated` event).
+     * For `subscription.started` and `subscription.billing_updated` the same
+     * enrichment pattern fetches the mandate summary so consumers can persist
+     * the payment method on file without a separate API roundtrip per portal
+     * render. Enrichment is best-effort: a transient `GetSubscription` failure
+     * does not block persistence — the event falls back to the webhook payload
+     * (mandate stays null, backfilled by the next `sync()`).
      *
-     * @return SubscriptionStarted|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|PaymentFailed|UnsupportedWebhookReceived
+     * For `refund.*` events the factory enriches via `GetRefund` for the same
+     * reason as `order.paid`: refund tax data is compliance-critical and the
+     * dispatched event must carry the authoritative breakdown.
+     *
+     * `order.canceled` and the `order.chargeback_*` events are built straight
+     * from the webhook payload — a status mirror and dispute signals
+     * respectively, neither of which needs enrichment.
+     *
+     * @return SubscriptionStarted|SubscriptionBillingUpdated|SubscriptionResumed|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|OrderCanceled|OrderChargebackReceived|OrderChargebackReversed|PaymentFailed|RefundCompleted|RefundFailed|RefundCanceled|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
         return match ($webhook->eventName) {
             SubscriptionStarted::VATLY_EVENT_NAME => $this->createSubscriptionStarted($webhook),
+            SubscriptionBillingUpdated::VATLY_EVENT_NAME => $this->createSubscriptionBillingUpdated($webhook),
+            SubscriptionResumed::VATLY_EVENT_NAME => SubscriptionResumed::fromWebhook($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
             OrderPaid::VATLY_EVENT_NAME => $this->createOrderPaid($webhook),
+            OrderCanceled::VATLY_EVENT_NAME => OrderCanceled::fromWebhook($webhook),
+            OrderChargebackReceived::VATLY_EVENT_NAME => OrderChargebackReceived::fromWebhook($webhook),
+            OrderChargebackReversed::VATLY_EVENT_NAME => OrderChargebackReversed::fromWebhook($webhook),
             PaymentFailed::VATLY_EVENT_NAME => $this->createPaymentFailed($webhook),
+            RefundCompleted::VATLY_EVENT_NAME => RefundCompleted::fromApiRefund($this->getRefund->execute($webhook->entityId)),
+            RefundFailed::VATLY_EVENT_NAME => RefundFailed::fromApiRefund($this->getRefund->execute($webhook->entityId)),
+            RefundCanceled::VATLY_EVENT_NAME => RefundCanceled::fromApiRefund($this->getRefund->execute($webhook->entityId)),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
@@ -68,6 +93,26 @@ class WebhookEventFactory
             );
         } catch (\Throwable) {
             return SubscriptionStarted::fromWebhook($webhook);
+        }
+    }
+
+    /**
+     * Build a SubscriptionBillingUpdated event, preferring the API-enriched
+     * form (carries the fresh mandate) but falling back to the webhook payload
+     * on any GetSubscription failure. Same resilience rationale as
+     * {@see self::createSubscriptionStarted()}: the mandate refresh is an
+     * enrichment, not a correctness requirement — a transient blip leaves the
+     * stored mandate as-is rather than forcing Vatly to retry the delivery,
+     * and the next `sync()` reconciles.
+     */
+    private function createSubscriptionBillingUpdated(WebhookReceived $webhook): SubscriptionBillingUpdated
+    {
+        try {
+            return SubscriptionBillingUpdated::fromApiSubscription(
+                $this->getSubscription->execute($webhook->entityId),
+            );
+        } catch (\Throwable) {
+            return SubscriptionBillingUpdated::fromWebhook($webhook);
         }
     }
 
@@ -131,10 +176,18 @@ class WebhookEventFactory
     {
         return [
             SubscriptionStarted::VATLY_EVENT_NAME,
+            SubscriptionBillingUpdated::VATLY_EVENT_NAME,
+            SubscriptionResumed::VATLY_EVENT_NAME,
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME,
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME,
             OrderPaid::VATLY_EVENT_NAME,
+            OrderCanceled::VATLY_EVENT_NAME,
+            OrderChargebackReceived::VATLY_EVENT_NAME,
+            OrderChargebackReversed::VATLY_EVENT_NAME,
             PaymentFailed::VATLY_EVENT_NAME,
+            RefundCompleted::VATLY_EVENT_NAME,
+            RefundFailed::VATLY_EVENT_NAME,
+            RefundCanceled::VATLY_EVENT_NAME,
         ];
     }
 

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Webhooks;
 
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Webhooks\Reactions\CancelOrderOnCanceled;
 use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+use Vatly\Fluent\Webhooks\Reactions\ResumeSubscriptionOnResumed;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
+use Vatly\Fluent\Webhooks\Reactions\SyncRefundOnStatusChange;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnBillingUpdated;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
 
 class WebhookProcessorFactory
@@ -25,6 +31,12 @@ class WebhookProcessorFactory
      *
      * Drivers call this from their bootstrap to avoid re-deriving the
      * reaction registration list on each install.
+     *
+     * `refunds` is optional: when supplied, the built-in
+     * {@see SyncRefundOnStatusChange} reaction persists `refund.*` webhooks.
+     * When omitted, the typed refund events are still dispatched for drivers
+     * to handle themselves — so existing drivers don't have to implement a
+     * refund repository to keep working.
      *
      * @param WebhookReactionInterface[] $additionalReactions
      */
@@ -37,18 +49,31 @@ class WebhookProcessorFactory
         CustomerBindingRepository $bindings,
         GetOrder $getOrder,
         GetSubscription $getSubscription,
+        GetRefund $getRefund,
+        ?RefundRepositoryInterface $refunds = null,
         array $additionalReactions = [],
     ): WebhookProcessor {
+        $reactions = [
+            new SyncSubscriptionOnStarted($subscriptions, $bindings, $dispatcher),
+            new SyncSubscriptionOnBillingUpdated($subscriptions),
+            new ResumeSubscriptionOnResumed($subscriptions),
+            new CancelSubscriptionOnCanceled($subscriptions),
+            new StoreOrderOnPaid($orders, $bindings),
+            new StoreOrderOnPaymentFailed($orders, $bindings),
+            new CancelOrderOnCanceled($orders),
+        ];
+
+        if ($refunds !== null) {
+            $reactions[] = new SyncRefundOnStatusChange($refunds, $bindings);
+        }
+
         return new WebhookProcessor(
-            eventFactory: new WebhookEventFactory($getOrder, $getSubscription),
+            eventFactory: new WebhookEventFactory($getOrder, $getSubscription, $getRefund),
             repository: $webhookCalls,
             dispatcher: $dispatcher,
             webhookSecret: $config->getWebhookSecret() ?? '',
             reactions: [
-                new SyncSubscriptionOnStarted($subscriptions, $bindings, $dispatcher),
-                new CancelSubscriptionOnCanceled($subscriptions),
-                new StoreOrderOnPaid($orders, $bindings),
-                new StoreOrderOnPaymentFailed($orders, $bindings),
+                ...$reactions,
                 ...$additionalReactions,
             ],
         );

--- a/src/Wiring.php
+++ b/src/Wiring.php
@@ -8,6 +8,7 @@ use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
@@ -34,6 +35,7 @@ final class Wiring
         public readonly ConfigurationInterface $config,
         public readonly ?SubscriptionRepositoryInterface $subscriptions = null,
         public readonly ?OrderRepositoryInterface $orders = null,
+        public readonly ?RefundRepositoryInterface $refunds = null,
         public readonly ?WebhookCallRepositoryInterface $webhookCalls = null,
         public readonly ?EventDispatcherInterface $events = null,
         public readonly ?CustomerBindingRepository $customerBindings = null,

--- a/tests/Events/ChargebackEventsTest.php
+++ b/tests/Events/ChargebackEventsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Vatly\Fluent\Events\OrderChargebackReceived;
+use Vatly\Fluent\Events\OrderChargebackReversed;
+use Vatly\Fluent\Events\WebhookReceived;
+use Vatly\Fluent\Tests\TestCase;
+
+class ChargebackEventsTest extends TestCase
+{
+    public function test_received_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('order.chargeback_received', OrderChargebackReceived::VATLY_EVENT_NAME);
+    }
+
+    public function test_reversed_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('order.chargeback_reversed', OrderChargebackReversed::VATLY_EVENT_NAME);
+    }
+
+    public function test_received_creates_from_webhook_with_order_id_from_entity_id(): void
+    {
+        $event = OrderChargebackReceived::fromWebhook($this->webhook('order.chargeback_received', [
+            'id' => 'chargeback_789',
+            'resource' => 'chargeback',
+            'originalOrderId' => 'ord_original_1',
+            'reason' => 'fraudulent',
+        ]));
+
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('chargeback_789', $event->chargebackId);
+        $this->assertSame('ord_original_1', $event->originalOrderId);
+        $this->assertSame('fraudulent', $event->reason);
+    }
+
+    public function test_reversed_creates_from_webhook_with_null_reason_when_absent(): void
+    {
+        $event = OrderChargebackReversed::fromWebhook($this->webhook('order.chargeback_reversed', [
+            'id' => 'chargeback_789',
+            'resource' => 'chargeback',
+            'originalOrderId' => 'ord_original_1',
+        ]));
+
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('chargeback_789', $event->chargebackId);
+        $this->assertSame('ord_original_1', $event->originalOrderId);
+        $this->assertNull($event->reason);
+    }
+
+    public function test_original_order_id_falls_back_to_entity_id_when_absent(): void
+    {
+        $event = OrderChargebackReceived::fromWebhook($this->webhook('order.chargeback_received', [
+            'id' => 'chargeback_789',
+        ]));
+
+        $this->assertSame('ord_123', $event->originalOrderId);
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function webhook(string $eventName, array $object): WebhookReceived
+    {
+        return new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: $eventName,
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: $object,
+        );
+    }
+}

--- a/tests/Events/OrderCanceledTest.php
+++ b/tests/Events/OrderCanceledTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Vatly\Fluent\Events\OrderCanceled;
+use Vatly\Fluent\Events\WebhookReceived;
+use Vatly\Fluent\Tests\TestCase;
+
+class OrderCanceledTest extends TestCase
+{
+    public function test_it_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('order.canceled', OrderCanceled::VATLY_EVENT_NAME);
+    }
+
+    public function test_it_creates_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'order.canceled',
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456', 'status' => 'canceled'],
+        );
+
+        $event = OrderCanceled::fromWebhook($webhook);
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('canceled', $event->status);
+    }
+
+    public function test_it_defaults_status_and_customer_when_absent_from_payload(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'order.canceled',
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [],
+        );
+
+        $event = OrderCanceled::fromWebhook($webhook);
+
+        $this->assertSame('', $event->customerId);
+        $this->assertSame('canceled', $event->status);
+    }
+}

--- a/tests/Events/RefundEventsTest.php
+++ b/tests/Events/RefundEventsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Mockery;
+use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Events\RefundCanceled;
+use Vatly\Fluent\Events\RefundCompleted;
+use Vatly\Fluent\Events\RefundFailed;
+use Vatly\Fluent\Tests\TestCase;
+
+class RefundEventsTest extends TestCase
+{
+    public function test_event_name_constants(): void
+    {
+        $this->assertSame('refund.completed', RefundCompleted::VATLY_EVENT_NAME);
+        $this->assertSame('refund.failed', RefundFailed::VATLY_EVENT_NAME);
+        $this->assertSame('refund.canceled', RefundCanceled::VATLY_EVENT_NAME);
+    }
+
+    public function test_completed_maps_api_refund_to_cents_and_tax_breakdown(): void
+    {
+        $event = RefundCompleted::fromApiRefund($this->apiRefund('refunded'));
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('refund_123', $event->refundId);
+        $this->assertSame('refunded', $event->status);
+        $this->assertSame('ord_original_1', $event->originalOrderId);
+        $this->assertSame(9900, $event->total);
+        $this->assertSame(8182, $event->subtotal);
+        $this->assertSame('EUR', $event->currency);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
+        $this->assertSame(1718, $event->taxSummary->items[0]->amount);
+    }
+
+    public function test_failed_carries_failed_status(): void
+    {
+        $event = RefundFailed::fromApiRefund($this->apiRefund('failed'));
+
+        $this->assertSame('failed', $event->status);
+        $this->assertSame(9900, $event->total);
+    }
+
+    public function test_canceled_carries_canceled_status(): void
+    {
+        $event = RefundCanceled::fromApiRefund($this->apiRefund('canceled'));
+
+        $this->assertSame('canceled', $event->status);
+    }
+
+    private function apiRefund(string $status): ApiRefund
+    {
+        $refund = new ApiRefund(Mockery::mock(VatlyApiClient::class));
+        $refund->id = 'refund_123';
+        $refund->customerId = 'cus_456';
+        $refund->status = $status;
+        $refund->originalOrderId = 'ord_original_1';
+        $refund->total = new Money('EUR', '99.00');
+        $refund->subtotal = new Money('EUR', '81.82');
+        $refund->taxSummary = new TaxSummaryCollection([
+            [
+                'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                'amount' => ['currency' => 'EUR', 'value' => '17.18'],
+            ],
+        ]);
+
+        return $refund;
+    }
+}

--- a/tests/Events/SubscriptionBillingUpdatedTest.php
+++ b/tests/Events/SubscriptionBillingUpdatedTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Mockery;
+use Vatly\API\Resources\Subscription as ApiSubscription;
+use Vatly\API\Types\Mandate;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Events\SubscriptionBillingUpdated;
+use Vatly\Fluent\Events\WebhookReceived;
+use Vatly\Fluent\Tests\TestCase;
+
+class SubscriptionBillingUpdatedTest extends TestCase
+{
+    public function test_it_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('subscription.billing_updated', SubscriptionBillingUpdated::VATLY_EVENT_NAME);
+    }
+
+    public function test_it_can_be_instantiated_with_all_properties(): void
+    {
+        $mandate = new Mandate('card', '4242');
+
+        $event = new SubscriptionBillingUpdated(
+            customerId: 'cus_123',
+            subscriptionId: 'sub_456',
+            planId: 'plan_789',
+            name: 'Premium Plan',
+            quantity: 2,
+            mandate: $mandate,
+        );
+
+        $this->assertSame('cus_123', $event->customerId);
+        $this->assertSame('sub_456', $event->subscriptionId);
+        $this->assertSame('plan_789', $event->planId);
+        $this->assertSame('Premium Plan', $event->name);
+        $this->assertSame(2, $event->quantity);
+        $this->assertSame($mandate, $event->mandate);
+    }
+
+    public function test_it_creates_from_api_subscription_with_mandate(): void
+    {
+        $mandate = new Mandate('sepa_debit', 'NL91****4300');
+
+        $subscription = new ApiSubscription(Mockery::mock(VatlyApiClient::class));
+        $subscription->id = 'sub_123';
+        $subscription->customerId = 'cus_456';
+        $subscription->subscriptionPlanId = 'plan_789';
+        $subscription->name = 'Premium Plan';
+        $subscription->quantity = 3;
+        $subscription->mandate = $mandate;
+
+        $event = SubscriptionBillingUpdated::fromApiSubscription($subscription);
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+        $this->assertSame('plan_789', $event->planId);
+        $this->assertSame('Premium Plan', $event->name);
+        $this->assertSame(3, $event->quantity);
+        $this->assertSame($mandate, $event->mandate);
+    }
+
+    public function test_it_creates_from_webhook_with_null_mandate(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.billing_updated',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Basic Plan',
+                'quantity' => 1,
+            ],
+        );
+
+        $event = SubscriptionBillingUpdated::fromWebhook($webhook);
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+        $this->assertSame('plan_789', $event->planId);
+        $this->assertSame('Basic Plan', $event->name);
+        $this->assertSame(1, $event->quantity);
+        $this->assertNull($event->mandate);
+    }
+}

--- a/tests/Events/SubscriptionResumedTest.php
+++ b/tests/Events/SubscriptionResumedTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Vatly\Fluent\Events\SubscriptionResumed;
+use Vatly\Fluent\Events\WebhookReceived;
+use Vatly\Fluent\Tests\TestCase;
+
+class SubscriptionResumedTest extends TestCase
+{
+    public function test_it_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('subscription.resumed', SubscriptionResumed::VATLY_EVENT_NAME);
+    }
+
+    public function test_it_can_be_instantiated_with_properties(): void
+    {
+        $event = new SubscriptionResumed(
+            customerId: 'cus_123',
+            subscriptionId: 'sub_456',
+        );
+
+        $this->assertSame('cus_123', $event->customerId);
+        $this->assertSame('sub_456', $event->subscriptionId);
+    }
+
+    public function test_it_creates_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.resumed',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456'],
+        );
+
+        $event = SubscriptionResumed::fromWebhook($webhook);
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+    }
+}

--- a/tests/VatlyTest.php
+++ b/tests/VatlyTest.php
@@ -187,8 +187,9 @@ class VatlyTest extends TestCase
         $reactions = $ref->getValue($processor);
 
         $this->assertContains($customReaction, $reactions);
-        // The 4 standard reactions stay on top, plus our extra one = 5.
-        $this->assertCount(5, $reactions);
+        // The 7 standard reactions stay on top, plus our extra one = 8.
+        // (No refund repo wired here, so the refund reaction isn't registered.)
+        $this->assertCount(8, $reactions);
     }
 
     public function test_subscription_handle_wraps_the_given_subscription(): void

--- a/tests/Webhooks/Reactions/CancelOrderOnCanceledTest.php
+++ b/tests/Webhooks/Reactions/CancelOrderOnCanceledTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Data\UpdateOrderData;
+use Vatly\Fluent\Events\OrderCanceled;
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Webhooks\Reactions\CancelOrderOnCanceled;
+
+class CancelOrderOnCanceledTest extends TestCase
+{
+    public function test_it_supports_order_canceled_events(): void
+    {
+        $reaction = new CancelOrderOnCanceled(Mockery::mock(OrderRepositoryInterface::class));
+
+        $this->assertTrue($reaction->supports(new OrderCanceled('cus_1', 'ord_1', 'canceled')));
+    }
+
+    public function test_it_does_not_support_other_events(): void
+    {
+        $reaction = new CancelOrderOnCanceled(Mockery::mock(OrderRepositoryInterface::class));
+
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
+    }
+
+    public function test_it_mirrors_the_canceled_status_onto_the_local_order(): void
+    {
+        $existing = Mockery::mock(OrderInterface::class);
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateOrderData $data) {
+            return $data->status === 'canceled';
+        }))->andReturn($existing);
+
+        $reaction = new CancelOrderOnCanceled($repo);
+        $reaction->handle(new OrderCanceled('cus_1', 'ord_1', 'canceled'));
+    }
+
+    public function test_it_does_nothing_if_order_not_found(): void
+    {
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
+        $repo->shouldNotReceive('update');
+
+        $reaction = new CancelOrderOnCanceled($repo);
+        $reaction->handle(new OrderCanceled('cus_1', 'ord_1', 'canceled'));
+    }
+}

--- a/tests/Webhooks/Reactions/ResumeSubscriptionOnResumedTest.php
+++ b/tests/Webhooks/Reactions/ResumeSubscriptionOnResumedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\SubscriptionResumed;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Webhooks\Reactions\ResumeSubscriptionOnResumed;
+
+class ResumeSubscriptionOnResumedTest extends TestCase
+{
+    public function test_it_supports_subscription_resumed_events(): void
+    {
+        $reaction = new ResumeSubscriptionOnResumed(
+            Mockery::mock(SubscriptionRepositoryInterface::class),
+        );
+
+        $this->assertTrue($reaction->supports(new SubscriptionResumed('cus_1', 'sub_1')));
+    }
+
+    public function test_it_does_not_support_other_events(): void
+    {
+        $reaction = new ResumeSubscriptionOnResumed(
+            Mockery::mock(SubscriptionRepositoryInterface::class),
+        );
+
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
+    }
+
+    public function test_it_clears_the_stored_end_date_for_an_existing_subscription(): void
+    {
+        $existing = Mockery::mock(SubscriptionInterface::class);
+
+        $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateSubscriptionData $data) {
+            return $data->clearEndsAt === true && $data->endsAt === null;
+        }))->andReturn($existing);
+
+        $reaction = new ResumeSubscriptionOnResumed($repo);
+        $reaction->handle(new SubscriptionResumed('cus_1', 'sub_1'));
+    }
+
+    public function test_it_does_nothing_if_subscription_not_found(): void
+    {
+        $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturnNull();
+        $repo->shouldNotReceive('update');
+
+        $reaction = new ResumeSubscriptionOnResumed($repo);
+        $reaction->handle(new SubscriptionResumed('cus_1', 'sub_1'));
+    }
+}

--- a/tests/Webhooks/Reactions/SyncRefundOnStatusChangeTest.php
+++ b/tests/Webhooks/Reactions/SyncRefundOnStatusChangeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\RefundInterface;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
+use Vatly\Fluent\Data\StoreRefundData;
+use Vatly\Fluent\Data\UpdateRefundData;
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\RefundCanceled;
+use Vatly\Fluent\Events\RefundCompleted;
+use Vatly\Fluent\Events\RefundFailed;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Webhooks\Reactions\SyncRefundOnStatusChange;
+
+class SyncRefundOnStatusChangeTest extends TestCase
+{
+    public function test_it_supports_all_three_refund_events(): void
+    {
+        $reaction = new SyncRefundOnStatusChange(
+            Mockery::mock(RefundRepositoryInterface::class),
+            Mockery::mock(CustomerBindingRepository::class),
+        );
+
+        $this->assertTrue($reaction->supports($this->event(RefundCompleted::class, 'refunded')));
+        $this->assertTrue($reaction->supports($this->event(RefundFailed::class, 'failed')));
+        $this->assertTrue($reaction->supports($this->event(RefundCanceled::class, 'canceled')));
+    }
+
+    public function test_it_does_not_support_other_events(): void
+    {
+        $reaction = new SyncRefundOnStatusChange(
+            Mockery::mock(RefundRepositoryInterface::class),
+            Mockery::mock(CustomerBindingRepository::class),
+        );
+
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
+    }
+
+    public function test_it_updates_an_existing_refund_with_the_new_status(): void
+    {
+        $existing = Mockery::mock(RefundInterface::class);
+        $repo = Mockery::mock(RefundRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('refund_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateRefundData $data) {
+            return $data->status === 'refunded' && $data->total === 9900 && $data->currency === 'EUR';
+        }))->andReturn($existing);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('record');
+
+        $reaction = new SyncRefundOnStatusChange($repo, $bindings);
+        $reaction->handle($this->event(RefundCompleted::class, 'refunded'));
+    }
+
+    public function test_it_stores_a_new_refund_resolving_host_customer_from_bindings(): void
+    {
+        $stored = Mockery::mock(RefundInterface::class);
+        $repo = Mockery::mock(RefundRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('refund_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreRefundData $data) {
+            return $data->vatlyId === 'refund_1'
+                && $data->customerId === 'cus_1'
+                && $data->status === 'refunded'
+                && $data->total === 9900
+                && $data->originalOrderId === 'ord_original_1'
+                && $data->hostCustomerId === 'host_42';
+        }))->andReturn($stored);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->with('cus_1')->once()->andReturn('host_42');
+        $bindings->shouldReceive('record')->with('cus_1')->once();
+
+        $reaction = new SyncRefundOnStatusChange($repo, $bindings);
+        $reaction->handle($this->event(RefundCompleted::class, 'refunded'));
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function event(string $class, string $status): object
+    {
+        return new $class(
+            'cus_1',
+            'refund_1',
+            $status,
+            9900,
+            8182,
+            TaxSummary::empty(),
+            'EUR',
+            'ord_original_1',
+        );
+    }
+}

--- a/tests/Webhooks/Reactions/SyncSubscriptionOnBillingUpdatedTest.php
+++ b/tests/Webhooks/Reactions/SyncSubscriptionOnBillingUpdatedTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use Vatly\API\Types\Mandate;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Events\SubscriptionBillingUpdated;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnBillingUpdated;
+
+class SyncSubscriptionOnBillingUpdatedTest extends TestCase
+{
+    public function test_it_supports_subscription_billing_updated_events(): void
+    {
+        $reaction = new SyncSubscriptionOnBillingUpdated(
+            Mockery::mock(SubscriptionRepositoryInterface::class),
+        );
+
+        $event = new SubscriptionBillingUpdated('cus_1', 'sub_1', 'plan_1', 'Monthly', 1, new Mandate('card', '4242'));
+
+        $this->assertTrue($reaction->supports($event));
+    }
+
+    public function test_it_does_not_support_other_events(): void
+    {
+        $reaction = new SyncSubscriptionOnBillingUpdated(
+            Mockery::mock(SubscriptionRepositoryInterface::class),
+        );
+
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
+    }
+
+    public function test_it_updates_the_stored_mandate_for_an_existing_subscription(): void
+    {
+        $mandate = new Mandate('sepa_debit', 'NL91****4300');
+        $existing = Mockery::mock(SubscriptionInterface::class);
+
+        $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateSubscriptionData $data) use ($mandate) {
+            return $data->planId === 'plan_2'
+                && $data->name === 'Annual'
+                && $data->quantity === 3
+                && $data->mandate === $mandate
+                && $data->clearMandate === false;
+        }))->andReturn($existing);
+
+        $reaction = new SyncSubscriptionOnBillingUpdated($repo);
+        $reaction->handle(new SubscriptionBillingUpdated('cus_1', 'sub_1', 'plan_2', 'Annual', 3, $mandate));
+    }
+
+    public function test_a_null_mandate_leaves_the_stored_mandate_untouched(): void
+    {
+        // Enrichment fell back to the webhook payload (mandate null). The
+        // reaction must NOT clear the stored mandate — a transient API blip
+        // shouldn't wipe a good payment method; the next sync() reconciles.
+        $existing = Mockery::mock(SubscriptionInterface::class);
+
+        $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(function (UpdateSubscriptionData $data) {
+            return $data->mandate === null && $data->clearMandate === false;
+        }))->andReturn($existing);
+
+        $reaction = new SyncSubscriptionOnBillingUpdated($repo);
+        $reaction->handle(new SubscriptionBillingUpdated('cus_1', 'sub_1', 'plan_1', 'Monthly', 1, null));
+    }
+
+    public function test_it_does_nothing_if_subscription_not_found(): void
+    {
+        // Find-or-skip: a billing update for a subscription we never recorded
+        // must not fabricate a half-known local row.
+        $repo = Mockery::mock(SubscriptionRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('sub_1')->once()->andReturnNull();
+        $repo->shouldNotReceive('update');
+
+        $reaction = new SyncSubscriptionOnBillingUpdated($repo);
+        $reaction->handle(new SubscriptionBillingUpdated('cus_1', 'sub_1', 'plan_1', 'Monthly', 1, new Mandate('card', '4242')));
+    }
+}

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -7,6 +7,7 @@ namespace Vatly\Fluent\Tests\Webhooks;
 use DateTimeInterface;
 use Mockery;
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Resources\Refund as ApiRefund;
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
 use Vatly\API\Types\Money;
@@ -14,11 +15,20 @@ use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
 use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Events\OrderCanceled;
+use Vatly\Fluent\Events\OrderChargebackReceived;
+use Vatly\Fluent\Events\OrderChargebackReversed;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Events\PaymentFailed;
+use Vatly\Fluent\Events\RefundCanceled;
+use Vatly\Fluent\Events\RefundCompleted;
+use Vatly\Fluent\Events\RefundFailed;
+use Vatly\Fluent\Events\SubscriptionBillingUpdated;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
+use Vatly\Fluent\Events\SubscriptionResumed;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
 use Vatly\Fluent\Events\WebhookReceived;
@@ -30,6 +40,7 @@ class WebhookEventFactoryTest extends TestCase
     private WebhookEventFactory $factory;
     private GetOrder $getOrder;
     private GetSubscription $getSubscription;
+    private GetRefund $getRefund;
 
     protected function setUp(): void
     {
@@ -37,7 +48,8 @@ class WebhookEventFactoryTest extends TestCase
 
         $this->getOrder = Mockery::mock(GetOrder::class);
         $this->getSubscription = Mockery::mock(GetSubscription::class);
-        $this->factory = new WebhookEventFactory($this->getOrder, $this->getSubscription);
+        $this->getRefund = Mockery::mock(GetRefund::class);
+        $this->factory = new WebhookEventFactory($this->getOrder, $this->getSubscription, $this->getRefund);
     }
 
     public function test_it_converts_upstream_webhook_payload_into_webhook_received_event(): void
@@ -237,6 +249,100 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertInstanceOf(DateTimeInterface::class, $event->endsAt);
     }
 
+    public function test_it_creates_subscription_billing_updated_event_from_enriched_api_subscription(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.billing_updated',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [],
+        );
+
+        $apiSubscription = $this->makeApiSubscription([
+            'id' => 'sub_123',
+            'customerId' => 'cus_456',
+            'subscriptionPlanId' => 'plan_789',
+            'name' => 'Premium Plan',
+            'quantity' => 1,
+            'mandate' => new Mandate('sepa_debit', 'NL91****4300'),
+        ]);
+
+        $this->getSubscription->shouldReceive('execute')
+            ->with('sub_123')
+            ->andReturn($apiSubscription);
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionBillingUpdated::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+        $this->assertSame('plan_789', $event->planId);
+        $this->assertSame('Premium Plan', $event->name);
+        $this->assertSame(1, $event->quantity);
+        $this->assertNotNull($event->mandate);
+        $this->assertSame('sepa_debit', $event->mandate->method);
+        $this->assertSame('NL91****4300', $event->mandate->maskedIdentifier);
+    }
+
+    public function test_subscription_billing_updated_falls_back_to_webhook_payload_when_enrichment_fails(): void
+    {
+        // Same resilience contract as subscription.started: a GetSubscription
+        // blip must not block the webhook. Mandate stays null on the fallback
+        // so the reaction makes no mandate change; the next sync() reconciles.
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.billing_updated',
+            entityType: 'subscription',
+            entityId: 'sub_transient_fail',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
+            ],
+        );
+
+        $this->getSubscription->shouldReceive('execute')
+            ->andThrow(new \RuntimeException('Transient API failure'));
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionBillingUpdated::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_transient_fail', $event->subscriptionId);
+        $this->assertSame('plan_789', $event->planId);
+        $this->assertSame('Premium Plan', $event->name);
+        $this->assertSame(1, $event->quantity);
+        $this->assertNull($event->mandate);
+    }
+
+    public function test_it_creates_subscription_resumed_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.resumed',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456'],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionResumed::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+    }
+
     public function test_it_creates_order_paid_event_from_webhook_with_enriched_tax_data(): void
     {
         $apiOrder = $this->buildApiOrder([
@@ -340,6 +446,192 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame(850, $event->taxSummary->items[0]->amount);
     }
 
+    public function test_it_creates_order_canceled_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_oc',
+            resource: 'webhook_event',
+            eventName: 'order.canceled',
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'status' => 'canceled',
+            ],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(OrderCanceled::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('canceled', $event->status);
+    }
+
+    public function test_it_creates_order_chargeback_received_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_cb',
+            resource: 'webhook_event',
+            eventName: 'order.chargeback_received',
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'id' => 'chargeback_789',
+                'resource' => 'chargeback',
+                'originalOrderId' => 'ord_original_1',
+                'reason' => 'fraudulent',
+            ],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(OrderChargebackReceived::class, $event);
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('chargeback_789', $event->chargebackId);
+        $this->assertSame('ord_original_1', $event->originalOrderId);
+        $this->assertSame('fraudulent', $event->reason);
+    }
+
+    public function test_it_creates_order_chargeback_reversed_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_cbr',
+            resource: 'webhook_event',
+            eventName: 'order.chargeback_reversed',
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'id' => 'chargeback_789',
+                'resource' => 'chargeback',
+                'originalOrderId' => 'ord_original_1',
+            ],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(OrderChargebackReversed::class, $event);
+        $this->assertSame('ord_123', $event->orderId);
+        $this->assertSame('chargeback_789', $event->chargebackId);
+        $this->assertNull($event->reason);
+    }
+
+    public function test_it_creates_refund_completed_event_from_enriched_api_refund(): void
+    {
+        $apiRefund = $this->buildApiRefund([
+            'id' => 'refund_123',
+            'customerId' => 'cus_456',
+            'status' => 'refunded',
+            'originalOrderId' => 'ord_original_1',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+            'subtotal' => ['currency' => 'EUR', 'value' => '81.82'],
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+        ]);
+
+        $this->getRefund->shouldReceive('execute')
+            ->once()
+            ->with('refund_123')
+            ->andReturn($apiRefund);
+
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_rf',
+            resource: 'webhook_event',
+            eventName: 'refund.completed',
+            entityType: 'refund',
+            entityId: 'refund_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456'],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(RefundCompleted::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('refund_123', $event->refundId);
+        $this->assertSame('refunded', $event->status);
+        $this->assertSame('ord_original_1', $event->originalOrderId);
+        $this->assertSame(9900, $event->total);
+        $this->assertSame(8182, $event->subtotal);
+        $this->assertSame('EUR', $event->currency);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
+        $this->assertSame(1718, $event->taxSummary->items[0]->amount);
+    }
+
+    public function test_it_creates_refund_failed_event_from_enriched_api_refund(): void
+    {
+        $apiRefund = $this->buildApiRefund([
+            'id' => 'refund_failed_1',
+            'customerId' => 'cus_456',
+            'status' => 'failed',
+            'originalOrderId' => 'ord_original_1',
+            'total' => ['currency' => 'EUR', 'value' => '49.00'],
+            'subtotal' => ['currency' => 'EUR', 'value' => '40.50'],
+            'taxRates' => [],
+        ]);
+
+        $this->getRefund->shouldReceive('execute')->once()->with('refund_failed_1')->andReturn($apiRefund);
+
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_rff',
+            resource: 'webhook_event',
+            eventName: 'refund.failed',
+            entityType: 'refund',
+            entityId: 'refund_failed_1',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(RefundFailed::class, $event);
+        $this->assertSame('refund_failed_1', $event->refundId);
+        $this->assertSame('failed', $event->status);
+        $this->assertSame(4900, $event->total);
+    }
+
+    public function test_it_creates_refund_canceled_event_from_enriched_api_refund(): void
+    {
+        $apiRefund = $this->buildApiRefund([
+            'id' => 'refund_canceled_1',
+            'customerId' => 'cus_456',
+            'status' => 'canceled',
+            'originalOrderId' => 'ord_original_1',
+            'total' => ['currency' => 'EUR', 'value' => '10.00'],
+            'subtotal' => ['currency' => 'EUR', 'value' => '8.26'],
+            'taxRates' => [],
+        ]);
+
+        $this->getRefund->shouldReceive('execute')->once()->with('refund_canceled_1')->andReturn($apiRefund);
+
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_rfc',
+            resource: 'webhook_event',
+            eventName: 'refund.canceled',
+            entityType: 'refund',
+            entityId: 'refund_canceled_1',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(RefundCanceled::class, $event);
+        $this->assertSame('refund_canceled_1', $event->refundId);
+        $this->assertSame('canceled', $event->status);
+    }
+
     public function test_it_creates_unsupported_webhook_received_for_unknown_events(): void
     {
         $webhook = new WebhookReceived(
@@ -364,17 +656,33 @@ class WebhookEventFactoryTest extends TestCase
         $supported = $this->factory->getSupportedEvents();
 
         $this->assertContains('subscription.started', $supported);
+        $this->assertContains('subscription.billing_updated', $supported);
+        $this->assertContains('subscription.resumed', $supported);
         $this->assertContains('subscription.canceled_immediately', $supported);
         $this->assertContains('subscription.canceled_with_grace_period', $supported);
         $this->assertContains('order.paid', $supported);
+        $this->assertContains('order.canceled', $supported);
+        $this->assertContains('order.chargeback_received', $supported);
+        $this->assertContains('order.chargeback_reversed', $supported);
         $this->assertContains('payment.failed', $supported);
+        $this->assertContains('refund.completed', $supported);
+        $this->assertContains('refund.failed', $supported);
+        $this->assertContains('refund.canceled', $supported);
     }
 
     public function test_it_checks_if_event_is_supported(): void
     {
         $this->assertTrue($this->factory->isSupported('subscription.started'));
+        $this->assertTrue($this->factory->isSupported('subscription.billing_updated'));
+        $this->assertTrue($this->factory->isSupported('subscription.resumed'));
         $this->assertTrue($this->factory->isSupported('order.paid'));
+        $this->assertTrue($this->factory->isSupported('order.canceled'));
+        $this->assertTrue($this->factory->isSupported('order.chargeback_received'));
+        $this->assertTrue($this->factory->isSupported('order.chargeback_reversed'));
         $this->assertTrue($this->factory->isSupported('payment.failed'));
+        $this->assertTrue($this->factory->isSupported('refund.completed'));
+        $this->assertTrue($this->factory->isSupported('refund.failed'));
+        $this->assertTrue($this->factory->isSupported('refund.canceled'));
         $this->assertFalse($this->factory->isSupported('unknown.event'));
     }
 
@@ -440,5 +748,44 @@ class WebhookEventFactoryTest extends TestCase
         $order->taxSummary = new TaxSummaryCollection($taxItems);
 
         return $order;
+    }
+
+    /**
+     * Build a minimal API Refund resource for enrichment-path tests.
+     *
+     * @param array{
+     *   id: string,
+     *   customerId: string,
+     *   status: string,
+     *   originalOrderId: string,
+     *   total: array{currency: string, value: string},
+     *   subtotal: array{currency: string, value: string},
+     *   taxRates: array<int, array{name: string, percentage: float, taxablePercentage: float, amount: string}>,
+     * } $data
+     */
+    private function buildApiRefund(array $data): ApiRefund
+    {
+        $refund = new ApiRefund(Mockery::mock(VatlyApiClient::class));
+        $refund->id = $data['id'];
+        $refund->customerId = $data['customerId'];
+        $refund->status = $data['status'];
+        $refund->originalOrderId = $data['originalOrderId'];
+        $refund->total = new Money($data['total']['currency'], $data['total']['value']);
+        $refund->subtotal = new Money($data['subtotal']['currency'], $data['subtotal']['value']);
+
+        $taxItems = array_map(
+            fn (array $rate) => [
+                'taxRate' => [
+                    'name' => $rate['name'],
+                    'percentage' => $rate['percentage'],
+                    'taxablePercentage' => $rate['taxablePercentage'],
+                ],
+                'amount' => ['currency' => $data['total']['currency'], 'value' => $rate['amount']],
+            ],
+            $data['taxRates'],
+        );
+        $refund->taxSummary = new TaxSummaryCollection($taxItems);
+
+        return $refund;
     }
 }

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -6,18 +6,24 @@ namespace Vatly\Fluent\Tests\Webhooks;
 
 use Mockery;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Contracts\RefundRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Webhooks\Reactions\CancelOrderOnCanceled;
 use Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled;
+use Vatly\Fluent\Webhooks\Reactions\ResumeSubscriptionOnResumed;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
+use Vatly\Fluent\Webhooks\Reactions\SyncRefundOnStatusChange;
+use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnBillingUpdated;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
 use Vatly\Fluent\Webhooks\WebhookProcessor;
 use Vatly\Fluent\Webhooks\WebhookProcessorFactory;
@@ -35,17 +41,42 @@ class WebhookProcessorFactoryTest extends TestCase
             bindings: Mockery::mock(CustomerBindingRepository::class),
             getOrder: Mockery::mock(GetOrder::class),
             getSubscription: Mockery::mock(GetSubscription::class),
+            getRefund: Mockery::mock(GetRefund::class),
         );
 
         $this->assertInstanceOf(WebhookProcessor::class, $processor);
 
         $reactions = $processor->getReactions();
 
-        $this->assertCount(4, $reactions);
+        $this->assertCount(7, $reactions);
         $this->assertInstanceOf(SyncSubscriptionOnStarted::class, $reactions[0]);
-        $this->assertInstanceOf(CancelSubscriptionOnCanceled::class, $reactions[1]);
-        $this->assertInstanceOf(StoreOrderOnPaid::class, $reactions[2]);
-        $this->assertInstanceOf(StoreOrderOnPaymentFailed::class, $reactions[3]);
+        $this->assertInstanceOf(SyncSubscriptionOnBillingUpdated::class, $reactions[1]);
+        $this->assertInstanceOf(ResumeSubscriptionOnResumed::class, $reactions[2]);
+        $this->assertInstanceOf(CancelSubscriptionOnCanceled::class, $reactions[3]);
+        $this->assertInstanceOf(StoreOrderOnPaid::class, $reactions[4]);
+        $this->assertInstanceOf(StoreOrderOnPaymentFailed::class, $reactions[5]);
+        $this->assertInstanceOf(CancelOrderOnCanceled::class, $reactions[6]);
+    }
+
+    public function test_it_registers_the_refund_reaction_only_when_a_refund_repository_is_supplied(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            bindings: Mockery::mock(CustomerBindingRepository::class),
+            getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
+            getRefund: Mockery::mock(GetRefund::class),
+            refunds: Mockery::mock(RefundRepositoryInterface::class),
+        );
+
+        $reactions = $processor->getReactions();
+
+        $this->assertCount(8, $reactions);
+        $this->assertInstanceOf(SyncRefundOnStatusChange::class, $reactions[7]);
     }
 
     public function test_it_appends_additional_reactions_after_the_standard_ones(): void
@@ -61,13 +92,14 @@ class WebhookProcessorFactoryTest extends TestCase
             bindings: Mockery::mock(CustomerBindingRepository::class),
             getOrder: Mockery::mock(GetOrder::class),
             getSubscription: Mockery::mock(GetSubscription::class),
+            getRefund: Mockery::mock(GetRefund::class),
             additionalReactions: [$custom],
         );
 
         $reactions = $processor->getReactions();
 
-        $this->assertCount(5, $reactions);
-        $this->assertSame($custom, $reactions[4]);
+        $this->assertCount(8, $reactions);
+        $this->assertSame($custom, $reactions[7]);
     }
 
     public function test_it_tolerates_a_null_webhook_secret(): void
@@ -81,6 +113,7 @@ class WebhookProcessorFactoryTest extends TestCase
             bindings: Mockery::mock(CustomerBindingRepository::class),
             getOrder: Mockery::mock(GetOrder::class),
             getSubscription: Mockery::mock(GetSubscription::class),
+            getRefund: Mockery::mock(GetRefund::class),
         );
 
         $this->assertInstanceOf(WebhookProcessor::class, $processor);

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -11,6 +11,7 @@ use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
@@ -28,6 +29,7 @@ class WebhookProcessorTest extends TestCase
     private string $secret;
     private GetOrder $getOrder;
     private GetSubscription $getSubscription;
+    private GetRefund $getRefund;
     private WebhookEventFactory $eventFactory;
     private WebhookCallRepositoryInterface $repository;
     private EventDispatcherInterface $dispatcher;
@@ -40,7 +42,8 @@ class WebhookProcessorTest extends TestCase
         $this->secret = 'test-webhook-secret';
         $this->getOrder = Mockery::mock(GetOrder::class);
         $this->getSubscription = Mockery::mock(GetSubscription::class);
-        $this->eventFactory = new WebhookEventFactory($this->getOrder, $this->getSubscription);
+        $this->getRefund = Mockery::mock(GetRefund::class);
+        $this->eventFactory = new WebhookEventFactory($this->getOrder, $this->getSubscription, $this->getRefund);
         $this->repository = Mockery::mock(WebhookCallRepositoryInterface::class);
         $this->dispatcher = Mockery::mock(EventDispatcherInterface::class);
 


### PR DESCRIPTION
Closes the bulk of the documented-webhook-surface gap (#54): every Vatly webhook that affects a billing/MoR plugin's local state now has a typed event, and where it maps to local persistence, a built-in reaction. Assumes the core `subscription.billing_updated` event ships (vatlify).

## Coverage added

| Event | Dispatched event | Built-in reaction |
|---|---|---|
| `order.canceled` | `OrderCanceled` | `CancelOrderOnCanceled` — mirrors Vatly's `canceled` status (find-or-skip) |
| `order.chargeback_received` / `_reversed` | `OrderChargebackReceived` / `OrderChargebackReversed` | — dispatched only |
| `refund.completed` / `refund.failed` / `refund.canceled` | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | `SyncRefundOnStatusChange` *(opt-in)* |
| `subscription.billing_updated` | `SubscriptionBillingUpdated` | `SyncSubscriptionOnBillingUpdated` — refreshes the stored mandate |
| `subscription.resumed` | `SubscriptionResumed` | `ResumeSubscriptionOnResumed` — clears the stored end date |

## Design notes

- **Refunds are a new, opt-in domain.** Supply a `RefundRepositoryInterface` via `Wiring(refunds: …)` and `SyncRefundOnStatusChange` persists `refund.*` (store-or-update, like orders) — unblocking terminal-state reconciliation for consumers that record refunds as `pending`. Omit it and the typed events are still dispatched. **Existing drivers are unaffected** (the param is optional/nullable). Refund events are enriched via `GetRefund` for the full tax breakdown, mirroring `order.paid`.
- **Chargebacks ship no state-mutating reaction.** Vatly's public order status doesn't change on a chargeback, so fluent doesn't synthesize one (mirror, don't synthesize). The typed events carry the affected order's `orderId` so drivers can suspend/reinstate access.
- **`order.canceled` / `billing_updated` / `resumed` are find-or-skip** — they update an existing local record, never create one.

## Deliberately out of scope
`checkout.*` (UX/analytics, not state-correctness) and `subscription.cancellation_grace_period_completed` (`DerivesSubscriptionState` already flips `isActive`/`isEnded` once `endsAt` passes).

## Follow-up
`SubscriptionBillingUpdated::VATLY_EVENT_NAME` stays a string literal (consistent with every other event class). Switching it to reference `vatly-api-php`'s new `WebhookEventName::SUBSCRIPTION_BILLING_UPDATED` constant (Vatly/vatly-api-php#33) is a follow-up tied to the next api-php version bump.

## Verification
236 tests / 721 assertions green; PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)