### PR TITLE
feat(webhooks): add checkout events + grace-period-completed (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in
 | `subscription.billing_updated` | `SubscriptionBillingUpdated`                               | `SyncSubscriptionOnBillingUpdated` | `SubscriptionWriter::update` (refreshes mandate)    |
 | `subscription.resumed`   | `SubscriptionResumed`                                             | `ResumeSubscriptionOnResumed`  | `SubscriptionWriter::update` (clears end date)       |
 | `subscription.canceled`  | `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update`                         |
+| `subscription.cancellation_grace_period_completed` | `SubscriptionCancellationGracePeriodCompleted` | — (dispatched only)            | none — driver-handled                                |
+| `checkout.paid` / `checkout.failed` / `checkout.canceled` / `checkout.expired` | `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` | — (dispatched only) | none — driver-handled |
 
 `OrderWriter::store`, `SubscriptionWriter::store`, and `RefundWriter::store` may return `null` if your driver can't route the data (see the adapter recipe below). Built-in reactions tolerate null — `SyncSubscriptionOnStarted` skips its follow-up `LocalSubscriptionCreated` dispatch when store returns null.
 
@@ -118,6 +120,10 @@ For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in
 **Refunds** are opt-in: supply a `RefundRepositoryInterface` via `Wiring(refunds: …)` and the built-in `SyncRefundOnStatusChange` reaction persists `refund.*` webhooks (store-or-update, like orders) — unblocking terminal-state refund reconciliation. Omit it and the typed refund events are still dispatched for you to handle. Refund events are enriched via `GetRefund` so they carry the full tax breakdown, mirroring `order.paid`.
 
 **Chargebacks** ship no built-in reaction: Vatly's public order status doesn't change on a chargeback, so fluent doesn't synthesize one. Instead `OrderChargebackReceived` / `OrderChargebackReversed` are dispatched (with the affected order's ID as `orderId`) for your driver to react to — e.g. suspend access on receipt, reinstate on reversal.
+
+**Checkout events** are dispatched only — no built-in reaction. The `checkout.*` deliveries carry the full Checkout resource (status, `customerId`, `orderId`, `metadata`) with no sparse money/tax fields, so they need no enriching API GET and are built straight from the payload. Use `CheckoutPaid` for an analytics/receipt handoff at the earliest "customer paid" moment — before `order.paid`'s tax-summary enrichment — and `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` for retry and cart-abandonment funnel hooks. `customerId` is nullable: an anonymous checkout only gets a customer attributed once payment completes.
+
+**`subscription.cancellation_grace_period_completed`** is dispatched only. The grace period was already stamped onto the local row by `CancelSubscriptionOnCanceled` when the cancellation arrived, so the derived "ended" state is correct once the clock passes `endsAt`; this event lets a driver flip local state atomically instead of polling `endsAt < now` on a scheduled job. Whether to additionally write a `fully_ended` status is driver-specific (Vatly has no such status to mirror), so it's left to the consumer.
 
 `additionalWebhookReactions` (on `WebhookProcessorFactory::create`) lets you append driver-specific reactions without losing the built-ins.
 

--- a/src/Concerns/NormalizesWebhookMetadata.php
+++ b/src/Concerns/NormalizesWebhookMetadata.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Concerns;
+
+/**
+ * Normalizes the free-form `metadata` bag off a webhook `object` payload into a
+ * plain `array<string, mixed>` (or `null`).
+ *
+ * Vatly returns `metadata` as either a JSON object or `null`; once it has gone
+ * through {@see \Vatly\Fluent\Webhooks\WebhookEventFactory::fromPayload()}'s
+ * deep array conversion it is already an array, but an event built directly
+ * from an API resource may still see a `stdClass`. This keeps consumers on a
+ * single, predictable shape regardless of which path produced the event.
+ */
+trait NormalizesWebhookMetadata
+{
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function normalizeMetadata(mixed $metadata): ?array
+    {
+        if ($metadata === null) {
+            return null;
+        }
+
+        if (is_array($metadata)) {
+            /** @var array<string, mixed> $metadata */
+            return $metadata;
+        }
+
+        if (is_object($metadata)) {
+            /** @var array<string, mixed> $decoded */
+            $decoded = (array) json_decode((string) json_encode($metadata), true);
+
+            return $decoded;
+        }
+
+        return null;
+    }
+}

