### PR TITLE
fix(webhooks): parse embedded mandate in subscription fromWebhook fallback (#58)

### DIFF
--- a/src/Concerns/ParsesWebhookMandate.php
+++ b/src/Concerns/ParsesWebhookMandate.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Concerns;
+
+use Vatly\API\Types\Mandate;
+
+/**
+ * Parses a {@see Mandate} out of a webhook `object` payload when it's present.
+ *
+ * Vatly embeds the mandate inline on subscription deliveries
+ * (`object.mandate.method` / `object.mandate.maskedIdentifier`). The event
+ * factory prefers an API-enriched mandate, but on a `GetSubscription` failure it
+ * falls back to the webhook payload — and this keeps that fallback non-lossy by
+ * reading the embedded mandate instead of dropping it.
+ *
+ * Defensive: returns `null` unless `object.mandate` is an array carrying a
+ * string `method`, so a missing/`null`/malformed mandate never throws.
+ */
+trait ParsesWebhookMandate
+{
+    /**
+     * @param array<string, mixed> $object
+     */
+    private static function mandateFromWebhookObject(array $object): ?Mandate
+    {
+        $mandate = $object['mandate'] ?? null;
+
+        if (! is_array($mandate) || ! isset($mandate['method']) || ! is_string($mandate['method'])) {
+            return null;
+        }
+
+        return Mandate::createResourceFromApiResult($mandate);
+    }
+}

--- a/src/Events/SubscriptionBillingUpdated.php
+++ b/src/Events/SubscriptionBillingUpdated.php
@@ -7,6 +7,7 @@ namespace Vatly\Fluent\Events;
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
 use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Concerns\ParsesWebhookMandate;
 
 /**
  * Event representing a subscription's billing details — most importantly the
@@ -15,8 +16,9 @@ use Vatly\API\Types\WebhookEventName;
  * Fired when a customer completes the hosted "update billing" flow (or the
  * mandate otherwise changes server-side). Built by
  * {@see \Vatly\Fluent\Webhooks\WebhookEventFactory} via a follow-up
- * `GetSubscription` call against the webhook's `entityId`, so the dispatched
- * event carries the fresh mandate summary that isn't on the webhook payload.
+ * `GetSubscription` call against the webhook's `entityId` (the fresh mandate
+ * summary). On a transient API failure it falls back to the webhook payload,
+ * which embeds the mandate inline — so the fallback stays non-lossy.
  *
  * This is the companion to {@see SubscriptionStarted}: `started` captures the
  * initial mandate, this event keeps it current. Without it, a mandate
@@ -27,6 +29,8 @@ use Vatly\API\Types\WebhookEventName;
  */
 class SubscriptionBillingUpdated
 {
+    use ParsesWebhookMandate;
+
     public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_BILLING_UPDATED;
 
     public function __construct(
@@ -66,9 +70,11 @@ class SubscriptionBillingUpdated
     }
 
     /**
-     * Sparse, webhook-payload-only build used when API enrichment fails.
-     * Mandate stays null — the whole point of this event — so the reaction
-     * deliberately makes no mandate change and defers to the next sync().
+     * Webhook-payload-only build, used when API enrichment fails. Reads the
+     * mandate — the whole point of this event — from the embedded
+     * `object.mandate` when present, so a transient `GetSubscription` failure
+     * no longer drops the new payment method; it falls back to `null` only when
+     * the payload carries no mandate, leaving the stored one untouched.
      */
     public static function fromWebhook(WebhookReceived $webhook): self
     {
@@ -78,6 +84,7 @@ class SubscriptionBillingUpdated
             planId: $webhook->object['subscriptionPlanId'],
             name: $webhook->object['name'],
             quantity: $webhook->object['quantity'],
+            mandate: self::mandateFromWebhookObject($webhook->object),
         );
     }
 }

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -7,18 +7,22 @@ namespace Vatly\Fluent\Events;
 use Vatly\API\Resources\Subscription as ApiSubscription;
 use Vatly\API\Types\Mandate;
 use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Concerns\ParsesWebhookMandate;
 
 /**
  * Event representing a subscription being started at Vatly.
  *
  * Built by {@see \Vatly\Fluent\Webhooks\WebhookEventFactory} via a follow-up
- * `GetSubscription` call against the webhook's `entityId`, so the dispatched
- * event carries the mandate summary that isn't on the webhook payload.
+ * `GetSubscription` call against the webhook's `entityId` (carrying the mandate
+ * summary). On a transient API failure it falls back to the webhook payload,
+ * which itself embeds the mandate inline — so the fallback stays non-lossy.
  *
  * @immutable
  */
 class SubscriptionStarted
 {
+    use ParsesWebhookMandate;
+
     public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_STARTED;
 
     public const DEFAULT_TYPE = 'default';
@@ -62,8 +66,10 @@ class SubscriptionStarted
     }
 
     /**
-     * Sparse, webhook-payload-only build kept for tests and callers who don't
-     * want to fetch the full API resource. Mandate stays null.
+     * Webhook-payload-only build (the factory's fallback when `GetSubscription`
+     * enrichment fails, and a convenience for tests). The mandate is read from
+     * the embedded `object.mandate` when present, falling back to `null` only
+     * when the payload genuinely carries none.
      */
     public static function fromWebhook(WebhookReceived $webhook): self
     {
@@ -74,6 +80,7 @@ class SubscriptionStarted
             type: self::DEFAULT_TYPE,
             name: $webhook->object['name'],
             quantity: $webhook->object['quantity'],
+            mandate: self::mandateFromWebhookObject($webhook->object),
         );
     }
 }

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -45,8 +45,8 @@ class WebhookEventFactory
      * enrichment pattern fetches the mandate summary so consumers can persist
      * the payment method on file without a separate API roundtrip per portal
      * render. Enrichment is best-effort: a transient `GetSubscription` failure
