### PR TITLE
chore(deps): bump vatly-api-php to ^0.1.0-alpha.12 + reference WebhookEventName constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vatly/vatly-api-php": "^0.1.0-alpha.11"
+        "vatly/vatly-api-php": "^0.1.0-alpha.12"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/src/Events/OrderCanceled.php
+++ b/src/Events/OrderCanceled.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Types\WebhookEventName;
+
 /**
  * Event representing an order being canceled at Vatly.
  *
@@ -15,7 +17,7 @@ namespace Vatly\Fluent\Events;
  */
 class OrderCanceled
 {
-    public const VATLY_EVENT_NAME = 'order.canceled';
+    public const VATLY_EVENT_NAME = WebhookEventName::ORDER_CANCELED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/OrderChargebackReceived.php
+++ b/src/Events/OrderChargebackReceived.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Types\WebhookEventName;
+
 /**
  * Event representing a chargeback being received against an order at Vatly.
  *
@@ -18,7 +20,7 @@ namespace Vatly\Fluent\Events;
  */
 class OrderChargebackReceived
 {
-    public const VATLY_EVENT_NAME = 'order.chargeback_received';
+    public const VATLY_EVENT_NAME = WebhookEventName::ORDER_CHARGEBACK_RECEIVED;
 
     public function __construct(
         public string $orderId,

--- a/src/Events/OrderChargebackReversed.php
+++ b/src/Events/OrderChargebackReversed.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Types\WebhookEventName;
+
 /**
  * Event representing a previously-received chargeback being reversed at Vatly.
  *
@@ -16,7 +18,7 @@ namespace Vatly\Fluent\Events;
  */
 class OrderChargebackReversed
 {
-    public const VATLY_EVENT_NAME = 'order.chargeback_reversed';
+    public const VATLY_EVENT_NAME = WebhookEventName::ORDER_CHARGEBACK_REVERSED;
 
     public function __construct(
         public string $orderId,

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\WebhookEventName;
 use Vatly\Fluent\Types\Money;
 use Vatly\Fluent\Types\TaxSummary;
 
@@ -19,7 +20,7 @@ use Vatly\Fluent\Types\TaxSummary;
  */
 class OrderPaid
 {
-    public const VATLY_EVENT_NAME = 'order.paid';
+    public const VATLY_EVENT_NAME = WebhookEventName::ORDER_PAID;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/PaymentFailed.php
+++ b/src/Events/PaymentFailed.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Types\WebhookEventName;
 use Vatly\Fluent\Types\Money;
 use Vatly\Fluent\Types\TaxSummary;
 
@@ -24,7 +25,7 @@ use Vatly\Fluent\Types\TaxSummary;
  */
 class PaymentFailed
 {
-    public const VATLY_EVENT_NAME = 'payment.failed';
+    public const VATLY_EVENT_NAME = WebhookEventName::PAYMENT_FAILED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/RefundCanceled.php
+++ b/src/Events/RefundCanceled.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\API\Types\WebhookEventName;
 use Vatly\Fluent\Types\Money;
 use Vatly\Fluent\Types\TaxSummary;
 
@@ -20,7 +21,7 @@ use Vatly\Fluent\Types\TaxSummary;
  */
 class RefundCanceled
 {
-    public const VATLY_EVENT_NAME = 'refund.canceled';
+    public const VATLY_EVENT_NAME = WebhookEventName::REFUND_CANCELED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/RefundCompleted.php
+++ b/src/Events/RefundCompleted.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\API\Types\WebhookEventName;
 use Vatly\Fluent\Types\Money;
 use Vatly\Fluent\Types\TaxSummary;
 
@@ -20,7 +21,7 @@ use Vatly\Fluent\Types\TaxSummary;
  */
 class RefundCompleted
 {
-    public const VATLY_EVENT_NAME = 'refund.completed';
+    public const VATLY_EVENT_NAME = WebhookEventName::REFUND_COMPLETED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/RefundFailed.php
+++ b/src/Events/RefundFailed.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Refund as ApiRefund;
+use Vatly\API\Types\WebhookEventName;
 use Vatly\Fluent\Types\Money;
 use Vatly\Fluent\Types\TaxSummary;
 
@@ -20,7 +21,7 @@ use Vatly\Fluent\Types\TaxSummary;
  */
 class RefundFailed
 {
-    public const VATLY_EVENT_NAME = 'refund.failed';
+    public const VATLY_EVENT_NAME = WebhookEventName::REFUND_FAILED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/SubscriptionBillingUpdated.php
+++ b/src/Events/SubscriptionBillingUpdated.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
+use Vatly\API\Types\WebhookEventName;
 
 /**
  * Event representing a subscription's billing details — most importantly the
@@ -26,7 +27,7 @@ use Vatly\API\Types\Mandate;
  */
 class SubscriptionBillingUpdated
 {
-    public const VATLY_EVENT_NAME = 'subscription.billing_updated';
+    public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_BILLING_UPDATED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/SubscriptionCanceledImmediately.php
+++ b/src/Events/SubscriptionCanceledImmediately.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Events;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Vatly\API\Types\WebhookEventName;
 
 /**
  * Event representing a subscription being canceled immediately at Vatly.
@@ -14,7 +15,7 @@ use DateTimeInterface;
  */
 class SubscriptionCanceledImmediately
 {
-    public const VATLY_EVENT_NAME = 'subscription.canceled_immediately';
+    public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_CANCELED_IMMEDIATELY;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/SubscriptionCanceledWithGracePeriod.php
+++ b/src/Events/SubscriptionCanceledWithGracePeriod.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Events;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Vatly\API\Types\WebhookEventName;
 
 /**
  * Event representing a subscription being canceled with a grace period at Vatly.
@@ -14,7 +15,7 @@ use DateTimeInterface;
  */
 class SubscriptionCanceledWithGracePeriod
 {
-    public const VATLY_EVENT_NAME = 'subscription.canceled_with_grace_period';
+    public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_CANCELED_WITH_GRACE_PERIOD;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/SubscriptionResumed.php
+++ b/src/Events/SubscriptionResumed.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Types\WebhookEventName;
+
 /**
  * Event representing a previously-canceled subscription being resumed at Vatly.
  *
@@ -19,7 +21,7 @@ namespace Vatly\Fluent\Events;
  */
 class SubscriptionResumed
 {
-    public const VATLY_EVENT_NAME = 'subscription.resumed';
+    public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_RESUMED;
 
     public function __construct(
         public string $customerId,

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
+use Vatly\API\Types\WebhookEventName;
 
 /**
  * Event representing a subscription being started at Vatly.
@@ -18,7 +19,7 @@ use Vatly\API\Types\Mandate;
  */
 class SubscriptionStarted
 {
-    public const VATLY_EVENT_NAME = 'subscription.started';
+    public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_STARTED;
 
     public const DEFAULT_TYPE = 'default';
 


### PR DESCRIPTION
Routine follow-up to #59, now that `vatly-api-php` v0.1.0-alpha.12 is published.

## What
- Bump `vatly/vatly-api-php` to `^0.1.0-alpha.12` (ships `WebhookEventName::SUBSCRIPTION_BILLING_UPDATED` + the corrected webhook OpenAPI spec).
- Point every event class's `VATLY_EVENT_NAME` at the api-php `WebhookEventName` constant instead of a hardcoded string (all 13: order/refund/chargeback/payment/subscription events).

## Why
`WebhookEventName` is the published single source of truth for event names. Referencing the constants removes the last place fluent could silently drift from the client's catalogue — the exact drift class that motivated the upstream cleanup.

## Safety
No behavioral change: each constant resolves to the same string the literals held, so `match` arms and `assertSame('...', X::VATLY_EVENT_NAME)` tests pass unchanged. 236 tests / 721 assertions green; PHPStan clean.