--- a/src/Events/CheckoutCanceled.php
+++ b/src/Events/CheckoutCanceled.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Types\CheckoutStatus;
+use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Concerns\NormalizesWebhookMetadata;
+
+/**
+ * Event representing a hosted checkout canceled by the customer at Vatly.
+ *
+ * The customer abandoned the hosted checkout before completing payment — useful
+ * for cart-abandonment funnel hooks. No order materializes, so `orderId` is
+ * normally null.
+ *
+ * Built straight from the webhook payload — see {@see CheckoutPaid} for the
+ * shared rationale (full Checkout resource on the wire, dispatched-only, no
+ * built-in reaction).
+ *
+ * @immutable
+ */
+class CheckoutCanceled
+{
+    use NormalizesWebhookMetadata;
+
+    public const VATLY_EVENT_NAME = WebhookEventName::CHECKOUT_CANCELED;
+
+    /**
+     * @param array<string, mixed>|null $metadata
+     */
+    public function __construct(
+        public string $checkoutId,
+        public ?string $customerId,
+        public ?string $orderId,
+        public string $status,
+        public ?array $metadata = null,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            checkoutId: $webhook->entityId,
+            customerId: $webhook->object['customerId'] ?? null,
+            orderId: $webhook->object['orderId'] ?? null,
+            status: $webhook->object['status'] ?? CheckoutStatus::STATUS_CANCELED,
+            metadata: self::normalizeMetadata($webhook->object['metadata'] ?? null),
+        );
+    }
+}

--- a/src/Events/CheckoutExpired.php
+++ b/src/Events/CheckoutExpired.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Types\CheckoutStatus;
+use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Concerns\NormalizesWebhookMetadata;
+
+/**
+ * Event representing a hosted checkout that expired without completion at Vatly.
+ *
+ * The checkout session timed out before the customer paid — distinct from
+ * {@see CheckoutCanceled} (an explicit customer action). No order materializes,
+ * so `orderId` is normally null.
+ *
+ * Built straight from the webhook payload — see {@see CheckoutPaid} for the
+ * shared rationale (full Checkout resource on the wire, dispatched-only, no
+ * built-in reaction).
+ *
+ * @immutable
+ */
+class CheckoutExpired
+{
+    use NormalizesWebhookMetadata;
+
+    public const VATLY_EVENT_NAME = WebhookEventName::CHECKOUT_EXPIRED;
+
+    /**
+     * @param array<string, mixed>|null $metadata
+     */
+    public function __construct(
+        public string $checkoutId,
+        public ?string $customerId,
+        public ?string $orderId,
+        public string $status,
+        public ?array $metadata = null,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            checkoutId: $webhook->entityId,
+            customerId: $webhook->object['customerId'] ?? null,
+            orderId: $webhook->object['orderId'] ?? null,
+            status: $webhook->object['status'] ?? CheckoutStatus::STATUS_EXPIRED,
+            metadata: self::normalizeMetadata($webhook->object['metadata'] ?? null),
+        );
+    }
+}

--- a/src/Events/CheckoutFailed.php
+++ b/src/Events/CheckoutFailed.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Types\CheckoutStatus;
+use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Concerns\NormalizesWebhookMetadata;
+
+/**
+ * Event representing a hosted checkout whose payment failed at Vatly.
+ *
+ * Distinct from {@see PaymentFailed}, which is about an existing order's billing
+ * attempt; this fires against the checkout itself before any order exists, so
+ * drivers can route the customer into a retry flow. No order materializes on a
+ * failed checkout, so `orderId` is normally null.
+ *
+ * Built straight from the webhook payload — see {@see CheckoutPaid} for the
+ * shared rationale (full Checkout resource on the wire, dispatched-only, no
+ * built-in reaction).
+ *
+ * @immutable
+ */
+class CheckoutFailed
+{
+    use NormalizesWebhookMetadata;
+
+    public const VATLY_EVENT_NAME = WebhookEventName::CHECKOUT_FAILED;
+
+    /**
+     * @param array<string, mixed>|null $metadata
+     */
+    public function __construct(
+        public string $checkoutId,
+        public ?string $customerId,
+        public ?string $orderId,
+        public string $status,
+        public ?array $metadata = null,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            checkoutId: $webhook->entityId,
+            customerId: $webhook->object['customerId'] ?? null,
+            orderId: $webhook->object['orderId'] ?? null,
+            status: $webhook->object['status'] ?? CheckoutStatus::STATUS_FAILED,
+            metadata: self::normalizeMetadata($webhook->object['metadata'] ?? null),
+        );
+    }
+}

