### PR TITLE
feat: claimCustomerFromCheckout + customerIdFromCheckout (anonymous-checkout return matching)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vatly/vatly-api-php": "^0.1.0-alpha.12"
+        "vatly/vatly-api-php": "^0.1.0-alpha.13"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent;
 
+use Vatly\API\Exceptions\ApiException;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
@@ -20,6 +22,7 @@ use Vatly\Fluent\Builders\SubscriptionBuilder;
 use Vatly\Fluent\Configuration\ArrayConfiguration;
 use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Exceptions\CustomerAlreadyBoundException;
 use Vatly\Fluent\Exceptions\IncompleteWiringException;
 use Vatly\Fluent\Webhooks\SignatureVerifier;
 use Vatly\Fluent\Webhooks\WebhookEventFactory;
@@ -46,6 +49,7 @@ class Vatly
     private ?GetCustomer $getCustomer = null;
     private ?GetOrder $getOrder = null;
     private ?GetRefund $getRefund = null;
+    private ?GetCheckout $getCheckout = null;
     private ?CreateCheckout $createCheckout = null;
     private ?GetSubscription $getSubscription = null;
     private ?CancelSubscription $cancelSubscription = null;
@@ -140,6 +144,57 @@ class Vatly
         );
     }
 
+    /**
+     * Resolve the Vatly customer id associated with a checkout, or null.
+     *
+     * The framework-agnostic core of anonymous-checkout return matching: given
+     * a checkout id (typically read off the redirect URL via the `{CHECKOUT_ID}`
+     * placeholder), it returns the attached `cus_…` id. Returns null — rather
+     * than throwing — when there is nothing to resolve: an unknown / out-of-scope
+     * checkout id, or a checkout with no customer associated yet (e.g. not
+     * completed). That keeps it safe to call straight from a request handler on
+     * the redirect back.
+     */
+    public function customerIdFromCheckout(string $checkoutId): ?string
+    {
+        try {
+            $customerId = $this->getCheckout()->execute($checkoutId)->customerId;
+        } catch (ApiException $e) {
+            if ($e->getCode() === 404) {
+                return null; // Unknown / out-of-scope checkout id — nothing to resolve.
+            }
+
+            throw $e;
+        }
+
+        return ($customerId === null || $customerId === '') ? null : $customerId;
+    }
+
+    /**
+     * Claim the Vatly customer behind a checkout for a host customer id.
+     *
+     * Resolves the checkout's customer id (see {@see self::customerIdFromCheckout()})
+     * and binds it to the given host customer id. Idempotent for the same pair;
+     * throws on a cross-host conflict. Returns false when there is nothing to
+     * claim. Drivers that also need to re-attribute previously-anonymous local
+     * records can resolve the id with {@see self::customerIdFromCheckout()} and
+     * run their own richer claim instead.
+     *
+     * @throws CustomerAlreadyBoundException When the host is already bound to a different Vatly customer.
+     */
+    public function claimCustomerFromCheckout(string $checkoutId, string $hostCustomerId): bool
+    {
+        $customerId = $this->customerIdFromCheckout($checkoutId);
+
+        if ($customerId === null) {
+            return false;
+        }
+
+        $this->customers()->attribute($customerId, $hostCustomerId);
+
+        return true;
+    }
+
     // --- Builders (per-call construction; no caching) ---
 
     public function checkoutBuilder(CustomerProfile $profile): CheckoutBuilder
@@ -213,6 +268,11 @@ class Vatly
     public function getRefund(): GetRefund
     {
         return $this->getRefund ??= new GetRefund($this->apiClient);
+    }
+
+    public function getCheckout(): GetCheckout
+    {
+        return $this->getCheckout ??= new GetCheckout($this->apiClient);
     }
 
     public function createCheckout(): CreateCheckout

