### PR TITLE
docs: webhook-flow matrix + host-owns-tables recipe + circular-construction patterns (#44, #45, #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A driver is a thin glue package (e.g. `vatly-laravel`) that supplies fluent with
 
 ### Webhook pipeline at a glance
 
-For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in reaction that calls back into your repos. A driver author only needs to implement the repo methods — the wiring is fixed:
+For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in reaction that calls back into your repos. A driver author only needs to implement the repo methods — the wiring is fixed. For the full event → reaction → repo-method matrix **including the fields each `Store*Data` / event carries**, see [docs/webhook-flow.md](docs/webhook-flow.md).
 
 | Vatly event              | Dispatched event class                                            | Built-in reaction              | Repo method(s) called                                |
 |--------------------------|-------------------------------------------------------------------|--------------------------------|------------------------------------------------------|
@@ -309,6 +309,8 @@ public function store(StoreOrderData $data): ?OrderInterface
 
 Same shape for `SubscriptionRepositoryInterface::store`. Built-in reactions tolerate null returns.
 
+**Full walkthrough:** [docs/recipes/host-owns-its-tables.md](docs/recipes/host-owns-its-tables.md) — covers the adapter wrapper, confirming (not duplicating) rows in `store()`, `findByVatlyId` as the idempotency hinge for safe re-deliveries, and discriminating renewal-vs-initial payments inside one `store()`.
+
 </details>
 
 ### 5. Implement the three repository contracts
@@ -344,6 +346,19 @@ public function store(StoreSubscriptionData $data): SubscriptionInterface
 > Each entity-side repo is also exposed as a Reader / Writer pair (`SubscriptionReader` + `SubscriptionWriter`, etc.). The combined interface extends both. Typehint the narrowest role you actually need.
 
 > **If your repo needs to call back into the SDK** — e.g. `GetOrder` to read fresh metadata from a partial webhook payload — don't inject `Vatly` directly. `Vatly` is being constructed *with* your repo, so a direct dependency is circular. Instead, inject a lazy resolver (your host's container, a singleton accessor, or a closure that returns `Vatly`) and resolve at call time.
+>
+> ```php
+> // ✗ Circular — $vatly doesn't exist yet at Wiring-construction time:
+> new Vatly(new Wiring(orders: new MyOrderRepository($vatly), …));
+>
+> // ✓ Closure resolver — the repo only touches Vatly at call time:
+> new Vatly(new Wiring(orders: new MyOrderRepository(fn () => $container->get(Vatly::class)), …));
+>
+> // ✓ Singleton accessor — same idea via a static entry point:
+> new Vatly(new Wiring(orders: new MyOrderRepository(Plugin::vatly(...)), …));
+> ```
+>
+> Inside the repo, resolve lazily: `($this->vatly)()->getOrder()->execute($vatlyId)` for the closure form, or `Plugin::vatly()->getOrder()->execute($vatlyId)` for the accessor form.
 
 ### 6. Implement `EventDispatcherInterface`
 

--- a/docs/recipes/host-owns-its-tables.md
+++ b/docs/recipes/host-owns-its-tables.md
@@ -21,7 +21,6 @@ final class FluentCartOrder implements OrderInterface
     public function getStatus(): string         { return $this->txn->status; }
     public function getInvoiceNumber(): ?string { return $this->txn->invoice_no; }
     public function getTotal(): int             { return (int) $this->txn->total; }
-    public function getSubtotal(): ?int         { return $this->txn->subtotal !== null ? (int) $this->txn->subtotal : null; }
     public function getCurrency(): string       { return $this->txn->currency; }
     public function getPaymentMethod(): ?string { return $this->txn->payment_method; }
     public function isPaid(): bool              { return $this->txn->status === 'paid'; }

