### PR TITLE
feat(chargebacks): persistence pipeline + consumer read surface (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in
 |--------------------------|-------------------------------------------------------------------|--------------------------------|------------------------------------------------------|
 | `order.paid`             | `OrderPaid`                                                       | `StoreOrderOnPaid`             | `OrderWriter::store` (new) / `OrderWriter::update` (existing) |
 | `order.canceled`         | `OrderCanceled`                                                   | `CancelOrderOnCanceled`        | `OrderWriter::update` (mirrors `canceled` status)    |
-| `order.chargeback_received` | `OrderChargebackReceived`                                      | — (dispatched only)            | none — driver-handled                                |
-| `order.chargeback_reversed` | `OrderChargebackReversed`                                      | — (dispatched only)            | none — driver-handled                                |
+| `order.chargeback_received` | `OrderChargebackReceived`                                   | `SyncChargebackOnStatusChange` *(opt-in, persistence)* | `ChargebackWriter::store` (new) |
+| `order.chargeback_reversed` | `OrderChargebackReversed`                                   | `SyncChargebackOnStatusChange` *(opt-in, persistence)* | `ChargebackWriter::update` (existing) |
 | `refund.completed` / `refund.failed` / `refund.canceled` | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | `SyncRefundOnStatusChange` *(opt-in)* | `RefundWriter::store` (new) / `::update` (existing) |
 | `subscription.started`   | `SubscriptionStarted`                                             | `SyncSubscriptionOnStarted`    | `SubscriptionWriter::store` (new) / `::update` (existing) |
 | `subscription.billing_updated` | `SubscriptionBillingUpdated`                               | `SyncSubscriptionOnBillingUpdated` | `SubscriptionWriter::update` (refreshes mandate)    |
@@ -123,7 +123,7 @@ Read the refunds back idiomatically with `RefundReader::listForOrder` / `listFor
 
 The order's reversal progress is read live from the Vatly API rather than synthesized into a local status — the order's own `status` stays terminal `paid`. `OrderHandle` exposes `reversedSubtotal()` / `refundableSubtotal()` (integer cents) and `isReversed()` / `isPartiallyReversed()` / `isFullyReversed()`, fetched once and memoized per handle instance. Because the API's `reversedSubtotal` combines refunds **and** chargebacks, these helpers answer "did money come back, and how much" regardless of how it was reversed.
 
-**Chargebacks** ship no built-in reaction: Vatly's public order status doesn't change on a chargeback, so fluent doesn't synthesize one. Instead `OrderChargebackReceived` / `OrderChargebackReversed` are dispatched (with the affected order's ID as `orderId`) for your driver to react to — e.g. suspend access on receipt, reinstate on reversal.
+**Chargebacks** mirror refunds and are opt-in: supply a `ChargebackRepositoryInterface` via `Wiring(chargebacks: …)` and the built-in `SyncChargebackOnStatusChange` reaction persists `order.chargeback_*` webhooks store-or-update (storing on receipt, updating on reversal). It does **not** mutate the order's status — the order stays `paid`, and whether money came back (chargebacks included) is read via the `OrderHandle` reversal helpers above. Omit the repository and the typed `OrderChargebackReceived` / `OrderChargebackReversed` events are still dispatched for you to handle (e.g. suspend access on receipt, reinstate on reversal). When a `GetChargeback` action is wired the events are enriched (customer id, dispute status, tax breakdown) so the reversed VAT can be reconciled without a second API call; without it they fall back to the sparse webhook payload. Read chargebacks back via `ChargebackReader::listForOrder` / `listForCustomer` or `$vatly->order($localOrder)->chargebacks()`.
 
 **Checkout events** are dispatched only — no built-in reaction. The `checkout.*` deliveries carry the full Checkout resource (status, `customerId`, `orderId`, `metadata`) with no sparse money/tax fields, so they need no enriching API GET and are built straight from the payload. Use `CheckoutPaid` for an analytics/receipt handoff at the earliest "customer paid" moment — before `order.paid`'s tax-summary enrichment — and `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` for retry and cart-abandonment funnel hooks. `customerId` is nullable: an anonymous checkout only gets a customer attributed once payment completes.
 
@@ -322,6 +322,7 @@ Each entity-side contract has three methods. See [src/Contracts](src/Contracts) 
 - `SubscriptionRepositoryInterface` — `findByVatlyId`, `store`, `update`
 - `OrderRepositoryInterface` — `findByVatlyId`, `store`, `update`
 - `RefundRepositoryInterface` — `findByVatlyId`, `listForOrder`, `listForCustomer`, `store`, `update` (**optional** — only needed to persist `refund.*` webhooks)
+- `ChargebackRepositoryInterface` — `findByVatlyId`, `listForOrder`, `listForCustomer`, `store`, `update` (**optional** — only needed to persist `order.chargeback_*` webhooks)
 - `WebhookCallRepositoryInterface` — record received webhook calls (audit log)
 
 `StoreSubscriptionData` and `StoreOrderData` both carry an optional `hostCustomerId` resolved from the binding repo when fluent persists from a webhook reaction. Use it to fill your host-side owner column when it's set, and accept `null` for the anonymous-checkout flow.
@@ -565,6 +566,7 @@ In [src/Contracts](src/Contracts):
 - `SubscriptionRepositoryInterface` — subscription persistence (3 methods). Splits into `SubscriptionReader` (find) + `SubscriptionWriter` (store/update).
 - `OrderRepositoryInterface` — order persistence (3 methods). Splits into `OrderReader` (find) + `OrderWriter` (store/update).
 - `RefundRepositoryInterface` — refund persistence (optional). Splits into `RefundReader` (find + `listForOrder` / `listForCustomer`) + `RefundWriter` (store/update).
+- `ChargebackRepositoryInterface` — chargeback persistence (optional). Splits into `ChargebackReader` (find + `listForOrder` / `listForCustomer`) + `ChargebackWriter` (store/update).
 - `WebhookCallRepositoryInterface` — webhook audit log (write-only by nature)
 - `EventDispatcherInterface` — fire domain events
 - `ConfigurationInterface` — API key, URL, version, webhook secret, redirect defaults

--- a/src/Actions/GetChargeback.php
+++ b/src/Actions/GetChargeback.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Actions;
+
+use Vatly\API\Resources\Chargeback;
+
+class GetChargeback extends BaseAction
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function execute(string $chargebackId, array $parameters = []): Chargeback
+    {
+        $chargeback = $this->vatlyApiClient->chargebacks->get($chargebackId, $parameters);
+
+        assert($chargeback instanceof Chargeback);
+
+        return $chargeback;
+    }
+}

--- a/src/Contracts/ChargebackInterface.php
+++ b/src/Contracts/ChargebackInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Interface for chargeback entities.
+ *
+ * Mirrors {@see RefundInterface}: a thin read surface over the driver's own
+ * persisted chargeback row, populated from Vatly's `order.chargeback_*`
+ * webhooks. Where a refund is a merchant-initiated return, a chargeback is a
+ * bank-initiated dispute — higher impact, so consumers usually want it queryable
+ * for finance ops and reconciliation.
+ */
+interface ChargebackInterface
+{
+    /**
+     * Get the Vatly chargeback ID.
+     */
+    public function getVatlyId(): string;
+
+    /**
+     * Get the raw Vatly chargeback status (e.g. "pending", "won", "lost").
+     */
+    public function getStatus(): string;
+
+    /**
+     * Get the chargeback total, in integer cents.
+     */
+    public function getTotal(): int;
+
+    /**
+     * Get the currency.
+     */
+    public function getCurrency(): string;
+
+    /**
+     * Get the Vatly ID of the original order the chargeback was raised against.
+     */
+    public function getOriginalOrderId(): string;
+
+    /**
+     * Get the chargeback reason, when Vatly provided one.
+     */
+    public function getReason(): ?string;
+
+    /**
+     * Whether the chargeback has been reversed (resolved in the merchant's
+     * favour — funds returned to the merchant).
+     */
+    public function isReversed(): bool;
+}

--- a/src/Contracts/ChargebackReader.php
+++ b/src/Contracts/ChargebackReader.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Read-side of the chargeback repository contract.
+ *
+ * Pairs with {@see ChargebackWriter}.
+ */
+interface ChargebackReader
+{
+    /**
+     * Find a chargeback by its Vatly ID.
+     */
+    public function findByVatlyId(string $vatlyId): ?ChargebackInterface;
+
+    /**
+     * List every chargeback tracked locally for a Vatly customer.
+     *
+     * @return ChargebackInterface[]
+     */
+    public function listForCustomer(string $customerId): array;
+
+    /**
+     * List every chargeback tracked locally against a given original order.
+     *
+     * Drives {@see \Vatly\Fluent\OrderHandle::chargebacks()}.
+     *
+     * @return ChargebackInterface[]
+     */
+    public function listForOrder(string $vatlyOrderId): array;
+}

--- a/src/Contracts/ChargebackRepositoryInterface.php
+++ b/src/Contracts/ChargebackRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Full chargeback repository — both read and write sides.
+ *
+ * Supplying this to {@see \Vatly\Fluent\Wiring} is optional: when present the
+ * built-in {@see \Vatly\Fluent\Webhooks\Reactions\SyncChargebackOnStatusChange}
+ * reaction persists `order.chargeback_*` webhooks; when absent the typed
+ * chargeback events are still dispatched for drivers to handle themselves.
+ */
+interface ChargebackRepositoryInterface extends ChargebackReader, ChargebackWriter
+{
+    //
+}

--- a/src/Contracts/ChargebackWriter.php
+++ b/src/Contracts/ChargebackWriter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+use Vatly\Fluent\Data\StoreChargebackData;
+use Vatly\Fluent\Data\UpdateChargebackData;
+
+/**
+ * Write-side of the chargeback repository contract.
+ *
+ * Pairs with {@see ChargebackReader}.
+ */
+interface ChargebackWriter
+{
+    /**
+     * Store a new chargeback from Vatly.
+     *
+     * Returns `null` when the driver legitimately cannot route the store
+     * (e.g. it can't locate the original order locally). Built-in reactions
+     * tolerate null.
+     */
+    public function store(StoreChargebackData $data): ?ChargebackInterface;
+
+    /**
+     * Update an existing chargeback from Vatly (e.g. on reversal).
+     */
+    public function update(ChargebackInterface $chargeback, UpdateChargebackData $data): ChargebackInterface;
+}

--- a/src/Data/StoreChargebackData.php
+++ b/src/Data/StoreChargebackData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Data;
+
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Data for storing a new chargeback from Vatly.
+ *
+ * @immutable
+ */
+class StoreChargebackData
+{
+    public function __construct(
+        public string $vatlyId,
+        public string $customerId,
+        public string $status,
+        public int $total,
+        public string $currency,
+        public string $originalOrderId,
+        public ?string $reason = null,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
+        public ?string $hostCustomerId = null,
+    ) {}
+}

--- a/src/Data/UpdateChargebackData.php
+++ b/src/Data/UpdateChargebackData.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Data;
+
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Data for updating an existing chargeback from Vatly (e.g. on reversal).
+ *
+ * @immutable
+ */
+class UpdateChargebackData
+{
+    public function __construct(
+        public ?string $status = null,
+        public ?int $total = null,
+        public ?string $currency = null,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
+        public ?string $reason = null,
+    ) {}
+}

--- a/src/Events/OrderChargebackReceived.php
+++ b/src/Events/OrderChargebackReceived.php
@@ -4,17 +4,26 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Resources\Chargeback as ApiChargeback;
 use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
 
 /**
  * Event representing a chargeback being received against an order at Vatly.
  *
- * Vatly's public order status does not change on a chargeback, so fluent ships
- * no built-in reaction that mutates local state (mirroring Vatly rather than
- * synthesizing a status it never returns). Instead this typed event is
- * dispatched so drivers can react — e.g. suspend access tied to the order and
+ * Dispatched so drivers can react — e.g. suspend access tied to the order and
  * open the dispute window. The envelope's `entityId` is the order ID, so the
  * driver can locate the affected order directly.
+ *
+ * When a `GetChargeback` action is wired, the {@see \Vatly\Fluent\Webhooks\WebhookEventFactory}
+ * enriches this event via the API before dispatch (mirroring `order.paid` /
+ * `refund.*`) so it carries the customer id, dispute status, and the full tax
+ * breakdown — enough for the built-in
+ * {@see \Vatly\Fluent\Webhooks\Reactions\SyncChargebackOnStatusChange} to
+ * persist a local row and reconcile the reversed VAT without a second API call.
+ * Without that action it degrades gracefully to the sparse webhook payload
+ * (`orderId`, `chargebackId`, `originalOrderId`, `reason`).
  *
  * @immutable
  */
@@ -27,6 +36,12 @@ class OrderChargebackReceived
         public string $chargebackId,
         public string $originalOrderId,
         public ?string $reason = null,
+        public string $customerId = '',
+        public string $status = '',
+        public int $total = 0,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
+        public string $currency = '',
     ) {
         //
     }
@@ -38,6 +53,22 @@ class OrderChargebackReceived
             chargebackId: $webhook->object['id'] ?? '',
             originalOrderId: $webhook->object['originalOrderId'] ?? $webhook->entityId,
             reason: $webhook->object['reason'] ?? null,
+        );
+    }
+
+    public static function fromApiChargeback(ApiChargeback $chargeback): self
+    {
+        return new self(
+            orderId: $chargeback->originalOrderId,
+            chargebackId: $chargeback->id,
+            originalOrderId: $chargeback->originalOrderId,
+            reason: $chargeback->reason !== '' ? $chargeback->reason : null,
+            customerId: $chargeback->customerId,
+            status: $chargeback->status,
+            total: Money::fromApiMoneyToCents($chargeback->total),
+            subtotal: Money::fromApiMoneyToCents($chargeback->subtotal),
+            taxSummary: TaxSummary::fromApiResource($chargeback->taxSummary),
+            currency: $chargeback->total->currency,
         );
     }
 }

--- a/src/Events/OrderChargebackReversed.php
+++ b/src/Events/OrderChargebackReversed.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Events;
 
+use Vatly\API\Resources\Chargeback as ApiChargeback;
 use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
 
 /**
  * Event representing a previously-received chargeback being reversed at Vatly.
  *
  * Counterpart to {@see OrderChargebackReceived}: dispatched so drivers can
- * reinstate access they suspended on the original chargeback. As with the
- * received event, Vatly's public order status is unchanged, so fluent ships no
- * built-in state-mutating reaction. The envelope's `entityId` is the order ID.
+ * reinstate access they suspended on the original chargeback. The envelope's
+ * `entityId` is the order ID.
+ *
+ * Enriched via `GetChargeback` when that action is wired (same rationale as
+ * {@see OrderChargebackReceived}); otherwise built from the sparse webhook
+ * payload. The built-in {@see \Vatly\Fluent\Webhooks\Reactions\SyncChargebackOnStatusChange}
+ * uses the enriched status to flip the local chargeback row to its reversed
+ * state.
  *
  * @immutable
  */
@@ -25,6 +33,12 @@ class OrderChargebackReversed
         public string $chargebackId,
         public string $originalOrderId,
         public ?string $reason = null,
+        public string $customerId = '',
+        public string $status = '',
+        public int $total = 0,
+        public ?int $subtotal = null,
+        public ?TaxSummary $taxSummary = null,
+        public string $currency = '',
     ) {
         //
     }
@@ -36,6 +50,22 @@ class OrderChargebackReversed
             chargebackId: $webhook->object['id'] ?? '',
             originalOrderId: $webhook->object['originalOrderId'] ?? $webhook->entityId,
             reason: $webhook->object['reason'] ?? null,
+        );
+    }
+
+    public static function fromApiChargeback(ApiChargeback $chargeback): self
+    {
+        return new self(
+            orderId: $chargeback->originalOrderId,
+            chargebackId: $chargeback->id,
+            originalOrderId: $chargeback->originalOrderId,
+            reason: $chargeback->reason !== '' ? $chargeback->reason : null,
+            customerId: $chargeback->customerId,
+            status: $chargeback->status,
+            total: Money::fromApiMoneyToCents($chargeback->total),
+            subtotal: Money::fromApiMoneyToCents($chargeback->subtotal),
+            taxSummary: TaxSummary::fromApiResource($chargeback->taxSummary),
+            currency: $chargeback->total->currency,
         );
     }
 }

--- a/src/OrderHandle.php
+++ b/src/OrderHandle.php
@@ -6,6 +6,8 @@ namespace Vatly\Fluent;
 
 use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Contracts\ChargebackInterface;
+use Vatly\Fluent\Contracts\ChargebackReader;
 use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\RefundInterface;
 use Vatly\Fluent\Contracts\RefundReader;
@@ -33,6 +35,12 @@ class OrderHandle
          * rather than reaching into driver internals.
          */
         private readonly ?RefundReader $refunds = null,
+        /**
+         * Optional: supplied by {@see Vatly::order()} when a chargeback
+         * repository is wired. Without it, {@see self::chargebacks()} returns an
+         * empty array.
+         */
+        private readonly ?ChargebackReader $chargebacks = null,
     ) {
         //
     }
@@ -172,5 +180,19 @@ class OrderHandle
     public function refunds(): array
     {
         return $this->refunds?->listForOrder($this->order->getVatlyId()) ?? [];
+    }
+
+    /**
+     * The chargebacks recorded locally against this order, per the driver's
+     * {@see ChargebackReader} implementation.
+     *
+     * Reads only local state (no API call). Returns an empty array when no
+     * chargeback repository is wired.
+     *
+     * @return ChargebackInterface[]
+     */
+    public function chargebacks(): array
+    {
+        return $this->chargebacks?->listForOrder($this->order->getVatlyId()) ?? [];
     }
 }

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -9,6 +9,7 @@ use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\CancelSubscription;
 use Vatly\Fluent\Actions\CreateCheckout;
 use Vatly\Fluent\Actions\CreateCustomer;
+use Vatly\Fluent\Actions\GetChargeback;
 use Vatly\Fluent\Actions\GetCheckout;
 use Vatly\Fluent\Actions\GetCustomer;
 use Vatly\Fluent\Actions\GetOrder;
@@ -49,6 +50,7 @@ class Vatly
     private ?GetCustomer $getCustomer = null;
     private ?GetOrder $getOrder = null;
     private ?GetRefund $getRefund = null;
+    private ?GetChargeback $getChargeback = null;
     private ?GetCheckout $getCheckout = null;
     private ?CreateCheckout $createCheckout = null;
     private ?GetSubscription $getSubscription = null;
@@ -107,7 +109,7 @@ class Vatly
 
     public function getWebhookEventFactory(): WebhookEventFactory
     {
-        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder(), $this->getSubscription(), $this->getRefund());
+        return $this->webhookEventFactory ??= new WebhookEventFactory($this->getOrder(), $this->getSubscription(), $this->getRefund(), $this->getChargeback());
     }
 
     public function webhookProcessor(): WebhookProcessor
@@ -128,6 +130,8 @@ class Vatly
             getSubscription: $this->getSubscription(),
             getRefund: $this->getRefund(),
             refunds: $this->wiring->refunds,
+            getChargeback: $this->getChargeback(),
+            chargebacks: $this->wiring->chargebacks,
             additionalReactions: $this->wiring->additionalWebhookReactions,
         );
     }
@@ -246,6 +250,7 @@ class Vatly
             order: $order,
             getOrderAction: $this->getOrder(),
             refunds: $this->wiring->refunds,
+            chargebacks: $this->wiring->chargebacks,
         );
     }
 
@@ -269,6 +274,11 @@ class Vatly
     public function getRefund(): GetRefund
     {
         return $this->getRefund ??= new GetRefund($this->apiClient);
+    }
+
+    public function getChargeback(): GetChargeback
+    {
+        return $this->getChargeback ??= new GetChargeback($this->apiClient);
     }
 
     public function getCheckout(): GetCheckout

--- a/src/Webhooks/Reactions/SyncChargebackOnStatusChange.php
+++ b/src/Webhooks/Reactions/SyncChargebackOnStatusChange.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Webhooks\Reactions;
+
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\WebhookReactionInterface;
+use Vatly\Fluent\Data\StoreChargebackData;
+use Vatly\Fluent\Data\UpdateChargebackData;
+use Vatly\Fluent\Events\OrderChargebackReceived;
+use Vatly\Fluent\Events\OrderChargebackReversed;
+
+/**
+ * Persists `order.chargeback_*` webhooks onto the driver's local chargeback row
+ * — the chargeback mirror of {@see SyncRefundOnStatusChange}.
+ *
+ * Store-or-update: a chargeback seen for the first time (`chargeback_received`)
+ * is stored, resolving the host customer via bindings; a subsequent
+ * `chargeback_reversed` for the same chargeback updates the existing row's
+ * status/totals rather than inserting a duplicate. Registered only when a
+ * {@see ChargebackRepositoryInterface} is wired — without one, the typed
+ * chargeback events are still dispatched for drivers to handle.
+ *
+ * Persistence is only meaningful when the events are enriched (a `GetChargeback`
+ * action is wired), since the sparse webhook payload carries no customer id,
+ * status, or tax breakdown.
+ *
+ * @immutable
+ */
+class SyncChargebackOnStatusChange implements WebhookReactionInterface
+{
+    public function __construct(
+        private ChargebackRepositoryInterface $chargebacks,
+        private CustomerBindingRepository $bindings,
+    ) {}
+
+    public function supports(object $event): bool
+    {
+        return $event instanceof OrderChargebackReceived
+            || $event instanceof OrderChargebackReversed;
+    }
+
+    public function handle(object $event): void
+    {
+        if (! $event instanceof OrderChargebackReceived
+            && ! $event instanceof OrderChargebackReversed) {
+            return;
+        }
+
+        $existing = $this->chargebacks->findByVatlyId($event->chargebackId);
+
+        if ($existing !== null) {
+            $this->chargebacks->update($existing, new UpdateChargebackData(
+                status: $event->status,
+                total: $event->total,
+                currency: $event->currency,
+                subtotal: $event->subtotal,
+                taxSummary: $event->taxSummary,
+                reason: $event->reason,
+            ));
+
+            return;
+        }
+
+        $hostCustomerId = null;
+        if ($event->customerId !== '') {
+            $hostCustomerId = $this->bindings->hostCustomerIdFor($event->customerId);
+            $this->bindings->record($event->customerId);
+        }
+
+        $this->chargebacks->store(new StoreChargebackData(
+            vatlyId: $event->chargebackId,
+            customerId: $event->customerId,
+            status: $event->status,
+            total: $event->total,
+            currency: $event->currency,
+            originalOrderId: $event->originalOrderId,
+            reason: $event->reason,
+            subtotal: $event->subtotal,
+            taxSummary: $event->taxSummary,
+            hostCustomerId: $hostCustomerId,
+        ));
+    }
+}

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Webhooks;
 
 use Vatly\API\Webhooks\WebhookPayload;
+use Vatly\Fluent\Actions\GetChargeback;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
@@ -40,6 +41,13 @@ class WebhookEventFactory
          * factory back-compatible for drivers that don't wire refunds.
          */
         private ?GetRefund $getRefund = null,
+        /**
+         * Optional: enriches `order.chargeback_*` events with the customer id,
+         * dispute status, and tax breakdown. When null, those events are built
+         * from the (sparse) webhook payload — still dispatched, just without the
+         * persistence-grade fields.
+         */
+        private ?GetChargeback $getChargeback = null,
     ) {
         //
     }
@@ -62,9 +70,12 @@ class WebhookEventFactory
      * reason as `order.paid`: refund tax data is compliance-critical and the
      * dispatched event must carry the authoritative breakdown.
      *
-     * `order.canceled` and the `order.chargeback_*` events are built straight
-     * from the webhook payload — a status mirror and dispute signals
-     * respectively, neither of which needs enrichment.
+     * `order.canceled` is built straight from the webhook payload — a status
+     * mirror that needs no enrichment. The `order.chargeback_*` events are
+     * enriched via `GetChargeback` when that action is wired (customer id,
+     * status, tax breakdown for persistence) but fall back to the sparse
+     * payload otherwise — best-effort, since the payload already carries the
+     * `originalOrderId` the access-suspension path needs.
      *
      * The `checkout.*` events and `subscription.cancellation_grace_period_completed`
      * are likewise built straight from the payload: checkout deliveries already
@@ -86,8 +97,8 @@ class WebhookEventFactory
             SubscriptionCancellationGracePeriodCompleted::VATLY_EVENT_NAME => SubscriptionCancellationGracePeriodCompleted::fromWebhook($webhook),
             OrderPaid::VATLY_EVENT_NAME => $this->createOrderPaid($webhook),
             OrderCanceled::VATLY_EVENT_NAME => OrderCanceled::fromWebhook($webhook),
-            OrderChargebackReceived::VATLY_EVENT_NAME => OrderChargebackReceived::fromWebhook($webhook),
-            OrderChargebackReversed::VATLY_EVENT_NAME => OrderChargebackReversed::fromWebhook($webhook),
+            OrderChargebackReceived::VATLY_EVENT_NAME => $this->createOrderChargebackReceived($webhook),
+            OrderChargebackReversed::VATLY_EVENT_NAME => $this->createOrderChargebackReversed($webhook),
             PaymentFailed::VATLY_EVENT_NAME => $this->createPaymentFailed($webhook),
             CheckoutPaid::VATLY_EVENT_NAME => CheckoutPaid::fromWebhook($webhook),
             CheckoutFailed::VATLY_EVENT_NAME => CheckoutFailed::fromWebhook($webhook),
@@ -141,6 +152,56 @@ class WebhookEventFactory
             );
         } catch (\Throwable) {
             return SubscriptionBillingUpdated::fromWebhook($webhook);
+        }
+    }
+
+    /**
+     * Build an OrderChargebackReceived event, enriching via `GetChargeback`
+     * when that action is wired so the event carries the customer id, status,
+     * and tax breakdown the persistence reactions need.
+     *
+     * Enrichment is best-effort (unlike `order.paid`): the sparse webhook
+     * payload already carries `originalOrderId`, which is enough for the
+     * access-suspension path, so a transient `GetChargeback` failure falls back
+     * to the payload rather than forcing a redelivery and delaying the
+     * suspension. The chargeback id lives in the webhook `object`, not the
+     * envelope `entityId` (which is the order id).
+     */
+    private function createOrderChargebackReceived(WebhookReceived $webhook): OrderChargebackReceived
+    {
+        $chargebackId = $webhook->object['id'] ?? '';
+
+        if ($this->getChargeback === null || $chargebackId === '') {
+            return OrderChargebackReceived::fromWebhook($webhook);
+        }
+
+        try {
+            return OrderChargebackReceived::fromApiChargeback(
+                $this->getChargeback->execute($chargebackId),
+            );
+        } catch (\Throwable) {
+            return OrderChargebackReceived::fromWebhook($webhook);
+        }
+    }
+
+    /**
+     * Build an OrderChargebackReversed event. Same enrichment + fallback
+     * rationale as {@see self::createOrderChargebackReceived()}.
+     */
+    private function createOrderChargebackReversed(WebhookReceived $webhook): OrderChargebackReversed
+    {
+        $chargebackId = $webhook->object['id'] ?? '';
+
+        if ($this->getChargeback === null || $chargebackId === '') {
+            return OrderChargebackReversed::fromWebhook($webhook);
+        }
+
+        try {
+            return OrderChargebackReversed::fromApiChargeback(
+                $this->getChargeback->execute($chargebackId),
+            );
+        } catch (\Throwable) {
+            return OrderChargebackReversed::fromWebhook($webhook);
         }
     }
 

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Webhooks;
 
+use Vatly\Fluent\Actions\GetChargeback;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -21,6 +23,7 @@ use Vatly\Fluent\Webhooks\Reactions\EndSubscriptionOnGracePeriodCompleted;
 use Vatly\Fluent\Webhooks\Reactions\ResumeSubscriptionOnResumed;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
+use Vatly\Fluent\Webhooks\Reactions\SyncChargebackOnStatusChange;
 use Vatly\Fluent\Webhooks\Reactions\SyncRefundOnStatusChange;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnBillingUpdated;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
@@ -41,6 +44,12 @@ class WebhookProcessorFactory
      * behavior), and the {@see SyncRefundOnStatusChange} reaction is registered
      * only when `refunds` is supplied.
      *
+     * `getChargeback` and `chargebacks` follow the same opt-in shape for the
+     * `order.chargeback_*` events: pass `getChargeback` to enrich them (customer
+     * id, status, tax breakdown) and `chargebacks` to register the persistence
+     * reactions. Both default to null, so existing callers are unaffected and
+     * the chargeback events keep dispatching from the (sparse) webhook payload.
+     *
      * @param WebhookReactionInterface[] $additionalReactions
      */
     public static function create(
@@ -54,6 +63,8 @@ class WebhookProcessorFactory
         GetSubscription $getSubscription,
         ?GetRefund $getRefund = null,
         ?RefundRepositoryInterface $refunds = null,
+        ?GetChargeback $getChargeback = null,
+        ?ChargebackRepositoryInterface $chargebacks = null,
         array $additionalReactions = [],
     ): WebhookProcessor {
         $reactions = [
@@ -74,8 +85,16 @@ class WebhookProcessorFactory
             $reactions[] = new SyncRefundOnStatusChange($refunds, $bindings);
         }
 
+        if ($chargebacks !== null) {
+            // Persistence only: SyncChargebackOnStatusChange writes the
+            // chargeback row. The order's reversal progress (incl. chargebacks)
+            // is read live from the API via OrderHandle, so no local order
+            // status is synthesized here.
+            $reactions[] = new SyncChargebackOnStatusChange($chargebacks, $bindings);
+        }
+
         return new WebhookProcessor(
-            eventFactory: new WebhookEventFactory($getOrder, $getSubscription, $getRefund),
+            eventFactory: new WebhookEventFactory($getOrder, $getSubscription, $getRefund, $getChargeback),
             repository: $webhookCalls,
             dispatcher: $dispatcher,
             webhookSecret: $config->getWebhookSecret() ?? '',

--- a/src/Wiring.php
+++ b/src/Wiring.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent;
 
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -36,6 +37,7 @@ final class Wiring
         public readonly ?SubscriptionRepositoryInterface $subscriptions = null,
         public readonly ?OrderRepositoryInterface $orders = null,
         public readonly ?RefundRepositoryInterface $refunds = null,
+        public readonly ?ChargebackRepositoryInterface $chargebacks = null,
         public readonly ?WebhookCallRepositoryInterface $webhookCalls = null,
         public readonly ?EventDispatcherInterface $events = null,
         public readonly ?CustomerBindingRepository $customerBindings = null,

--- a/tests/Events/ChargebackEventsTest.php
+++ b/tests/Events/ChargebackEventsTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Vatly\Fluent\Tests\Events;
 
+use Mockery;
+use Vatly\API\Resources\Chargeback as ApiChargeback;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Events\OrderChargebackReceived;
 use Vatly\Fluent\Events\OrderChargebackReversed;
 use Vatly\Fluent\Events\WebhookReceived;
@@ -57,6 +62,54 @@ class ChargebackEventsTest extends TestCase
         ]));
 
         $this->assertSame('ord_123', $event->originalOrderId);
+    }
+
+    public function test_received_enriches_from_api_chargeback(): void
+    {
+        $event = OrderChargebackReceived::fromApiChargeback($this->apiChargeback('pending'));
+
+        $this->assertSame('chargeback_789', $event->chargebackId);
+        $this->assertSame('ord_original_1', $event->originalOrderId);
+        $this->assertSame('ord_original_1', $event->orderId);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame('pending', $event->status);
+        $this->assertSame(9900, $event->total);
+        $this->assertSame(8182, $event->subtotal);
+        $this->assertSame('EUR', $event->currency);
+        $this->assertSame('fraudulent', $event->reason);
+        $this->assertCount(1, $event->taxSummary);
+        $this->assertSame('VAT', $event->taxSummary->items[0]->rate->name);
+        $this->assertSame(1718, $event->taxSummary->items[0]->amount);
+    }
+
+    public function test_reversed_enriches_from_api_chargeback(): void
+    {
+        $event = OrderChargebackReversed::fromApiChargeback($this->apiChargeback('won'));
+
+        $this->assertSame('chargeback_789', $event->chargebackId);
+        $this->assertSame('won', $event->status);
+        $this->assertSame('cus_456', $event->customerId);
+        $this->assertSame(9900, $event->total);
+    }
+
+    private function apiChargeback(string $status): ApiChargeback
+    {
+        $chargeback = new ApiChargeback(Mockery::mock(VatlyApiClient::class));
+        $chargeback->id = 'chargeback_789';
+        $chargeback->customerId = 'cus_456';
+        $chargeback->status = $status;
+        $chargeback->reason = 'fraudulent';
+        $chargeback->originalOrderId = 'ord_original_1';
+        $chargeback->total = new Money('EUR', '99.00');
+        $chargeback->subtotal = new Money('EUR', '81.82');
+        $chargeback->taxSummary = new TaxSummaryCollection([
+            [
+                'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                'amount' => ['currency' => 'EUR', 'value' => '17.18'],
+            ],
+        ]);
+
+        return $chargeback;
     }
 
     /**

--- a/tests/OrderHandleTest.php
+++ b/tests/OrderHandleTest.php
@@ -11,6 +11,8 @@ use Vatly\API\Types\Link;
 use Vatly\API\Types\Money as ApiMoney;
 use Vatly\API\VatlyApiClient;
 use Vatly\Fluent\Actions\GetOrder;
+use Vatly\Fluent\Contracts\ChargebackInterface;
+use Vatly\Fluent\Contracts\ChargebackReader;
 use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\RefundInterface;
 use Vatly\Fluent\Contracts\RefundReader;
@@ -104,6 +106,37 @@ class OrderHandleTest extends TestCase
         );
 
         $this->assertSame([], $handle->refunds());
+    }
+
+    public function test_chargebacks_returns_local_chargebacks_for_the_order(): void
+    {
+        $cb = Mockery::mock(ChargebackInterface::class);
+
+        $reader = Mockery::mock(ChargebackReader::class);
+        $reader->shouldReceive('listForOrder')->with('order_abc')->once()->andReturn([$cb]);
+
+        $order = Mockery::mock(OrderInterface::class);
+        $order->shouldReceive('getVatlyId')->andReturn('order_abc');
+
+        $handle = new OrderHandle(
+            order: $order,
+            getOrderAction: Mockery::mock(GetOrder::class),
+            chargebacks: $reader,
+        );
+
+        $this->assertSame([$cb], $handle->chargebacks());
+    }
+
+    public function test_chargebacks_is_empty_when_no_chargeback_reader_is_wired(): void
+    {
+        $order = Mockery::mock(OrderInterface::class);
+
+        $handle = new OrderHandle(
+            order: $order,
+            getOrderAction: Mockery::mock(GetOrder::class),
+        );
+
+        $this->assertSame([], $handle->chargebacks());
     }
 
     public function test_reversal_helpers_read_the_live_api_order(): void

--- a/tests/Webhooks/Reactions/SyncChargebackOnStatusChangeTest.php
+++ b/tests/Webhooks/Reactions/SyncChargebackOnStatusChangeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Webhooks\Reactions;
+
+use Mockery;
+use Vatly\Fluent\Contracts\ChargebackInterface;
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
+use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Data\StoreChargebackData;
+use Vatly\Fluent\Data\UpdateChargebackData;
+use Vatly\Fluent\Events\OrderChargebackReceived;
+use Vatly\Fluent\Events\OrderChargebackReversed;
+use Vatly\Fluent\Events\OrderPaid;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+use Vatly\Fluent\Webhooks\Reactions\SyncChargebackOnStatusChange;
+
+class SyncChargebackOnStatusChangeTest extends TestCase
+{
+    public function test_it_supports_both_chargeback_events(): void
+    {
+        $reaction = new SyncChargebackOnStatusChange(
+            Mockery::mock(ChargebackRepositoryInterface::class),
+            Mockery::mock(CustomerBindingRepository::class),
+        );
+
+        $this->assertTrue($reaction->supports($this->received('pending')));
+        $this->assertTrue($reaction->supports($this->reversed('won')));
+        $this->assertFalse($reaction->supports(new OrderPaid('cus_1', 'ord_1', 'paid', 9900, 8182, TaxSummary::empty(), 'EUR', null, null)));
+    }
+
+    public function test_it_stores_a_new_chargeback_resolving_host_customer_from_bindings(): void
+    {
+        $stored = Mockery::mock(ChargebackInterface::class);
+        $repo = Mockery::mock(ChargebackRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('chargeback_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreChargebackData $data) {
+            return $data->vatlyId === 'chargeback_1'
+                && $data->customerId === 'cus_1'
+                && $data->status === 'pending'
+                && $data->total === 9900
+                && $data->originalOrderId === 'ord_original_1'
+                && $data->hostCustomerId === 'host_42';
+        }))->andReturn($stored);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->with('cus_1')->once()->andReturn('host_42');
+        $bindings->shouldReceive('record')->with('cus_1')->once();
+
+        $reaction = new SyncChargebackOnStatusChange($repo, $bindings);
+        $reaction->handle($this->received('pending'));
+    }
+
+    public function test_it_updates_an_existing_chargeback_on_reversal(): void
+    {
+        $existing = Mockery::mock(ChargebackInterface::class);
+        $repo = Mockery::mock(ChargebackRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('chargeback_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->with($existing, Mockery::on(
+            fn (UpdateChargebackData $data) => $data->status === 'won' && $data->total === 9900,
+        ))->andReturn($existing);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('record');
+
+        $reaction = new SyncChargebackOnStatusChange($repo, $bindings);
+        $reaction->handle($this->reversed('won'));
+    }
+
+    public function test_it_skips_binding_when_customer_id_is_empty(): void
+    {
+        $stored = Mockery::mock(ChargebackInterface::class);
+        $repo = Mockery::mock(ChargebackRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(
+            fn (StoreChargebackData $data) => $data->hostCustomerId === null,
+        ))->andReturn($stored);
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldNotReceive('hostCustomerIdFor');
+        $bindings->shouldNotReceive('record');
+
+        // Sparse (un-enriched) event: chargebackId set, but no customer id.
+        $event = new OrderChargebackReceived('ord_original_1', 'chargeback_1', 'ord_original_1', null);
+
+        $reaction = new SyncChargebackOnStatusChange($repo, $bindings);
+        $reaction->handle($event);
+    }
+
+    private function received(string $status): OrderChargebackReceived
+    {
+        return new OrderChargebackReceived(
+            orderId: 'ord_original_1',
+            chargebackId: 'chargeback_1',
+            originalOrderId: 'ord_original_1',
+            reason: 'fraudulent',
+            customerId: 'cus_1',
+            status: $status,
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+        );
+    }
+
+    private function reversed(string $status): OrderChargebackReversed
+    {
+        return new OrderChargebackReversed(
+            orderId: 'ord_original_1',
+            chargebackId: 'chargeback_1',
+            originalOrderId: 'ord_original_1',
+            reason: 'fraudulent',
+            customerId: 'cus_1',
+            status: $status,
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+        );
+    }
+}

--- a/tests/Webhooks/WebhookProcessorFactoryTest.php
+++ b/tests/Webhooks/WebhookProcessorFactoryTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Tests\Webhooks;
 
 use Mockery;
+use Vatly\Fluent\Actions\GetChargeback;
 use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Actions\GetRefund;
 use Vatly\Fluent\Actions\GetSubscription;
+use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
@@ -23,6 +25,7 @@ use Vatly\Fluent\Webhooks\Reactions\EndSubscriptionOnGracePeriodCompleted;
 use Vatly\Fluent\Webhooks\Reactions\ResumeSubscriptionOnResumed;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaymentFailed;
+use Vatly\Fluent\Webhooks\Reactions\SyncChargebackOnStatusChange;
 use Vatly\Fluent\Webhooks\Reactions\SyncRefundOnStatusChange;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnBillingUpdated;
 use Vatly\Fluent\Webhooks\Reactions\SyncSubscriptionOnStarted;
@@ -103,6 +106,46 @@ class WebhookProcessorFactoryTest extends TestCase
 
         $this->assertCount(9, $reactions);
         $this->assertInstanceOf(SyncRefundOnStatusChange::class, $reactions[8]);
+    }
+
+    public function test_it_registers_the_chargeback_reactions_only_when_a_chargeback_repository_is_supplied(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            bindings: Mockery::mock(CustomerBindingRepository::class),
+            getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
+            getChargeback: Mockery::mock(GetChargeback::class),
+            chargebacks: Mockery::mock(ChargebackRepositoryInterface::class),
+        );
+
+        $reactions = $processor->getReactions();
+
+        // 8 standard + 1 chargeback persistence reaction (no refunds wired here).
+        $this->assertCount(9, $reactions);
+        $this->assertInstanceOf(SyncChargebackOnStatusChange::class, $reactions[8]);
+    }
+
+    public function test_it_does_not_register_chargeback_reactions_without_a_repository(): void
+    {
+        $processor = WebhookProcessorFactory::create(
+            config: $this->config('secret'),
+            subscriptions: Mockery::mock(SubscriptionRepositoryInterface::class),
+            orders: Mockery::mock(OrderRepositoryInterface::class),
+            webhookCalls: Mockery::mock(WebhookCallRepositoryInterface::class),
+            dispatcher: Mockery::mock(EventDispatcherInterface::class),
+            bindings: Mockery::mock(CustomerBindingRepository::class),
+            getOrder: Mockery::mock(GetOrder::class),
+            getSubscription: Mockery::mock(GetSubscription::class),
+        );
+
+        foreach ($processor->getReactions() as $reaction) {
+            $this->assertNotInstanceOf(SyncChargebackOnStatusChange::class, $reaction);
+        }
     }
 
     public function test_it_appends_additional_reactions_after_the_standard_ones(): void


### PR DESCRIPTION
> Stacked on #72 (`feat/refunds-consumer-surface`). Rebased onto the reshaped branch 1.

## What

Adds the chargeback **persistence + read** pipeline (mirror of refunds). Following the new model, it does **not** synthesize a local order status — the order stays terminal `paid`, and reversal/status is read live from the API via the `OrderHandle` helpers introduced in #72.

Requires `vatly/vatly-api-php` **^0.1.0-alpha.14**.

## Changes

**Added:**
- Contracts: `ChargebackInterface`, `ChargebackReader` / `ChargebackWriter`, `ChargebackRepositoryInterface`
- DTOs: `StoreChargebackData`, `UpdateChargebackData`
- `GetChargeback` action; `OrderChargebackReceived` / `OrderChargebackReversed` gain `fromApiChargeback()` enrichment (customerId, status, total/subtotal, taxSummary), with graceful fallback to the sparse webhook payload when `GetChargeback` isn't wired
- `SyncChargebackOnStatusChange` reaction (opt-in, registered only when a `ChargebackRepositoryInterface` is wired): store-or-update the local chargeback row
- `OrderHandle::chargebacks()`; `Wiring` / `Vatly` / `WebhookProcessorFactory` threading

**Not included (vs. the original PR):**
- **No** `SyncOrderOnChargebackChange` reaction and **no** `paid → chargeback → paid` order-status mutation. The order's `status` stays `paid`; whether money came back (chargebacks included) is read via the `OrderHandle` reversal helpers (`reversedSubtotal()` / `refundableSubtotal()` / `isReversed()` / `isPartiallyReversed()` / `isFullyReversed()`) from #72, since the API's `reversedSubtotal` combines refunds and chargebacks.

## Tests

- `vendor/bin/phpunit`: 292 passing
- `composer analyse` (PHPStan): clean
- Factory's chargeback-repo test now expects **9** reactions (`SyncChargebackOnStatusChange` at index 8).