--- a/tests/ClaimCustomerFromCheckoutTest.php
+++ b/tests/ClaimCustomerFromCheckoutTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests;
+
+use Mockery;
+use Vatly\API\Exceptions\ApiException;
+use Vatly\API\Resources\Checkout;
+use Vatly\Fluent\Actions\GetCheckout;
+use Vatly\Fluent\Configuration\ArrayConfiguration;
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Exceptions\CustomerAlreadyBoundException;
+use Vatly\Fluent\Vatly;
+use Vatly\Fluent\Wiring;
+
+class ClaimCustomerFromCheckoutTest extends TestCase
+{
+    private const CHECKOUT_ID = 'checkout_abc';
+    private const VATLY_CUSTOMER_ID = 'customer_vatly';
+    private const HOST_CUSTOMER_ID = '42';
+
+    public function test_attributes_customer_and_returns_true_for_an_unbound_host(): void
+    {
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('vatlyCustomerIdFor')->with(self::HOST_CUSTOMER_ID)->andReturn(null);
+        $bindings->shouldReceive('bind')->once()->with(self::VATLY_CUSTOMER_ID, self::HOST_CUSTOMER_ID);
+
+        $vatly = $this->vatlyWithBindings($bindings);
+        $this->fakeCheckout($vatly, self::VATLY_CUSTOMER_ID);
+
+        $this->assertTrue(
+            $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID)
+        );
+    }
+
+    public function test_is_idempotent_for_the_same_host_customer_pair(): void
+    {
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('vatlyCustomerIdFor')->with(self::HOST_CUSTOMER_ID)->andReturn(self::VATLY_CUSTOMER_ID);
+        $bindings->shouldReceive('bind')->with(self::VATLY_CUSTOMER_ID, self::HOST_CUSTOMER_ID);
+
+        $vatly = $this->vatlyWithBindings($bindings);
+        $this->fakeCheckout($vatly, self::VATLY_CUSTOMER_ID);
+
+        $this->assertTrue(
+            $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID)
+        );
+    }
+
+    public function test_throws_on_a_cross_host_conflict(): void
+    {
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('vatlyCustomerIdFor')->with(self::HOST_CUSTOMER_ID)->andReturn('customer_someone_else');
+        $bindings->shouldNotReceive('bind');
+
+        $vatly = $this->vatlyWithBindings($bindings);
+        $this->fakeCheckout($vatly, self::VATLY_CUSTOMER_ID);
+
+        $this->expectException(CustomerAlreadyBoundException::class);
+
+        $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID);
+    }
+
+    public function test_returns_false_for_an_unknown_checkout(): void
+    {
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('bind');
+
+        $vatly = $this->vatlyWithBindings($bindings);
+
+        $getCheckout = Mockery::mock(GetCheckout::class);
+        $getCheckout->shouldReceive('execute')->with(self::CHECKOUT_ID)
+            ->andThrow(new ApiException('Error 404 executing API call', 404));
+        $this->setPrivate($vatly, 'getCheckout', $getCheckout);
+
+        $this->assertFalse(
+            $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID)
+        );
+    }
+
+    public function test_rethrows_non_not_found_api_errors(): void
+    {
+        $vatly = $this->vatlyWithBindings(Mockery::mock(CustomerBindingRepository::class));
+
+        $getCheckout = Mockery::mock(GetCheckout::class);
+        $getCheckout->shouldReceive('execute')->with(self::CHECKOUT_ID)
+            ->andThrow(new ApiException('Error 500 executing API call', 500));
+        $this->setPrivate($vatly, 'getCheckout', $getCheckout);
+
+        $this->expectException(ApiException::class);
+
+        $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID);
+    }
+
+    public function test_returns_false_when_the_checkout_has_no_customer_yet(): void
+    {
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('bind');
+
+        $vatly = $this->vatlyWithBindings($bindings);
+        $this->fakeCheckout($vatly, null);
+
+        $this->assertFalse(
+            $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID)
+        );
+    }
+
+    public function test_returns_false_for_an_empty_customer_id(): void
+    {
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('bind');
+
+        $vatly = $this->vatlyWithBindings($bindings);
+        $this->fakeCheckout($vatly, '');
+
+        $this->assertFalse(
+            $vatly->claimCustomerFromCheckout(self::CHECKOUT_ID, self::HOST_CUSTOMER_ID)
+        );
+    }
+
+    public function test_customer_id_from_checkout_returns_the_attached_customer_id(): void
+    {
+        $vatly = $this->vatlyWithBindings(Mockery::mock(CustomerBindingRepository::class));
+        $this->fakeCheckout($vatly, self::VATLY_CUSTOMER_ID);
+
+        $this->assertSame(
+            self::VATLY_CUSTOMER_ID,
+            $vatly->customerIdFromCheckout(self::CHECKOUT_ID)
+        );
+    }
+
+    public function test_customer_id_from_checkout_returns_null_for_an_unknown_checkout(): void
+    {
+        $vatly = $this->vatlyWithBindings(Mockery::mock(CustomerBindingRepository::class));
+
+        $getCheckout = Mockery::mock(GetCheckout::class);
+        $getCheckout->shouldReceive('execute')->with(self::CHECKOUT_ID)
+            ->andThrow(new ApiException('Error 404 executing API call', 404));
+        $this->setPrivate($vatly, 'getCheckout', $getCheckout);
+
+        $this->assertNull($vatly->customerIdFromCheckout(self::CHECKOUT_ID));
+    }
+
+    public function test_customer_id_from_checkout_returns_null_when_no_customer_yet(): void
+    {
+        $vatly = $this->vatlyWithBindings(Mockery::mock(CustomerBindingRepository::class));
+        $this->fakeCheckout($vatly, null);
+
+        $this->assertNull($vatly->customerIdFromCheckout(self::CHECKOUT_ID));
+    }
+
+    private function vatlyWithBindings(CustomerBindingRepository $bindings): Vatly
+    {
+        return new Vatly(new Wiring(
+            config: new ArrayConfiguration(['api_key' => 'test_abcdefghijklmnopqrstuvwxyz']),
+            customerBindings: $bindings,
+        ));
+    }
+
+    /**
+     * Stub the GetCheckout action so it returns a Checkout carrying the given
+     * customer id, without hitting the API.
+     */
+    private function fakeCheckout(Vatly $vatly, ?string $customerId): void
+    {
+        $checkout = new Checkout($vatly->getApiClient());
+        $checkout->customerId = $customerId;
+
+        $getCheckout = Mockery::mock(GetCheckout::class);
+        $getCheckout->shouldReceive('execute')->with(self::CHECKOUT_ID)->andReturn($checkout);
+
+        $this->setPrivate($vatly, 'getCheckout', $getCheckout);
+    }
+
+    private function setPrivate(object $target, string $property, mixed $value): void
+    {
+        $ref = new \ReflectionProperty($target, $property);
+        $ref->setValue($target, $value);
+    }
+}