--- a/src/Events/CheckoutPaid.php
+++ b/src/Events/CheckoutPaid.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\API\Types\CheckoutStatus;
+use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Concerns\NormalizesWebhookMetadata;
+
+/**
+ * Event representing a hosted checkout being paid at Vatly.
+ *
+ * Fires at the earliest "customer paid" moment — before `order.paid`'s
+ * tax-summary enrichment GET — so drivers using the hosted-checkout flow can
+ * drive in-app "thanks" / receipt UI and analytics handoff without waiting for
+ * the order to materialize. It overlaps semantically with {@see OrderPaid} but
+ * is scoped to the checkout, not the order it produces; the `orderId` links the
+ * two once the order exists.
+ *
+ * Built straight from the webhook payload: the `checkout.*` deliveries carry the
+ * full Checkout resource (status, customerId, orderId, metadata) with no sparse
+ * money/tax fields that would need a follow-up API GET — unlike orders and
+ * subscriptions. fluent ships no built-in reaction; this is a dispatched-only
+ * signal drivers consume for receipts/analytics.
+ *
+ * `customerId` is nullable: an anonymous checkout only gets a customer
+ * associated once payment completes, so it is normally present here but the
+ * type stays honest rather than synthesizing an empty string.
+ *
+ * @immutable
+ */
+class CheckoutPaid
+{
+    use NormalizesWebhookMetadata;
+
+    public const VATLY_EVENT_NAME = WebhookEventName::CHECKOUT_PAID;
+
+    /**
+     * @param array<string, mixed>|null $metadata
+     */
+    public function __construct(
+        public string $checkoutId,
+        public ?string $customerId,
+        public ?string $orderId,
+        public string $status,
+        public ?array $metadata = null,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            checkoutId: $webhook->entityId,
+            customerId: $webhook->object['customerId'] ?? null,
+            orderId: $webhook->object['orderId'] ?? null,
+            status: $webhook->object['status'] ?? CheckoutStatus::STATUS_PAID,
+            metadata: self::normalizeMetadata($webhook->object['metadata'] ?? null),
+        );
+    }
+}

--- a/src/Events/SubscriptionCancellationGracePeriodCompleted.php
+++ b/src/Events/SubscriptionCancellationGracePeriodCompleted.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Vatly\API\Types\WebhookEventName;
+
+/**
+ * Event representing a canceled subscription whose grace period has now run out.
+ *
+ * The terminal transition after {@see SubscriptionCanceledWithGracePeriod}: the
+ * grace-period clock reached `endsAt` and the subscription is now fully ended.
+ * Today drivers infer this by polling `endsAt < now` on a scheduled job; this
+ * direct event lets local state flip atomically and removes a class of
+ * "the cron is late so the state is wrong" bugs.
+ *
+ * fluent ships no built-in reaction: the cancellation that scheduled the grace
+ * period already stamped `endsAt` onto the local row (via
+ * {@see \Vatly\Fluent\Webhooks\Reactions\CancelSubscriptionOnCanceled}), so the
+ * derived "ended" state is already correct once the clock passes. Whether to
+ * additionally flip a stored status to a `fully_ended` value is driver-specific
+ * — there is no such status in Vatly's own model to mirror — so this is
+ * dispatched-only, leaving that decision to the consumer.
+ *
+ * @immutable
+ */
+class SubscriptionCancellationGracePeriodCompleted
+{
+    public const VATLY_EVENT_NAME = WebhookEventName::SUBSCRIPTION_CANCELLATION_GRACE_PERIOD_COMPLETED;
+
+    public function __construct(
+        public string $customerId,
+        public string $subscriptionId,
+        public DateTimeInterface $endsAt,
+    ) {
+        //
+    }
+
+    public static function fromWebhook(WebhookReceived $webhook): self
+    {
+        return new self(
+            customerId: $webhook->object['customerId'] ?? '',
+            subscriptionId: $webhook->entityId,
+            endsAt: new DateTimeImmutable($webhook->object['endedAt'] ?? $webhook->createdAt),
+        );
+    }
+}

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -8,6 +8,10 @@ use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Events\CheckoutCanceled;
+use Vatly\Fluent\Events\CheckoutExpired;
+use Vatly\Fluent\Events\CheckoutFailed;
+use Vatly\Fluent\Events\CheckoutPaid;
 use Vatly\Fluent\Events\OrderCanceled;
 use Vatly\Fluent\Events\OrderChargebackReceived;
 use Vatly\Fluent\Events\OrderChargebackReversed;
