### PR TITLE
fix(webhooks): make GetRefund optional in WebhookProcessorFactory::create (restore BC)

### DIFF
--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -29,7 +29,12 @@ class WebhookEventFactory
     public function __construct(
         private GetOrder $getOrder,
         private GetSubscription $getSubscription,
-        private GetRefund $getRefund,
+        /**
+         * Optional: only needed to enrich `refund.*` events. When null, refund
+         * webhooks degrade to {@see UnsupportedWebhookReceived} — keeping the
+         * factory back-compatible for drivers that don't wire refunds.
+         */
+        private ?GetRefund $getRefund = null,
     ) {
         //
     }
@@ -71,9 +76,15 @@ class WebhookEventFactory
             OrderChargebackReceived::VATLY_EVENT_NAME => OrderChargebackReceived::fromWebhook($webhook),
             OrderChargebackReversed::VATLY_EVENT_NAME => OrderChargebackReversed::fromWebhook($webhook),
             PaymentFailed::VATLY_EVENT_NAME => $this->createPaymentFailed($webhook),
-            RefundCompleted::VATLY_EVENT_NAME => RefundCompleted::fromApiRefund($this->getRefund->execute($webhook->entityId)),
-            RefundFailed::VATLY_EVENT_NAME => RefundFailed::fromApiRefund($this->getRefund->execute($webhook->entityId)),
-            RefundCanceled::VATLY_EVENT_NAME => RefundCanceled::fromApiRefund($this->getRefund->execute($webhook->entityId)),
+            RefundCompleted::VATLY_EVENT_NAME => $this->getRefund !== null
+                ? RefundCompleted::fromApiRefund($this->getRefund->execute($webhook->entityId))
+                : UnsupportedWebhookReceived::fromWebhook($webhook),
+            RefundFailed::VATLY_EVENT_NAME => $this->getRefund !== null
+                ? RefundFailed::fromApiRefund($this->getRefund->execute($webhook->entityId))
+                : UnsupportedWebhookReceived::fromWebhook($webhook),
+            RefundCanceled::VATLY_EVENT_NAME => $this->getRefund !== null
+                ? RefundCanceled::fromApiRefund($this->getRefund->execute($webhook->entityId))
+                : UnsupportedWebhookReceived::fromWebhook($webhook),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
@@ -174,7 +185,7 @@ class WebhookEventFactory
      */
     public function getSupportedEvents(): array
     {
-        return [
+        $events = [
             SubscriptionStarted::VATLY_EVENT_NAME,
             SubscriptionBillingUpdated::VATLY_EVENT_NAME,
             SubscriptionResumed::VATLY_EVENT_NAME,
@@ -185,10 +196,18 @@ class WebhookEventFactory
             OrderChargebackReceived::VATLY_EVENT_NAME,
             OrderChargebackReversed::VATLY_EVENT_NAME,
             PaymentFailed::VATLY_EVENT_NAME,
-            RefundCompleted::VATLY_EVENT_NAME,
-            RefundFailed::VATLY_EVENT_NAME,
-            RefundCanceled::VATLY_EVENT_NAME,
         ];
+
+        // Refund events require `GetRefund` enrichment; only report them as
+        // supported when that action is wired (otherwise they degrade to
+        // UnsupportedWebhookReceived, so advertising them would be misleading).
+        if ($this->getRefund !== null) {
+            $events[] = RefundCompleted::VATLY_EVENT_NAME;
+            $events[] = RefundFailed::VATLY_EVENT_NAME;
+            $events[] = RefundCanceled::VATLY_EVENT_NAME;
+        }
+
+        return $events;
     }
 
     /**

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -32,11 +32,13 @@ class WebhookProcessorFactory
      * Drivers call this from their bootstrap to avoid re-deriving the
      * reaction registration list on each install.
      *
-     * `refunds` is optional: when supplied, the built-in
-     * {@see SyncRefundOnStatusChange} reaction persists `refund.*` webhooks.
-     * When omitted, the typed refund events are still dispatched for drivers
-     * to handle themselves — so existing drivers don't have to implement a
-     * refund repository to keep working.
+     * `getRefund` and `refunds` are both optional and back-compatible: a driver
+     * that only wires subscriptions/orders can keep calling this exactly as
+     * before. Pass `getRefund` (and `refunds`) only to opt into refund handling
+     * — when `getRefund` is null, `refund.*` webhooks degrade to
+     * {@see \Vatly\Fluent\Events\UnsupportedWebhookReceived} (the pre-refund
+     * behavior), and the {@see SyncRefundOnStatusChange} reaction is registered
+     * only when `refunds` is supplied.
      *
      * @param WebhookReactionInterface[] $additionalReactions
      */
@@ -49,7 +51,7 @@ class WebhookProcessorFactory
         CustomerBindingRepository $bindings,
         GetOrder $getOrder,
         GetSubscription $getSubscription,
-        GetRefund $getRefund,
+        ?GetRefund $getRefund = null,
         ?RefundRepositoryInterface $refunds = null,
         array $additionalReactions = [],
     ): WebhookProcessor {

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -692,6 +692,32 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('canceled', $event->status);
     }
 