### PR DESCRIPTION
The framework-agnostic core of anonymous-checkout return matching for vatly-laravel#25.

Once Vatly substitutes a `{CHECKOUT_ID}` placeholder into the checkout redirect URL, the host learns the checkout id on the way back and can resolve + claim the customer behind it — **no server-side token store**, multi-tab safe by construction.

## API

- **`customerIdFromCheckout(string $checkoutId): ?string`** — resolves the checkout's `customerId`. Returns `null` (rather than throwing) for an unknown / out-of-scope checkout (404) or one with no customer associated yet, so it's safe to call straight from a request handler.
- **`claimCustomerFromCheckout(string $checkoutId, string $hostCustomerId): bool`** — composes the resolver with `customers()->attribute()`. Idempotent for the same pair; throws `CustomerAlreadyBoundException` on a cross-host conflict. Returns `false` when there's nothing to claim.
- **`getCheckout()`** action accessor (the `GetCheckout` action existed; the accessor didn't).

`customerIdFromCheckout()` is split out so drivers that also re-attribute previously-anonymous local records (e.g. vatly-laravel re-owning a guest's orders/subscriptions) can resolve the id and run their own richer claim.

## ⚠️ Dependency / merge order

Requires **vatly-api-php ^0.1.0-alpha.13** (adds `Checkout::$customerId`) — bumped in `composer.json`. **CI will be red until that alpha is released to Packagist.** Verified locally green against the api-php branch: `composer test` (253 tests) ✓, `composer analyse` ✓.

## Note on the issue premise

This deliberately contradicts vatly-laravel#25's "no fluent change" premise. The issue proposed a host-side token store; once Vatly does URL templating, the remaining logic is pure composition of fluent primitives, so it belongs here where every driver reuses it.