@@ -19,6 +23,7 @@ use Vatly\Fluent\Events\RefundFailed;
 use Vatly\Fluent\Events\SubscriptionBillingUpdated;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
+use Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted;
 use Vatly\Fluent\Events\SubscriptionResumed;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
@@ -61,7 +66,14 @@ class WebhookEventFactory
      * from the webhook payload — a status mirror and dispute signals
      * respectively, neither of which needs enrichment.
      *
-     * @return SubscriptionStarted|SubscriptionBillingUpdated|SubscriptionResumed|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|OrderPaid|OrderCanceled|OrderChargebackReceived|OrderChargebackReversed|PaymentFailed|RefundCompleted|RefundFailed|RefundCanceled|UnsupportedWebhookReceived
+     * The `checkout.*` events and `subscription.cancellation_grace_period_completed`
+     * are likewise built straight from the payload: checkout deliveries already
+     * carry the full Checkout resource (no sparse money/tax fields), and the
+     * grace-period-completed transition only needs the customer/subscription IDs
+     * and end timestamp, all present on the wire. They are dispatched-only — no
+     * built-in reaction mutates local state.
+     *
+     * @return SubscriptionStarted|SubscriptionBillingUpdated|SubscriptionResumed|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|SubscriptionCancellationGracePeriodCompleted|OrderPaid|OrderCanceled|OrderChargebackReceived|OrderChargebackReversed|PaymentFailed|CheckoutPaid|CheckoutFailed|CheckoutCanceled|CheckoutExpired|RefundCompleted|RefundFailed|RefundCanceled|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
@@ -71,11 +83,16 @@ class WebhookEventFactory
             SubscriptionResumed::VATLY_EVENT_NAME => SubscriptionResumed::fromWebhook($webhook),
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME => SubscriptionCanceledImmediately::fromWebhook($webhook),
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME => SubscriptionCanceledWithGracePeriod::fromWebhook($webhook),
+            SubscriptionCancellationGracePeriodCompleted::VATLY_EVENT_NAME => SubscriptionCancellationGracePeriodCompleted::fromWebhook($webhook),
             OrderPaid::VATLY_EVENT_NAME => $this->createOrderPaid($webhook),
             OrderCanceled::VATLY_EVENT_NAME => OrderCanceled::fromWebhook($webhook),
             OrderChargebackReceived::VATLY_EVENT_NAME => OrderChargebackReceived::fromWebhook($webhook),
             OrderChargebackReversed::VATLY_EVENT_NAME => OrderChargebackReversed::fromWebhook($webhook),
             PaymentFailed::VATLY_EVENT_NAME => $this->createPaymentFailed($webhook),
+            CheckoutPaid::VATLY_EVENT_NAME => CheckoutPaid::fromWebhook($webhook),
+            CheckoutFailed::VATLY_EVENT_NAME => CheckoutFailed::fromWebhook($webhook),
+            CheckoutCanceled::VATLY_EVENT_NAME => CheckoutCanceled::fromWebhook($webhook),
+            CheckoutExpired::VATLY_EVENT_NAME => CheckoutExpired::fromWebhook($webhook),
             RefundCompleted::VATLY_EVENT_NAME => $this->getRefund !== null
                 ? RefundCompleted::fromApiRefund($this->getRefund->execute($webhook->entityId))
                 : UnsupportedWebhookReceived::fromWebhook($webhook),
@@ -191,11 +208,16 @@ class WebhookEventFactory
             SubscriptionResumed::VATLY_EVENT_NAME,
             SubscriptionCanceledImmediately::VATLY_EVENT_NAME,
             SubscriptionCanceledWithGracePeriod::VATLY_EVENT_NAME,