--- a/docs/recipes/host-owns-its-tables.md
+++ b/docs/recipes/host-owns-its-tables.md
@@ -1,0 +1,134 @@
+# Recipe: adapting fluent contracts to a host that already owns its tables
+
+The README's driver guide implicitly assumes you're modeling subscriptions/orders from scratch in your own schema. The other common case is the inverse: you're bolting onto an ecosystem plugin — **FluentCart, PMPro, MemberPress, Easy Digital Downloads, WooCommerce**, a Cashier-style Spark app — that **already owns** its `subscriptions`, `orders`, and `customers` tables. You don't want a parallel set of tables; you want fluent's contracts to read and write the host's existing ones.
+
+The v0.8 contract shape makes this clean (v0.5's `Billable` forced a host-model shape that was wrong for non-Laravel drivers). This recipe is the sanctioned pattern.
+
+> The README has a condensed version of steps 1–2 under [*"What if my host already has Order / Subscription tables?"*](../../README.md#5-implement-the-three-repository-contracts). This page is the full walkthrough, including idempotency and renewal-vs-initial routing.
+
+## 1. Adapter wrappers, not native implementations
+
+Don't make the host's own Order/Subscription model implement `OrderInterface` — you usually can't edit it, and you don't want fluent's surface bleeding into the host's model. Instead wrap it in a thin adapter that holds the host record and exposes only the fluent surface:
+
+```php
+use Vatly\Fluent\Contracts\OrderInterface;
+
+final class FluentCartOrder implements OrderInterface
+{
+    public function __construct(private OrderTransaction $txn) {}
+
+    public function getVatlyId(): string        { return $this->txn->vatly_id; }
+    public function getStatus(): string         { return $this->txn->status; }
+    public function getInvoiceNumber(): ?string { return $this->txn->invoice_no; }
+    public function getTotal(): int             { return (int) $this->txn->total; }
+    public function getSubtotal(): ?int         { return $this->txn->subtotal !== null ? (int) $this->txn->subtotal : null; }
+    public function getCurrency(): string       { return $this->txn->currency; }
+    public function getPaymentMethod(): ?string { return $this->txn->payment_method; }
+    public function isPaid(): bool              { return $this->txn->status === 'paid'; }
+
+    /** Escape hatch for your own code that needs the underlying host record. */
+    public function transaction(): OrderTransaction { return $this->txn; }
+}
+```
+
+## 2. Route inside `store()` instead of literally storing
+
+When the host already created the row at checkout time (before the webhook arrives), `OrderWriter::store(StoreOrderData)` is the place to **confirm** the existing row rather than `INSERT` a new one. Look up the host row by some signal the checkout stamped — most commonly a host id round-tripped through the Vatly order's `metadata` — update its status, write the Vatly id back, and return the adapter:
+
+```php
+public function store(StoreOrderData $data): ?OrderInterface
+{
+    $txnId = $data->metadata['fluentcart_transaction_id'] ?? null;
+    if ($txnId === null) {
+        return null; // anonymous / audit-only delivery — nothing local to attach to
+    }
+
+    $txn = OrderTransaction::find($txnId);
+    if ($txn === null) {
+        return null; // host row gone — tolerate rather than throw
+    }
+
+    $txn->vatly_id = $data->vatlyId; // <-- the idempotency hinge (see step 3)
+    $txn->status   = $data->status;
+    $txn->save();
+
+    return new FluentCartOrder($txn);
+}
+```
+
+Returning `null` is a first-class outcome: the built-in reactions tolerate it (a `SubscriptionWriter::store` returning null simply skips the follow-up `LocalSubscriptionCreated` dispatch).
+
+## 3. `findByVatlyId` as the idempotency hinge
+
+Every entity reaction calls `findByVatlyId()` first: a null return routes to `store()`, a hit routes to `update()`. So the moment `store()` writes the Vatly id onto the host row (step 2), **every subsequent re-delivery of that webhook hits `update()` instead of `store()`** — which is exactly what you want, because Vatly retries deliveries and you must be idempotent.
+
+```php
+public function findByVatlyId(string $vatlyId): ?OrderInterface
+{
+    $txn = OrderTransaction::where('vatly_id', $vatlyId)->first();
+
+    return $txn !== null ? new FluentCartOrder($txn) : null;
+}
+
+public function update(OrderInterface $order, UpdateOrderData $data): OrderInterface
+{
+    $txn = $order->transaction();           // adapter escape hatch from step 1
+    if ($data->status !== null)  { $txn->status = $data->status; }
+    if ($data->invoiceNumber !== null) { $txn->invoice_no = $data->invoiceNumber; }
+    $txn->save();
+
+    return $order;
+}
+```
+
+The result: a `store()` that *confirms* a pre-existing row on first delivery, and an `update()` that *reconciles* it on every re-delivery — with no duplicate rows and no host-side unique-constraint violations.
+
+## 4. Discriminating renewal vs. initial payment inside `store()`
+
+Some ecosystems split "first payment" and "renewal payment" into different service calls. FluentCart is the canonical example: `Confirmations::confirmPaymentSuccessByCharge` for the initial order vs. `SubscriptionRenewal::recordRenewalPayment` for renewals. A single `order.paid` webhook flows into your one `OrderWriter::store` — so you have to discriminate.
+
+Use the same metadata round-trip plus `$data->hostCustomerId` (pre-resolved by fluent via your `CustomerBindingRepository`):
+
+```php
+public function store(StoreOrderData $data): ?OrderInterface
+{
+    // Initial checkout stamped the host transaction id onto the Vatly order's
+    // metadata; renewals (created server-side by Vatly) carry no such id.
+    $txnId = $data->metadata['fluentcart_transaction_id'] ?? null;
+
+    if ($txnId !== null && ($txn = OrderTransaction::find($txnId)) !== null) {
+        // INITIAL payment — confirm the row the customer's checkout created.
+        Confirmations::confirmPaymentSuccessByCharge($txn, $data->vatlyId);
+
+        return new FluentCartOrder($txn->refresh());
+    }
+
+    // RENEWAL — no initial host row. Resolve the owning customer (via the
+    // binding fluent already mapped) and let the host mint a renewal order.
+    if ($data->hostCustomerId === null) {
+        return null; // unattributed renewal — nothing to route to
+    }
+
+    $renewal = SubscriptionRenewal::recordRenewalPayment(
+        customerId: $data->hostCustomerId,
+        vatlyOrderId: $data->vatlyId,
+        total: $data->total,
+        currency: $data->currency,
+    );
+
+    return new FluentCartOrder($renewal);
+}
+```
+
+The discriminator is "did *this* charge originate from a host-side checkout?" — answered by the presence of the metadata id. `hostCustomerId` then tells you *who* the renewal belongs to without an API re-fetch.
+
+## Summary
+
+| Step | Contract surface | Pattern |
+| --- | --- | --- |
+| Wrap | `OrderInterface` / `SubscriptionInterface` | thin adapter over the host model; never make the host model implement the contract |
+| Confirm | `…Writer::store` | look up + confirm the existing host row; write the Vatly id back; return `null` when unroutable |
+| Idempotency | `…Reader::findByVatlyId` | once the Vatly id is on the host row, re-deliveries route to `update()` |
+| Route | `…Writer::store` | discriminate initial vs. renewal via metadata id + `hostCustomerId` |
+
+A concrete end-to-end implementation lives in the FluentCart driver (`vatly-fluentcart-wp`).

--- a/docs/webhook-flow.md
+++ b/docs/webhook-flow.md
@@ -10,7 +10,8 @@ Some events are built straight from the webhook payload; others are **enriched**
 
 - **`order.paid`, `payment.failed`, `refund.*`** — enriched via `GetOrder` / `GetRefund`. Tax data is compliance-critical, so these **rethrow** on enrichment failure (Vatly retries the delivery) rather than persist a degraded row.
 - **`subscription.started`, `subscription.billing_updated`** — enriched via `GetSubscription` for the mandate summary, but **fall back** to the webhook payload (which embeds the mandate) on failure — enrichment here is non-lossy.
-- **`order.canceled`, `order.chargeback_*`, `checkout.*`, `subscription.cancellation_grace_period_completed`** — built straight from the payload; no GET needed.
+- **`order.chargeback_*`** — enriched via `GetChargeback` when that action is wired (customer id, dispute status, tax breakdown), but **fall back** to the sparse payload otherwise — best-effort.
+- **`order.canceled`, `checkout.*`, `subscription.cancellation_grace_period_completed`** — built straight from the payload; no GET needed.
 
 Refund events are only enriched (and thus only reported as supported) when a `GetRefund` action is wired — otherwise they degrade to `UnsupportedWebhookReceived`.
 
@@ -21,15 +22,13 @@ Refund events are only enriched (and thus only reported as supported) when a `Ge
 | `order.paid` | `OrderPaid` | `StoreOrderOnPaid` | `OrderWriter::store(StoreOrderData)` if `findByVatlyId` is null, else `OrderWriter::update(…, UpdateOrderData)` | `hostCustomerId` (pre-resolved via binding repo), `customerId`, `total`, `subtotal`, `currency`, `invoiceNumber`, `paymentMethod`, `taxSummary`, `metadata` |
 | `order.canceled` | `OrderCanceled` | `CancelOrderOnCanceled` | `OrderWriter::update(…, UpdateOrderData{status})` | `status` (== `canceled`) — find-or-skip, never creates |
 | `refund.completed` / `refund.failed` / `refund.canceled` | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | `SyncRefundOnStatusChange` *(opt-in: needs `RefundRepositoryInterface`)* | `RefundWriter::store(StoreRefundData)` if new, else `RefundWriter::update(…, UpdateRefundData)` | `refundId`, `originalOrderId`, `customerId`, `hostCustomerId`, `status`, `total`, `subtotal`, `currency`, `taxSummary` |
-| `refund.completed` / `refund.canceled` | (same) | `SyncOrderOnRefundChange` *(opt-in: needs order + refund repos)* | `RefundReader::sumSubtotalsForOrder`, then `OrderWriter::update(…, UpdateOrderData{status})` | `originalOrderId`; reads `OrderInterface::getSubtotal()`; writes `LocalOrderStatus::{REFUNDED, PARTIALLY_REFUNDED, PAID}` |
 | `subscription.started` | `SubscriptionStarted` | `SyncSubscriptionOnStarted` | `SubscriptionWriter::store(StoreSubscriptionData)` then dispatches `LocalSubscriptionCreated` (skipped if store returns null) | `hostCustomerId`, `customerId`, `planId`, `name`, `quantity`, `type`, `mandate` |
 | `subscription.billing_updated` | `SubscriptionBillingUpdated` | `SyncSubscriptionOnBillingUpdated` | `SubscriptionWriter::update(…, UpdateSubscriptionData{mandate})` | `mandate` (card last-4 / masked IBAN) — find-or-skip |
 | `subscription.resumed` | `SubscriptionResumed` | `ResumeSubscriptionOnResumed` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt: null})` | clears `endsAt` — find-or-skip |
 | `subscription.canceled_immediately` | `SubscriptionCanceledImmediately` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (== now) |
 | `subscription.canceled_with_grace_period` | `SubscriptionCanceledWithGracePeriod` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (future grace end) |
 | `subscription.cancellation_grace_period_completed` | `SubscriptionCancellationGracePeriodCompleted` | `EndSubscriptionOnGracePeriodCompleted` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (actual end; self-heals a missed/out-of-order cancel webhook) |
-| `order.chargeback_received` | `OrderChargebackReceived` | — *(dispatched only)* | none — driver-handled | `orderId`, `chargebackId`, `originalOrderId`, `reason` |
-| `order.chargeback_reversed` | `OrderChargebackReversed` | — *(dispatched only)* | none — driver-handled | `orderId`, `chargebackId`, `originalOrderId`, `reason` |
+| `order.chargeback_received` / `order.chargeback_reversed` | `OrderChargebackReceived` / `OrderChargebackReversed` | `SyncChargebackOnStatusChange` *(opt-in: needs `ChargebackRepositoryInterface`)* | `ChargebackWriter::store(StoreChargebackData)` if new, else `ChargebackWriter::update(…, UpdateChargebackData)` | `chargebackId`, `originalOrderId`, `customerId`, `hostCustomerId`, `status`, `total`, `subtotal`, `currency`, `taxSummary`, `reason` |
 | `checkout.paid` / `checkout.failed` / `checkout.canceled` / `checkout.expired` | `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` | — *(dispatched only)* | none — driver-handled | `checkoutId`, `customerId` (nullable for anonymous), `orderId`, `status`, `metadata` |
 | *(any unmapped event)* | `UnsupportedWebhookReceived` | — | none | raw `WebhookReceived` envelope |
 
@@ -38,5 +37,6 @@ Refund events are only enriched (and thus only reported as supported) when a `Ge
 - **"store if new, else update"** — every entity reaction first calls `findByVatlyId()`. A null return routes to `store()`; a hit routes to `update()`. This is the idempotency hinge: once `store()` writes the Vatly id back, webhook re-deliveries safely hit `update()`. See the [host-owns-its-tables recipe](recipes/host-owns-its-tables.md).
 - **"find-or-skip"** — the reaction only `update()`s an existing local record and never creates one (`order.canceled`, `subscription.billing_updated`, `subscription.resumed`).
 - **`hostCustomerId`** — resolved from your `CustomerBindingRepository` *before* the reaction calls your writer, so `store()` can fill the owner column directly. It's `null` for unattributed / anonymous-checkout rows; accept that.
-- **store may return `null`** — `OrderWriter`, `SubscriptionWriter`, and `RefundWriter` `store()` may return `null` when the driver can't route the data. Built-in reactions tolerate it.
+- **store may return `null`** — `OrderWriter`, `SubscriptionWriter`, `RefundWriter`, and `ChargebackWriter` `store()` may return `null` when the driver can't route the data. Built-in reactions tolerate it.
 - **opt-in reactions** register only when their repository is wired into `Wiring`. Without it, the typed events still dispatch for you to handle yourself.
+- **order reversal progress is not a webhook reaction.** Whether — and how much of — an order was returned to the customer (by refund *or* chargeback) is read from the live API Order via `OrderHandle::reversedSubtotal()` / `refundableSubtotal()` / `isReversed()` / `isPartiallyReversed()` / `isFullyReversed()`. The order's own `status` stays terminal `paid`; fluent never synthesizes a local refunded/chargeback status.

--- a/docs/webhook-flow.md
+++ b/docs/webhook-flow.md
@@ -1,0 +1,42 @@
+# Webhook flow: event → reaction → repo method → fields
+
+A driver author shouldn't have to read four directories (`src/Events/`, `src/Webhooks/Reactions/`, `WebhookEventFactory`, `src/Contracts/`) to answer *"if I implement `OrderWriter::store`, which webhooks flow into it and with what data?"* This page is that single reference.
+
+The [README's "Webhook pipeline at a glance"](../README.md#webhook-pipeline-at-a-glance) table is the quick version; this one adds the **fields drivers care about** column so you know exactly what each `Store*Data` / event carries.
+
+## Enrichment
+
+Some events are built straight from the webhook payload; others are **enriched** with a follow-up API GET before dispatch, because the raw webhook is sparse (gross total only — no subtotal/tax breakdown). Enrichment matters because it determines whether a transient API error can block the delivery:
+
+- **`order.paid`, `payment.failed`, `refund.*`** — enriched via `GetOrder` / `GetRefund`. Tax data is compliance-critical, so these **rethrow** on enrichment failure (Vatly retries the delivery) rather than persist a degraded row.
+- **`subscription.started`, `subscription.billing_updated`** — enriched via `GetSubscription` for the mandate summary, but **fall back** to the webhook payload (which embeds the mandate) on failure — enrichment here is non-lossy.
+- **`order.canceled`, `order.chargeback_*`, `checkout.*`, `subscription.cancellation_grace_period_completed`** — built straight from the payload; no GET needed.
+
+Refund events are only enriched (and thus only reported as supported) when a `GetRefund` action is wired — otherwise they degrade to `UnsupportedWebhookReceived`.
+
+## Full matrix
+
+| Vatly event | Typed event | Built-in reaction | Repo method called | Fields drivers care about |
+| --- | --- | --- | --- | --- |
+| `order.paid` | `OrderPaid` | `StoreOrderOnPaid` | `OrderWriter::store(StoreOrderData)` if `findByVatlyId` is null, else `OrderWriter::update(…, UpdateOrderData)` | `hostCustomerId` (pre-resolved via binding repo), `customerId`, `total`, `subtotal`, `currency`, `invoiceNumber`, `paymentMethod`, `taxSummary`, `metadata` |
+| `order.canceled` | `OrderCanceled` | `CancelOrderOnCanceled` | `OrderWriter::update(…, UpdateOrderData{status})` | `status` (== `canceled`) — find-or-skip, never creates |
+| `refund.completed` / `refund.failed` / `refund.canceled` | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | `SyncRefundOnStatusChange` *(opt-in: needs `RefundRepositoryInterface`)* | `RefundWriter::store(StoreRefundData)` if new, else `RefundWriter::update(…, UpdateRefundData)` | `refundId`, `originalOrderId`, `customerId`, `hostCustomerId`, `status`, `total`, `subtotal`, `currency`, `taxSummary` |
+| `refund.completed` / `refund.canceled` | (same) | `SyncOrderOnRefundChange` *(opt-in: needs order + refund repos)* | `RefundReader::sumSubtotalsForOrder`, then `OrderWriter::update(…, UpdateOrderData{status})` | `originalOrderId`; reads `OrderInterface::getSubtotal()`; writes `LocalOrderStatus::{REFUNDED, PARTIALLY_REFUNDED, PAID}` |
+| `subscription.started` | `SubscriptionStarted` | `SyncSubscriptionOnStarted` | `SubscriptionWriter::store(StoreSubscriptionData)` then dispatches `LocalSubscriptionCreated` (skipped if store returns null) | `hostCustomerId`, `customerId`, `planId`, `name`, `quantity`, `type`, `mandate` |
+| `subscription.billing_updated` | `SubscriptionBillingUpdated` | `SyncSubscriptionOnBillingUpdated` | `SubscriptionWriter::update(…, UpdateSubscriptionData{mandate})` | `mandate` (card last-4 / masked IBAN) — find-or-skip |
+| `subscription.resumed` | `SubscriptionResumed` | `ResumeSubscriptionOnResumed` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt: null})` | clears `endsAt` — find-or-skip |
+| `subscription.canceled_immediately` | `SubscriptionCanceledImmediately` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (== now) |
+| `subscription.canceled_with_grace_period` | `SubscriptionCanceledWithGracePeriod` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (future grace end) |
+| `subscription.cancellation_grace_period_completed` | `SubscriptionCancellationGracePeriodCompleted` | `EndSubscriptionOnGracePeriodCompleted` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (actual end; self-heals a missed/out-of-order cancel webhook) |
+| `order.chargeback_received` | `OrderChargebackReceived` | — *(dispatched only)* | none — driver-handled | `orderId`, `chargebackId`, `originalOrderId`, `reason` |
+| `order.chargeback_reversed` | `OrderChargebackReversed` | — *(dispatched only)* | none — driver-handled | `orderId`, `chargebackId`, `originalOrderId`, `reason` |
+| `checkout.paid` / `checkout.failed` / `checkout.canceled` / `checkout.expired` | `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` | — *(dispatched only)* | none — driver-handled | `checkoutId`, `customerId` (nullable for anonymous), `orderId`, `status`, `metadata` |
+| *(any unmapped event)* | `UnsupportedWebhookReceived` | — | none | raw `WebhookReceived` envelope |
+
+## Reading the matrix
+
+- **"store if new, else update"** — every entity reaction first calls `findByVatlyId()`. A null return routes to `store()`; a hit routes to `update()`. This is the idempotency hinge: once `store()` writes the Vatly id back, webhook re-deliveries safely hit `update()`. See the [host-owns-its-tables recipe](recipes/host-owns-its-tables.md).
+- **"find-or-skip"** — the reaction only `update()`s an existing local record and never creates one (`order.canceled`, `subscription.billing_updated`, `subscription.resumed`).
+- **`hostCustomerId`** — resolved from your `CustomerBindingRepository` *before* the reaction calls your writer, so `store()` can fill the owner column directly. It's `null` for unattributed / anonymous-checkout rows; accept that.
+- **store may return `null`** — `OrderWriter`, `SubscriptionWriter`, and `RefundWriter` `store()` may return `null` when the driver can't route the data. Built-in reactions tolerate it.
+- **opt-in reactions** register only when their repository is wired into `Wiring`. Without it, the typed events still dispatch for you to handle yourself.


### PR DESCRIPTION
Closes #44, closes #45, closes #46.

Three driver-guide doc gaps, bundled since they're all documentation.

## #44 — event → reaction → repo-method matrix
The README already had a "Webhook pipeline at a glance" table; what it lacked was the **fields drivers care about** column the issue asked for. Rather than widen the README table to 5 columns, added [docs/webhook-flow.md](docs/webhook-flow.md) — the full matrix plus an **enrichment** section explaining which events rethrow on API failure (compliance-critical tax data) vs. fall back to the payload. Linked from the README.

## #45 — recipe for a host that already owns its tables
The README had a condensed inline `<details>` snippet (adapter + route-in-store). [docs/recipes/host-owns-its-tables.md](docs/recipes/host-owns-its-tables.md) expands it into the full recipe the issue requested, including the two parts that were missing inline:
- **`findByVatlyId` as the idempotency hinge** — why writing the Vatly id back makes re-deliveries safe.
- **renewal-vs-initial routing** inside one `store()** — the FluentCart `confirmPaymentSuccessByCharge` vs `recordRenewalPayment` discrimination via metadata id + `hostCustomerId`.

## #46 — circular-construction warning
**Already partially shipped** — the callout exists in Step 5 of the driver guide. Verified it covers the core ask and **strengthened** it with side-by-side closure + singleton resolver code examples (the issue's optional extra). If you'd prefer, #46 could simply be closed as already-addressed; the example block is the only net-new content for it.

## Note on ordering
`docs/webhook-flow.md` and the recipe reference symbols introduced in #69 (`SyncOrderOnRefundChange`, `LocalOrderStatus`, `OrderInterface::getSubtotal()`) — see #72. They describe the intended merged state; merge #72 first (or together) so the cross-references resolve.

No code changed; tests/PHPStan unaffected.