-     * does not block persistence — the event falls back to the webhook payload
-     * (mandate stays null, backfilled by the next `sync()`).
+     * does not block persistence — the event falls back to the webhook payload,
+     * which embeds the mandate inline, so the fallback stays non-lossy.
      *
      * For `refund.*` events the factory enriches via `GetRefund` for the same
      * reason as `order.paid`: refund tax data is compliance-critical and the

--- a/tests/Events/SubscriptionBillingUpdatedTest.php
+++ b/tests/Events/SubscriptionBillingUpdatedTest.php
@@ -89,4 +89,30 @@ class SubscriptionBillingUpdatedTest extends TestCase
         $this->assertSame(1, $event->quantity);
         $this->assertNull($event->mandate);
     }
+
+    public function test_it_parses_the_mandate_embedded_in_the_webhook_payload(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.billing_updated',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Basic Plan',
+                'quantity' => 1,
+                'mandate' => ['method' => 'sepa_debit', 'maskedIdentifier' => 'NL91****4300'],
+            ],
+        );
+
+        $event = SubscriptionBillingUpdated::fromWebhook($webhook);
+
+        $this->assertNotNull($event->mandate);
+        $this->assertSame('sepa_debit', $event->mandate->method);
+        $this->assertSame('NL91****4300', $event->mandate->maskedIdentifier);
+    }
 }

--- a/tests/Events/SubscriptionStartedTest.php
+++ b/tests/Events/SubscriptionStartedTest.php
@@ -65,5 +65,54 @@ class SubscriptionStartedTest extends TestCase
         $this->assertSame('default', $event->type);
         $this->assertSame('Basic Plan', $event->name);
         $this->assertSame(1, $event->quantity);
+        $this->assertNull($event->mandate);
+    }
+
+    public function test_it_parses_the_mandate_embedded_in_the_webhook_payload(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Basic Plan',
+                'quantity' => 1,
+                'mandate' => ['method' => 'card', 'maskedIdentifier' => '4242'],
+            ],
+        );
+
+        $event = SubscriptionStarted::fromWebhook($webhook);
+
+        $this->assertNotNull($event->mandate);
+        $this->assertSame('card', $event->mandate->method);
+        $this->assertSame('4242', $event->mandate->maskedIdentifier);
+    }
+
+    public function test_it_leaves_mandate_null_when_payload_mandate_is_malformed(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Basic Plan',
+                'quantity' => 1,
+                'mandate' => null,
+            ],
+        );
+
+        $this->assertNull(SubscriptionStarted::fromWebhook($webhook)->mandate);
     }
 }

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -168,8 +168,68 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('plan_789', $event->planId);
         $this->assertSame('Premium Plan', $event->name);
         $this->assertSame(1, $event->quantity);
-        // Fallback path can't enrich mandate from the webhook payload.
+        // This payload carries no `mandate`, so the fallback yields null.
         $this->assertNull($event->mandate);
+    }
+
+    public function test_subscription_started_fallback_parses_mandate_embedded_in_webhook_payload(): void
+    {
+        // Enrichment fails, but the webhook payload embeds the mandate inline —
+        // the fallback must carry it through rather than drop it.
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.started',
+            entityType: 'subscription',
+            entityId: 'sub_fail_with_mandate',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
+                'mandate' => ['method' => 'card', 'maskedIdentifier' => '4242'],
+            ],
+        );
+
+        $this->getSubscription->shouldReceive('execute')->andThrow(new \RuntimeException('Transient API failure'));
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionStarted::class, $event);
+        $this->assertNotNull($event->mandate);
+        $this->assertSame('card', $event->mandate->method);
+        $this->assertSame('4242', $event->mandate->maskedIdentifier);
+    }
+
+    public function test_subscription_billing_updated_fallback_parses_mandate_embedded_in_webhook_payload(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_bu',
+            resource: 'webhook_event',
+            eventName: 'subscription.billing_updated',
+            entityType: 'subscription',
+            entityId: 'sub_fail_with_mandate',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'subscriptionPlanId' => 'plan_789',
+                'name' => 'Premium Plan',
+                'quantity' => 1,
+                'mandate' => ['method' => 'sepa_debit', 'maskedIdentifier' => 'NL91****4300'],
+            ],
+        );
+
+        $this->getSubscription->shouldReceive('execute')->andThrow(new \RuntimeException('Transient API failure'));
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionBillingUpdated::class, $event);
+        $this->assertNotNull($event->mandate);
+        $this->assertSame('sepa_debit', $event->mandate->method);
+        $this->assertSame('NL91****4300', $event->mandate->maskedIdentifier);
     }
 
     public function test_subscription_started_event_carries_null_mandate_when_api_returns_none(): void


### PR DESCRIPTION
Closes #58.

Subscription webhook payloads embed the mandate inline (`object.mandate`). The factory's `fromWebhook()` fallback (used when `GetSubscription` enrichment fails) previously dropped it to null. Now it parses the embedded mandate so a transient API failure no longer loses the payment method on file — the stored mandate stays correct until the next `sync()` regardless.

- New `Concerns\ParsesWebhookMandate` trait — defensive (only an array `object.mandate` with a string `method`, else null).
- Wired into `SubscriptionStarted::fromWebhook()` + `SubscriptionBillingUpdated::fromWebhook()`.
- Primary path unchanged (API enrichment still preferred).

241 tests / 737 assertions; PHPStan clean.