+            SubscriptionCancellationGracePeriodCompleted::VATLY_EVENT_NAME,
             OrderPaid::VATLY_EVENT_NAME,
             OrderCanceled::VATLY_EVENT_NAME,
             OrderChargebackReceived::VATLY_EVENT_NAME,
             OrderChargebackReversed::VATLY_EVENT_NAME,
             PaymentFailed::VATLY_EVENT_NAME,
+            CheckoutPaid::VATLY_EVENT_NAME,
+            CheckoutFailed::VATLY_EVENT_NAME,
+            CheckoutCanceled::VATLY_EVENT_NAME,
+            CheckoutExpired::VATLY_EVENT_NAME,
         ];
 
         // Refund events require `GetRefund` enrichment; only report them as

--- a/tests/Events/CheckoutEventsTest.php
+++ b/tests/Events/CheckoutEventsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use Vatly\Fluent\Events\CheckoutCanceled;
+use Vatly\Fluent\Events\CheckoutExpired;
+use Vatly\Fluent\Events\CheckoutFailed;
+use Vatly\Fluent\Events\CheckoutPaid;
+use Vatly\Fluent\Events\WebhookReceived;
+use Vatly\Fluent\Tests\TestCase;
+
+class CheckoutEventsTest extends TestCase
+{
+    public function test_paid_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('checkout.paid', CheckoutPaid::VATLY_EVENT_NAME);
+    }
+
+    public function test_failed_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('checkout.failed', CheckoutFailed::VATLY_EVENT_NAME);
+    }
+
+    public function test_canceled_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('checkout.canceled', CheckoutCanceled::VATLY_EVENT_NAME);
+    }
+
+    public function test_expired_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame('checkout.expired', CheckoutExpired::VATLY_EVENT_NAME);
+    }
+
+    public function test_paid_creates_from_webhook_with_order_and_customer_links(): void
+    {
+        $event = CheckoutPaid::fromWebhook($this->webhook('checkout.paid', [
+            'customerId' => 'cus_456',
+            'orderId' => 'ord_789',
+            'status' => 'paid',
+            'metadata' => ['cart_id' => 'cart_1'],
+        ]));
+
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('ord_789', $event->orderId);
+        $this->assertSame('paid', $event->status);
+        $this->assertSame(['cart_id' => 'cart_1'], $event->metadata);
+    }
+
+    public function test_paid_defaults_status_and_nulls_absent_fields(): void
+    {
+        // An anonymous checkout that just paid may not echo every field back;
+        // the type stays honest (null) rather than synthesizing empty strings,
+        // and status falls back to the lifecycle this event represents.
+        $event = CheckoutPaid::fromWebhook($this->webhook('checkout.paid', []));
+
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertNull($event->customerId);
+        $this->assertNull($event->orderId);
+        $this->assertSame('paid', $event->status);
+        $this->assertNull($event->metadata);
+    }
+
+    public function test_failed_creates_from_webhook_with_null_order(): void
+    {
+        $event = CheckoutFailed::fromWebhook($this->webhook('checkout.failed', [
+            'customerId' => 'cus_456',
+            'status' => 'failed',
+        ]));
+
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertNull($event->orderId);
+        $this->assertSame('failed', $event->status);
+    }
+
+    public function test_canceled_creates_from_webhook(): void
+    {
+        $event = CheckoutCanceled::fromWebhook($this->webhook('checkout.canceled', [
+            'customerId' => 'cus_456',
+        ]));
+
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('canceled', $event->status);
+    }
+
+    public function test_expired_creates_from_webhook(): void
+    {
+        $event = CheckoutExpired::fromWebhook($this->webhook('checkout.expired', []));
+
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertNull($event->customerId);
+        $this->assertSame('expired', $event->status);
+    }
+
+    public function test_metadata_normalizes_stdclass_into_array(): void
+    {
+        // The factory deep-converts the payload to arrays, but guard the
+        // object path so an event built from a raw stdClass payload stays
+        // on the same array shape consumers expect.
+        $event = CheckoutPaid::fromWebhook($this->webhook('checkout.paid', [
+            'metadata' => (object) ['order_id' => '123456'],
+        ]));
+
+        $this->assertSame(['order_id' => '123456'], $event->metadata);
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function webhook(string $eventName, array $object): WebhookReceived
+    {
+        return new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: $eventName,
+            entityType: 'checkout',
+            entityId: 'checkout_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: $object,
+        );
+    }
+}

