### PR TITLE
feat(subscriptions): trial-period helpers on SubscriptionBuilder (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,15 @@ $checkout = $vatly
     ->toPlan('plan_premium')
     ->create();
 
+// Subscribe with a free trial. withTrialDays() is the whole-day form;
+// withTrialEndsAt() takes a DateTimeInterface and rounds up to whole days
+// (Vatly's trial input is day-granular) so the trial never ends early.
+$checkout = $vatly
+    ->subscriptionBuilder(new CustomerProfile(vatlyId: $user->vatly_id))
+    ->toPlan('plan_premium')
+    ->withTrialDays(14)
+    ->create();
+
 // Operate on a stored Subscription / Order
 $vatly->subscription($localSubscription)->cancel();
 $vatly->order($localOrder)->invoiceUrl();

--- a/src/Builders/SubscriptionBuilder.php
+++ b/src/Builders/SubscriptionBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Builders;
 
+use DateTimeInterface;
+use InvalidArgumentException;
 use Vatly\API\Resources\Checkout;
 use Vatly\Fluent\Builders\Concerns\ManagesTestmode;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
@@ -20,6 +22,8 @@ class SubscriptionBuilder
     protected string $redirectUrlSuccess = '';
 
     protected string $redirectUrlCanceled = '';
+
+    protected ?int $trialDays = null;
 
     public function __construct(
         /** @readonly */
@@ -62,6 +66,51 @@ class SubscriptionBuilder
     }
 
     /**
+     * Start the subscription with a free trial of the given whole-day length.
+     *
+     * Vatly bills the first cycle after the trial elapses. The trial window is
+     * measured in whole days from checkout creation, matching the API's
+     * per-product `trialDays` input.
+     *
+     * @throws InvalidArgumentException When $days is not a positive integer.
+     */
+    public function withTrialDays(int $days): static
+    {
+        if ($days < 1) {
+            throw new InvalidArgumentException(
+                "Trial length must be at least 1 day, got {$days}.",
+            );
+        }
+
+        $this->trialDays = $days;
+
+        return $this;
+    }
+
+    /**
+     * Start the subscription with a trial that ends at the given moment.
+     *
+     * Convenience over {@see self::withTrialDays()} for callers that think in
+     * end-dates (e.g. "trial until the 1st of next month"). Because Vatly's
+     * trial input is whole-day granular, the remaining time is rounded *up* to
+     * the next whole day so the trial never ends earlier than requested.
+     *
+     * @throws InvalidArgumentException When $endsAt is not in the future.
+     */
+    public function withTrialEndsAt(DateTimeInterface $endsAt): static
+    {
+        $secondsUntil = $endsAt->getTimestamp() - (new \DateTimeImmutable())->getTimestamp();
+
+        if ($secondsUntil <= 0) {
+            throw new InvalidArgumentException(
+                'Trial end date must be in the future.',
+            );
+        }
+
+        return $this->withTrialDays((int) ceil($secondsUntil / 86400));
+    }
+
+    /**
      * Create the subscription checkout session.
      *
      * @param array<string, mixed> $checkoutOptions
@@ -86,10 +135,18 @@ class SubscriptionBuilder
      */
     public function getSubscriptionPayload(): array
     {
-        return [
+        $payload = [
             'quantity' => $this->quantity,
             'id' => $this->planId,
         ];
+
+        // Only include the trial when one was set, so a plain subscription
+        // payload stays minimal (and the API applies any plan-level default).
+        if ($this->trialDays !== null) {
+            $payload['trialDays'] = $this->trialDays;
+        }
+
+        return $payload;
     }
 
     /**

--- a/tests/Builders/SubscriptionBuilderTest.php
+++ b/tests/Builders/SubscriptionBuilderTest.php
@@ -102,6 +102,49 @@ class SubscriptionBuilderTest extends TestCase
         $this->assertSame(1, $payload['quantity']);
     }
 
+    public function test_with_trial_days_adds_trial_days_to_the_payload(): void
+    {
+        $result = $this->builder->toPlan('plan_pro')->withTrialDays(14);
+
+        $payload = $this->builder->getSubscriptionPayload();
+
+        $this->assertSame($this->builder, $result);
+        $this->assertSame(14, $payload['trialDays']);
+        $this->assertSame('plan_pro', $payload['id']);
+    }
+
+    public function test_trial_days_is_absent_from_payload_when_not_set(): void
+    {
+        $this->builder->toPlan('plan_pro');
+
+        $this->assertArrayNotHasKey('trialDays', $this->builder->getSubscriptionPayload());
+    }
+
+    public function test_with_trial_days_rejects_non_positive_values(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->withTrialDays(0);
+    }
+
+    public function test_with_trial_ends_at_converts_to_whole_days_rounding_up(): void
+    {
+        // 13 days + 1 hour from now rounds up to a 14-day trial so it never
+        // ends earlier than requested.
+        $endsAt = (new \DateTimeImmutable())->modify('+13 days +1 hour');
+
+        $this->builder->toPlan('plan_pro')->withTrialEndsAt($endsAt);
+
+        $this->assertSame(14, $this->builder->getSubscriptionPayload()['trialDays']);
+    }
+
+    public function test_with_trial_ends_at_rejects_a_past_date(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->withTrialEndsAt((new \DateTimeImmutable())->modify('-1 day'));
+    }
+
     public function test_get_checkout_builder_returns_the_checkout_builder_instance(): void
     {
         $checkoutBuilder = $this->builder->getCheckoutBuilder();


### PR DESCRIPTION
Closes #66.

## What

Adds trial-period support to `SubscriptionBuilder`:

```php
$user->subscribe()->toPlan($planId)->withTrialDays(14)->create();
$user->subscribe()->toPlan($planId)->withTrialEndsAt(new DateTimeImmutable('+30 days'))->create();
```

- `withTrialDays(int $days): static` — sets the per-product `trialDays` field.
- `withTrialEndsAt(DateTimeInterface $endsAt): static` — convenience for end-date thinkers; rounds the remaining time **up** to whole days so the trial never ends earlier than requested.
- `trialDays` is only added to the payload when set, so a plain subscription stays minimal and any plan-level trial default still applies.
- Both reject non-positive / past inputs with `InvalidArgumentException`.

## Upstream — not blocked

The issue flagged a possible upstream dependency. I verified the Vatly API already accepts a per-product trial on checkout create: `CreateCheckoutRequest` validates `products.*.trialDays` (integer) and the checkout controller computes `trialUntil = now + trialDays`. The builder threads `trialDays` into the subscription item, which the existing `CheckoutBuilder` → `CreateCheckout` path posts through unchanged — no api-php or API change needed.

vatly-api-php#35 tracks documenting/typing this pre-fill; I've commented there with the end-to-end confirmation. A native `trialEndsAt` *timestamp* input (vs. whole days) would be a minor future upstream enhancement, but is not required — `withTrialEndsAt()` converts client-side.

## Tests
`withTrialDays` payload + validation, `withTrialEndsAt` round-up + past-date rejection, and absence-when-unset. 282 tests green, PHPStan clean.