+    public function test_refund_events_degrade_to_unsupported_without_a_get_refund_action(): void
+    {
+        // Back-compat: a factory built without GetRefund (the pre-refund shape)
+        // must treat refund webhooks as unsupported, not fatal.
+        $factory = new WebhookEventFactory($this->getOrder, $this->getSubscription);
+
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_rf',
+            resource: 'webhook_event',
+            eventName: 'refund.completed',
+            entityType: 'refund',
+            entityId: 'refund_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456'],
+        );
+
+        $event = $factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(UnsupportedWebhookReceived::class, $event);
+        $this->assertFalse($factory->isSupported('refund.completed'));
+        $this->assertNotContains('refund.completed', $factory->getSupportedEvents());
+        // Non-refund events are unaffected.
+        $this->assertTrue($factory->isSupported('order.paid'));
+    }
+
     public function test_it_creates_unsupported_webhook_received_for_unknown_events(): void
     {
         $webhook = new WebhookReceived(

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -58,6 +58,30 @@ class WebhookProcessorFactoryTest extends TestCase
         $this->assertInstanceOf(CancelOrderOnCanceled::class, $reactions[6]);
     }
 
+    public function test_it_is_back_compatible_when_called_without_a_get_refund_action(): void
+    {
+        // A pre-refund driver wires only subscriptions/orders and never passes
+        // getRefund/refunds — this must not throw ArgumentCountError.
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            bindings: Mockery::mock(CustomerBindingRepository::class),
+            getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
+        );
+
+        $reactions = $processor->getReactions();
+
+        $this->assertInstanceOf(WebhookProcessor::class, $processor);
+        $this->assertCount(7, $reactions); // no refund reaction without a refunds repo
+        foreach ($reactions as $reaction) {
+            $this->assertNotInstanceOf(SyncRefundOnStatusChange::class, $reaction);
+        }
+    }
+
     public function test_it_registers_the_refund_reaction_only_when_a_refund_repository_is_supplied(): void
     {
         $processor = WebhookProcessorFactory::create(


### PR DESCRIPTION
Fixes a backwards-incompatible break introduced in #59: `WebhookProcessorFactory::create()` (and `WebhookEventFactory`) gained a **required** `GetRefund` argument, so a driver calling the documented factory directly without opting into refunds fatals with `ArgumentCountError` on upgrade.

`getRefund` is now `?GetRefund $getRefund = null` in both. When absent:
- `refund.*` webhooks degrade to `UnsupportedWebhookReceived` (pre-refund behavior),
- `getSupportedEvents()` omits the refund names so `isSupported()` stays truthful,
- the `SyncRefundOnStatusChange` reaction is still registered only when `refunds` is supplied.

The normal `Vatly::webhookProcessor()` path always passes it, so this is a pure back-compat restoration. +2 regression tests. 243 tests; PHPStan clean.