--- a/tests/Events/SubscriptionCancellationGracePeriodCompletedTest.php
+++ b/tests/Events/SubscriptionCancellationGracePeriodCompletedTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Events;
+
+use DateTimeInterface;
+use Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted;
+use Vatly\Fluent\Events\WebhookReceived;
+use Vatly\Fluent\Tests\TestCase;
+
+class SubscriptionCancellationGracePeriodCompletedTest extends TestCase
+{
+    public function test_has_correct_vatly_event_name_constant(): void
+    {
+        $this->assertSame(
+            'subscription.cancellation_grace_period_completed',
+            SubscriptionCancellationGracePeriodCompleted::VATLY_EVENT_NAME,
+        );
+    }
+
+    public function test_creates_from_webhook_with_ended_at_timestamp(): void
+    {
+        $event = SubscriptionCancellationGracePeriodCompleted::fromWebhook($this->webhook([
+            'customerId' => 'cus_456',
+            'endedAt' => '2024-02-15T10:00:00Z',
+        ]));
+
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+        $this->assertInstanceOf(DateTimeInterface::class, $event->endsAt);
+        $this->assertSame('2024-02-15T10:00:00+00:00', $event->endsAt->format('c'));
+    }
+
+    public function test_ends_at_falls_back_to_created_at_when_ended_at_absent(): void
+    {
+        $event = SubscriptionCancellationGracePeriodCompleted::fromWebhook($this->webhook([
+            'customerId' => 'cus_456',
+        ]));
+
+        $this->assertSame('2024-01-15T10:00:00+00:00', $event->endsAt->format('c'));
+    }
+
+    public function test_customer_id_falls_back_to_empty_string_when_absent(): void
+    {
+        $event = SubscriptionCancellationGracePeriodCompleted::fromWebhook($this->webhook([]));
+
+        $this->assertSame('', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+    }
+
+    /**
+     * @param array<string, mixed> $object
+     */
+    private function webhook(array $object): WebhookReceived
+    {
+        return new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'subscription.cancellation_grace_period_completed',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: $object,
+        );
+    }
+}

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -17,6 +17,10 @@ use Vatly\API\Webhooks\WebhookPayload;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Events\CheckoutCanceled;
+use Vatly\Fluent\Events\CheckoutExpired;
+use Vatly\Fluent\Events\CheckoutFailed;
+use Vatly\Fluent\Events\CheckoutPaid;
 use Vatly\Fluent\Events\OrderCanceled;
 use Vatly\Fluent\Events\OrderChargebackReceived;
 use Vatly\Fluent\Events\OrderChargebackReversed;
@@ -28,6 +32,7 @@ use Vatly\Fluent\Events\RefundFailed;
 use Vatly\Fluent\Events\SubscriptionBillingUpdated;
 use Vatly\Fluent\Events\SubscriptionCanceledImmediately;
 use Vatly\Fluent\Events\SubscriptionCanceledWithGracePeriod;
+use Vatly\Fluent\Events\SubscriptionCancellationGracePeriodCompleted;
 use Vatly\Fluent\Events\SubscriptionResumed;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
@@ -718,6 +723,123 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertTrue($factory->isSupported('order.paid'));
     }
 
+    public function test_it_creates_checkout_paid_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_cp',
+            resource: 'webhook_event',
+            eventName: 'checkout.paid',
+            entityType: 'checkout',
+            entityId: 'checkout_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'orderId' => 'ord_789',
+                'status' => 'paid',
+                'metadata' => ['cart_id' => 'cart_1'],
+            ],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(CheckoutPaid::class, $event);
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('ord_789', $event->orderId);
+        $this->assertSame('paid', $event->status);
+        $this->assertSame(['cart_id' => 'cart_1'], $event->metadata);
+    }
+
+    public function test_it_creates_checkout_failed_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_cf',
+            resource: 'webhook_event',
+            eventName: 'checkout.failed',
+            entityType: 'checkout',
+            entityId: 'checkout_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456', 'status' => 'failed'],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(CheckoutFailed::class, $event);
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertNull($event->orderId);
+        $this->assertSame('failed', $event->status);
+    }
+
+    public function test_it_creates_checkout_canceled_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_cc',
+            resource: 'webhook_event',
+            eventName: 'checkout.canceled',
+            entityType: 'checkout',
+            entityId: 'checkout_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456'],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(CheckoutCanceled::class, $event);
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('canceled', $event->status);
+    }
+
+    public function test_it_creates_checkout_expired_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_ce',
+            resource: 'webhook_event',
+            eventName: 'checkout.expired',
+            entityType: 'checkout',
+            entityId: 'checkout_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(CheckoutExpired::class, $event);
+        $this->assertSame('checkout_123', $event->checkoutId);
+        $this->assertNull($event->customerId);
+        $this->assertSame('expired', $event->status);
+    }
+
+    public function test_it_creates_subscription_cancellation_grace_period_completed_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_gpc',
+            resource: 'webhook_event',
+            eventName: 'subscription.cancellation_grace_period_completed',
+            entityType: 'subscription',
+            entityId: 'sub_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: [
+                'customerId' => 'cus_456',
+                'endedAt' => '2024-02-15T10:00:00Z',
+            ],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(SubscriptionCancellationGracePeriodCompleted::class, $event);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('sub_123', $event->subscriptionId);
+        $this->assertInstanceOf(DateTimeInterface::class, $event->endsAt);
+        $this->assertSame('2024-02-15T10:00:00+00:00', $event->endsAt->format('c'));
+    }
+
     public function test_it_creates_unsupported_webhook_received_for_unknown_events(): void
     {
         $webhook = new WebhookReceived(
@@ -746,11 +868,16 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertContains('subscription.resumed', $supported);
         $this->assertContains('subscription.canceled_immediately', $supported);
         $this->assertContains('subscription.canceled_with_grace_period', $supported);
+        $this->assertContains('subscription.cancellation_grace_period_completed', $supported);
         $this->assertContains('order.paid', $supported);
         $this->assertContains('order.canceled', $supported);
         $this->assertContains('order.chargeback_received', $supported);
         $this->assertContains('order.chargeback_reversed', $supported);
         $this->assertContains('payment.failed', $supported);
+        $this->assertContains('checkout.paid', $supported);
+        $this->assertContains('checkout.failed', $supported);
+        $this->assertContains('checkout.canceled', $supported);
+        $this->assertContains('checkout.expired', $supported);
         $this->assertContains('refund.completed', $supported);
         $this->assertContains('refund.failed', $supported);
         $this->assertContains('refund.canceled', $supported);
@@ -766,6 +893,11 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertTrue($this->factory->isSupported('order.chargeback_received'));
         $this->assertTrue($this->factory->isSupported('order.chargeback_reversed'));
         $this->assertTrue($this->factory->isSupported('payment.failed'));
+        $this->assertTrue($this->factory->isSupported('checkout.paid'));
+        $this->assertTrue($this->factory->isSupported('checkout.failed'));
+        $this->assertTrue($this->factory->isSupported('checkout.canceled'));
+        $this->assertTrue($this->factory->isSupported('checkout.expired'));
+        $this->assertTrue($this->factory->isSupported('subscription.cancellation_grace_period_completed'));
         $this->assertTrue($this->factory->isSupported('refund.completed'));
         $this->assertTrue($this->factory->isSupported('refund.failed'));
         $this->assertTrue($this->factory->isSupported('refund.canceled'));

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -16,6 +16,7 @@ use Vatly\Fluent\Actions\GetSubscription;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Events\CheckoutPaid;
 use Vatly\Fluent\Events\PaymentFailed;
 use Vatly\Fluent\Events\SubscriptionStarted;
 use Vatly\Fluent\Events\UnsupportedWebhookReceived;
@@ -222,6 +223,63 @@ class WebhookProcessorTest extends TestCase
                     && $event->currency === 'EUR'
                     && $event->paymentMethod === 'sepa_direct_debit'
                     && $event->taxSummary->items[0]->amount === 850;
+            });
+
+        $this->processor->handle($payload, $signature);
+    }
+
+    public function test_it_processes_a_checkout_paid_webhook_end_to_end(): void
+    {
+        // Checkout events route straight from the payload — no enrichment GET —
+        // so no GetCheckout/GetOrder call is expected here.
+        $payload = $this->makePayload(
+            id: 'webhook_event_cp',
+            eventName: 'checkout.paid',
+            entityType: 'checkout',
+            entityId: 'checkout_123',
+            object: [
+                'customerId' => 'cus_456',
+                'orderId' => 'ord_789',
+                'status' => 'paid',
+                'metadata' => ['cart_id' => 'cart_1'],
+            ],
+        );
+
+        $signature = $this->makeSignatureHeader($payload, $this->secret);
+
+        $this->getOrder->shouldNotReceive('execute');
+
+        $this->repository
+            ->shouldReceive('record')
+            ->once()
+            ->withArgs(function (
+                string $id,
+                string $resource,
+                string $eventName,
+                string $entityType,
+                string $entityId,
+                bool $testmode,
+                \DateTimeInterface $createdAt,
+                array $object,
+                ?string $vatlyCustomerId,
+            ) {
+                return $id === 'webhook_event_cp'
+                    && $eventName === 'checkout.paid'
+                    && $entityType === 'checkout'
+                    && $entityId === 'checkout_123'
+                    && $vatlyCustomerId === 'cus_456';
+            });
+
+        $this->dispatcher
+            ->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function (object $event) {
+                return $event instanceof CheckoutPaid
+                    && $event->checkoutId === 'checkout_123'
+                    && $event->customerId === 'cus_456'
+                    && $event->orderId === 'ord_789'
+                    && $event->status === 'paid'
+                    && $event->metadata === ['cart_id' => 'cart_1'];
             });
 
         $this->processor->handle($payload, $signature);


### PR DESCRIPTION
Closes #54.

Implements all 5 events that were still missing from the #54 coverage matrix (the other 12 were already shipped through alpha.7). Kept as a single PR per request.

## Events added (under `Vatly\Fluent\Events\`)

| Event name | Class | Reaction |
| --- | --- | --- |
| `checkout.paid` | `CheckoutPaid` | dispatched-only |
| `checkout.failed` | `CheckoutFailed` | dispatched-only |
| `checkout.canceled` | `CheckoutCanceled` | dispatched-only |
| `checkout.expired` | `CheckoutExpired` | dispatched-only |
| `subscription.cancellation_grace_period_completed` | `SubscriptionCancellationGracePeriodCompleted` | dispatched-only |

All are routed by `WebhookEventFactory::createFromWebhook()` and reported by `getSupportedEvents()` / `isSupported()`. With this, all 17 documented webhook events are covered as typed events (`webhook.setup` stays out of scope — it's a verification ping acknowledged with a 2xx).

## Design notes

- **No enrichment for checkout events.** The `checkout.*` deliveries carry the full `Checkout` resource (status, `customerId`, `orderId`, `metadata`) with no sparse money/tax fields, so — unlike `order.paid`/`subscription.*` — there's nothing to fetch. They're built straight from the payload, matching the `order.canceled` / chargeback precedent. This means **no `WebhookEventFactory` / `Wiring` signature change** — fully back-compatible.
- **`customerId` is nullable** on checkout events: an anonymous checkout only gets a customer attributed once payment completes (honest nullable rather than a synthetic empty string).
- **All dispatched-only (no built-in reaction).** For grace-period-completed, the cancellation already stamped `endsAt` via `CancelSubscriptionOnCanceled` and `DerivesSubscriptionState` flips ended-ness once the clock passes, so a built-in write would be redundant. Whether to additionally persist a driver-specific `fully_ended` status is left to the consumer (Vatly has no such status to mirror) — exactly the design question the issue flagged.
- New `Concerns\NormalizesWebhookMetadata` trait shared by the checkout events.

## Tests

- `tests/Events/CheckoutEventsTest.php` — per-event class coverage (incl. nullable/default-status paths and stdClass metadata normalization)
- `tests/Events/SubscriptionCancellationGracePeriodCompletedTest.php` — incl. `endedAt` → `createdAt` fallback
- `WebhookEventFactoryTest` — a factory branch per new event + supported-events assertions
- `WebhookProcessorTest` — end-to-end `checkout.paid` route through `WebhookProcessor`

Full suite: 273 tests / 835 assertions pass. PHPStan clean.