### PR TITLE
feat(testing): ship FakeVatly + fakes for consumer test ergonomics (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,32 @@ Dispatched by webhook reactions through your `EventDispatcherInterface`. Subscri
 composer test
 ```
 
+### Test helpers for consumers
+
+`Vatly\Fluent\Testing` ships fakes so consumers don't hand-roll a Mockery stub for every fluent entry point (which breaks the moment fluent grows a method):
+
+```php
+use Vatly\Fluent\Testing\FakeVatly;
+use Vatly\Fluent\Testing\FakeCheckout;
+
+$fake = (new FakeVatly())->onSubscriptionCreate(
+    fn (string $planId) => FakeCheckout::make('https://checkout.vatly.test/chk_1'),
+);
+$this->app->instance(Vatly::class, $fake); // drop-in: FakeVatly extends Vatly
+
+$this->get('/vatly/subscription-checkout/plan_pro')
+    ->assertRedirect('https://checkout.vatly.test/chk_1');
+
+$fake->assertSubscriptionCreated('plan_pro');
+$fake->assertNothingCanceled();
+```
+
+- **`FakeVatly`** — drop-in `Vatly` that hands out recording builders/handles and returns scriptable `Checkout`s (`onSubscriptionCreate` / `onCheckoutCreate` / `withDefaultCheckout`).
+- **`FakeCheckout::make($url)`** — a minimal `Checkout` with a working `links->checkoutUrl->href`.
+- **Assertions** — `assertSubscriptionCreated($planId)`, `assertCheckoutCreated(productId:)`, `assertSubscriptionSwapped(from:, to:)`, `assertSubscriptionCanceled($id)`, `assertNothingCanceled()`, `assertNothingCreated()`.
+
+Swap/cancel/resume routed through `$fake->subscription($localSub)` are recorded too. Ships in-package (like Cashier's helpers); the PHPUnit dependency is only touched from the `assert*` methods.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/Testing/FakeCheckout.php
+++ b/src/Testing/FakeCheckout.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Testing;
+
+use Vatly\API\Resources\Checkout;
+use Vatly\API\Resources\Links\CheckoutLinks;
+use Vatly\API\Types\Link;
+use Vatly\API\VatlyApiClient;
+
+/**
+ * Factory for a minimal, working {@see Checkout} resource for use in consumer
+ * tests — the one with a real `links->checkoutUrl->href`, so a controller that
+ * redirects to the checkout URL can be asserted against without hand-rolling
+ * the full resource graph.
+ *
+ * ```php
+ * $checkout = FakeCheckout::make('https://checkout.vatly.test/chk_123');
+ * $this->get('/subscribe/plan_pro')->assertRedirect($checkout->links->checkoutUrl->href);
+ * ```
+ */
+final class FakeCheckout
+{
+    /**
+     * @param array<string, mixed> $overrides Resource property overrides (e.g. `status`, `customerId`).
+     */
+    public static function make(string $url = 'https://checkout.vatly.test/chk_fake', array $overrides = []): Checkout
+    {
+        $checkout = new Checkout(new VatlyApiClient());
+        $checkout->id = $overrides['id'] ?? 'chk_fake';
+        $checkout->resource = 'checkout';
+        $checkout->status = $overrides['status'] ?? 'created';
+        $checkout->testmode = $overrides['testmode'] ?? true;
+        $checkout->customerId = $overrides['customerId'] ?? null;
+        $checkout->redirectUrlSuccess = $overrides['redirectUrlSuccess'] ?? 'https://app.vatly.test/success';
+        $checkout->redirectUrlCanceled = $overrides['redirectUrlCanceled'] ?? 'https://app.vatly.test/canceled';
+
+        $checkout->links = new CheckoutLinks();
+        $checkout->links->checkoutUrl = new Link($url, 'text/html');
+
+        foreach ($overrides as $key => $value) {
+            if (property_exists($checkout, $key)) {
+                $checkout->{$key} = $value;
+            }
+        }
+
+        return $checkout;
+    }
+}

--- a/src/Testing/FakeCheckoutBuilder.php
+++ b/src/Testing/FakeCheckoutBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Testing;
+
+use Vatly\API\Resources\Checkout;
+use Vatly\Fluent\Builders\CheckoutBuilder;
+use Vatly\Fluent\CustomerProfile;
+
+/**
+ * Recording {@see CheckoutBuilder} handed out by {@see FakeVatly}.
+ *
+ * Inherits the real builder surface; only `create()` is overridden to record
+ * the assembled payload on the `FakeVatly` and return the scripted Checkout
+ * (no API call, no empty-items guard — a test shouldn't have to fully populate
+ * a cart to assert a redirect).
+ */
+final class FakeCheckoutBuilder extends CheckoutBuilder
+{
+    public function __construct(
+        private readonly FakeVatly $vatly,
+        CustomerProfile $profile,
+    ) {
+        parent::__construct(
+            customer: $profile,
+            createCheckout: $vatly->createCheckout(),
+        );
+    }
+
+    public function create(
+        array $items,
+        string $redirectUrlSuccess,
+        string $redirectUrlCanceled,
+        array $payloadOverrides = [],
+    ): Checkout {
+        $this
+            ->withItems($items)
+            ->withRedirectUrlSuccess($redirectUrlSuccess)
+            ->withRedirectUrlCanceled($redirectUrlCanceled);
+
+        return $this->vatly->recordCheckoutCreated($this->payload($payloadOverrides));
+    }
+}

--- a/src/Testing/FakeSubscriptionBuilder.php
+++ b/src/Testing/FakeSubscriptionBuilder.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Testing;
+
+use Vatly\API\Resources\Checkout;
+use Vatly\Fluent\Builders\SubscriptionBuilder;
+use Vatly\Fluent\CustomerProfile;
+
+/**
+ * Recording {@see SubscriptionBuilder} handed out by {@see FakeVatly}.
+ *
+ * All the fluent setters (`toPlan`, `withQuantity`, `withRedirectUrl*`, …) are
+ * inherited unchanged, so a test exercises the real builder API. Only
+ * `create()` is overridden: instead of hitting the API it records the
+ * subscription payload on the `FakeVatly` and returns the scripted Checkout.
+ */
+final class FakeSubscriptionBuilder extends SubscriptionBuilder
+{
+    public function __construct(
+        private readonly FakeVatly $vatly,
+        CustomerProfile $profile,
+    ) {
+        parent::__construct(
+            config: $vatly->getWiring()->config,
+            customer: $profile,
+            checkoutBuilder: new FakeCheckoutBuilder($vatly, $profile),
+        );
+    }
+
+    public function create(array $checkoutOptions = []): Checkout
+    {
+        return $this->vatly->recordSubscriptionCreated(
+            $this->getSubscriptionPayload(),
+            $this->customer,
+        );
+    }
+}

--- a/src/Testing/FakeSubscriptionHandle.php
+++ b/src/Testing/FakeSubscriptionHandle.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Testing;
+
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\Contracts\SubscriptionWriter;
+use Vatly\Fluent\Data\StoreSubscriptionData;
+use Vatly\Fluent\Data\UpdateSubscriptionData;
+use Vatly\Fluent\SubscriptionHandle;
+
+/**
+ * Recording {@see SubscriptionHandle} handed out by {@see FakeVatly}.
+ *
+ * State accessors (`getPlanId`, `isActive`, …) delegate to the underlying
+ * {@see SubscriptionInterface} you pass in, so a test can build a scriptable
+ * subscription state with a plain stub. The mutating operations
+ * (`swap`, `cancel`, `resume`, …) are overridden to record on the `FakeVatly`
+ * and short-circuit the API.
+ */
+final class FakeSubscriptionHandle extends SubscriptionHandle
+{
+    public function __construct(
+        private readonly SubscriptionInterface $fakeSubscription,
+        private readonly FakeVatly $vatly,
+    ) {
+        parent::__construct(
+            subscription: $fakeSubscription,
+            subscriptions: self::nullWriter(),
+            swapAction: $vatly->swapSubscriptionPlan(),
+            cancelAction: $vatly->cancelSubscription(),
+            resumeAction: $vatly->resumeSubscription(),
+            getSubscriptionAction: $vatly->getSubscription(),
+            updateBillingAction: $vatly->updateSubscriptionBilling(),
+        );
+    }
+
+    public function swap(string $planId, array $options = []): SubscriptionHandle
+    {
+        $this->vatly->recordSwap($this->fakeSubscription->getPlanId(), $planId);
+
+        return $this;
+    }
+
+    public function swapAndInvoice(string $planId, array $options = []): SubscriptionHandle
+    {
+        return $this->swap($planId, $options);
+    }
+
+    public function cancel(): void
+    {
+        $this->vatly->recordCancellation($this->fakeSubscription->getVatlyId());
+    }
+
+    public function resume(): SubscriptionHandle
+    {
+        return $this;
+    }
+
+    public function updateBilling(array $prefillData = []): string
+    {
+        return 'https://billing.vatly.test/update/' . $this->fakeSubscription->getVatlyId();
+    }
+
+    public function sync(): SubscriptionHandle
+    {
+        return $this;
+    }
+
+    private static function nullWriter(): SubscriptionWriter
+    {
+        return new class implements SubscriptionWriter {
+            public function store(StoreSubscriptionData $data): ?SubscriptionInterface
+            {
+                return null;
+            }
+
+            public function update(SubscriptionInterface $subscription, UpdateSubscriptionData $data): SubscriptionInterface
+            {
+                return $subscription;
+            }
+        };
+    }
+}

--- a/src/Testing/FakeVatly.php
+++ b/src/Testing/FakeVatly.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Testing;
+
+use Closure;
+use PHPUnit\Framework\Assert;
+use Vatly\API\Resources\Checkout;
+use Vatly\Fluent\Configuration\ArrayConfiguration;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\SubscriptionHandle;
+use Vatly\Fluent\Vatly;
+use Vatly\Fluent\Wiring;
+
+/**
+ * A drop-in {@see Vatly} double for consumer feature tests.
+ *
+ * Instead of hand-rolling a Mockery stub for every fluent entry point (which
+ * breaks the moment fluent grows a method), bind a `FakeVatly` and script only
+ * the bits your test cares about:
+ *
+ * ```php
+ * $fake = (new FakeVatly())->onSubscriptionCreate(
+ *     fn (string $planId) => FakeCheckout::make('https://checkout.vatly.test/chk_1'),
+ * );
+ * $this->app->instance(Vatly::class, $fake);
+ *
+ * $this->get('/vatly/subscription-checkout/plan_pro')
+ *     ->assertRedirect('https://checkout.vatly.test/chk_1');
+ *
+ * $fake->assertSubscriptionCreated('plan_pro');
+ * $fake->assertNothingCanceled();
+ * ```
+ *
+ * It records every checkout/subscription creation, plan swap, and cancellation
+ * routed through the builders/handles it hands out, and ships assertion helpers
+ * in the spirit of `Notification::assertSentTo`.
+ *
+ * Ships in-package (like Cashier's test helpers). The PHPUnit `Assert`
+ * dependency is only touched from the `assert*` methods, so production code
+ * paths never load it.
+ */
+class FakeVatly extends Vatly
+{
+    /** @var array<int, array{planId: string, quantity: int, customerId: string}> */
+    private array $createdSubscriptions = [];
+
+    /** @var array<int, array<string, mixed>> */
+    private array $createdCheckouts = [];
+
+    /** @var array<int, array{from: string, to: string}> */
+    private array $swaps = [];
+
+    /** @var array<int, string> */
+    private array $cancellations = [];
+
+    private ?Closure $subscriptionCreateHandler = null;
+
+    private ?Closure $checkoutCreateHandler = null;
+
+    private Checkout $defaultCheckout;
+
+    public function __construct()
+    {
+        parent::__construct(new Wiring(
+            // Format-valid placeholder (test_ + >=18 chars) so the underlying
+            // api client accepts it; the fake never makes a real API call.
+            config: new ArrayConfiguration(['api_key' => 'test_fakefakefakefakefake']),
+        ));
+
+        $this->defaultCheckout = FakeCheckout::make();
+    }
+
+    // --- Scripting ---
+
+    /**
+     * Script the Checkout returned when a subscription is created. The closure
+     * receives the plan id (and the full subscription payload as a 2nd arg).
+     */
+    public function onSubscriptionCreate(callable $handler): static
+    {
+        $this->subscriptionCreateHandler = Closure::fromCallable($handler);
+
+        return $this;
+    }
+
+    /**
+     * Script the Checkout returned when a checkout is created directly. The
+     * closure receives the checkout payload array.
+     */
+    public function onCheckoutCreate(callable $handler): static
+    {
+        $this->checkoutCreateHandler = Closure::fromCallable($handler);
+
+        return $this;
+    }
+
+    /**
+     * Set the Checkout returned when no per-call handler is scripted.
+     */
+    public function withDefaultCheckout(Checkout $checkout): static
+    {
+        $this->defaultCheckout = $checkout;
+
+        return $this;
+    }
+
+    // --- Overridden entry points (hand out recording fakes) ---
+
+    public function subscriptionBuilder(CustomerProfile $profile): \Vatly\Fluent\Builders\SubscriptionBuilder
+    {
+        return new FakeSubscriptionBuilder($this, $profile);
+    }
+
+    public function checkoutBuilder(CustomerProfile $profile): \Vatly\Fluent\Builders\CheckoutBuilder
+    {
+        return new FakeCheckoutBuilder($this, $profile);
+    }
+
+    public function subscription(SubscriptionInterface $subscription): SubscriptionHandle
+    {
+        return new FakeSubscriptionHandle($subscription, $this);
+    }
+
+    // --- Recording hooks (called by the fakes above) ---
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @internal
+     */
+    public function recordSubscriptionCreated(array $payload, CustomerProfile $profile): Checkout
+    {
+        $planId = (string) ($payload['id'] ?? '');
+
+        $this->createdSubscriptions[] = [
+            'planId' => $planId,
+            'quantity' => (int) ($payload['quantity'] ?? 1),
+            'customerId' => $profile->vatlyId,
+        ];
+
+        if ($this->subscriptionCreateHandler !== null) {
+            return ($this->subscriptionCreateHandler)($planId, $payload);
+        }
+
+        return $this->defaultCheckout;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @internal
+     */
+    public function recordCheckoutCreated(array $payload): Checkout
+    {
+        $this->createdCheckouts[] = $payload;
+
+        if ($this->checkoutCreateHandler !== null) {
+            return ($this->checkoutCreateHandler)($payload);
+        }
+
+        return $this->defaultCheckout;
+    }
+
+    /** @internal */
+    public function recordSwap(string $from, string $to): void
+    {
+        $this->swaps[] = ['from' => $from, 'to' => $to];
+    }
+
+    /** @internal */
+    public function recordCancellation(string $vatlyId): void
+    {
+        $this->cancellations[] = $vatlyId;
+    }
+
+    // --- Assertions ---
+
+    public function assertSubscriptionCreated(?string $planId = null): void
+    {
+        if ($planId === null) {
+            Assert::assertNotEmpty($this->createdSubscriptions, 'Expected a subscription to be created, but none were.');
+
+            return;
+        }
+
+        $plans = array_column($this->createdSubscriptions, 'planId');
+        Assert::assertContains($planId, $plans, "Expected a subscription created for plan [{$planId}], got: " . implode(', ', $plans));
+    }
+
+    public function assertCheckoutCreated(?string $productId = null): void
+    {
+        if ($productId === null) {
+            Assert::assertNotEmpty($this->createdCheckouts, 'Expected a checkout to be created, but none were.');
+
+            return;
+        }
+
+        $found = false;
+        foreach ($this->createdCheckouts as $payload) {
+            foreach ($payload['products'] ?? [] as $product) {
+                if (($product['id'] ?? null) === $productId) {
+                    $found = true;
+                }
+            }
+        }
+
+        Assert::assertTrue($found, "Expected a checkout created containing product [{$productId}].");
+    }
+
+    public function assertSubscriptionSwapped(?string $from = null, ?string $to = null): void
+    {
+        if ($from === null && $to === null) {
+            Assert::assertNotEmpty($this->swaps, 'Expected a subscription plan swap, but none were recorded.');
+
+            return;
+        }
+
+        $match = array_filter(
+            $this->swaps,
+            fn (array $swap) => ($from === null || $swap['from'] === $from)
+                && ($to === null || $swap['to'] === $to),
+        );
+
+        Assert::assertNotEmpty($match, 'Expected a matching subscription plan swap, but none were recorded.');
+    }
+
+    public function assertSubscriptionCanceled(?string $vatlyId = null): void
+    {
+        if ($vatlyId === null) {
+            Assert::assertNotEmpty($this->cancellations, 'Expected a subscription cancellation, but none were recorded.');
+
+            return;
+        }
+
+        Assert::assertContains($vatlyId, $this->cancellations, "Expected subscription [{$vatlyId}] to be canceled.");
+    }
+
+    public function assertNothingCanceled(): void
+    {
+        Assert::assertEmpty($this->cancellations, 'Expected no cancellations, but some were recorded.');
+    }
+
+    public function assertNothingCreated(): void
+    {
+        Assert::assertEmpty($this->createdSubscriptions, 'Expected no subscriptions created.');
+        Assert::assertEmpty($this->createdCheckouts, 'Expected no checkouts created.');
+    }
+}

--- a/tests/Testing/FakeVatlyTest.php
+++ b/tests/Testing/FakeVatlyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Testing;
+
+use Mockery;
+use Vatly\Fluent\Contracts\SubscriptionInterface;
+use Vatly\Fluent\CustomerProfile;
+use Vatly\Fluent\Testing\FakeCheckout;
+use Vatly\Fluent\Testing\FakeVatly;
+use Vatly\Fluent\Tests\TestCase;
+
+class FakeVatlyTest extends TestCase
+{
+    private function profile(string $id = 'cus_1'): CustomerProfile
+    {
+        return new CustomerProfile(vatlyId: $id);
+    }
+
+    public function test_subscription_create_returns_scripted_checkout_and_records_the_plan(): void
+    {
+        $fake = (new FakeVatly())->onSubscriptionCreate(
+            fn (string $planId) => FakeCheckout::make('https://checkout.vatly.test/chk_1'),
+        );
+
+        $checkout = $fake->subscriptionBuilder($this->profile())
+            ->toPlan('plan_pro')
+            ->withQuantity(2)
+            ->create();
+
+        $this->assertSame('https://checkout.vatly.test/chk_1', $checkout->links->checkoutUrl->href);
+        $fake->assertSubscriptionCreated('plan_pro');
+        $fake->assertNothingCanceled();
+    }
+
+    public function test_subscription_create_falls_back_to_the_default_checkout(): void
+    {
+        $fake = (new FakeVatly())->withDefaultCheckout(FakeCheckout::make('https://checkout.vatly.test/default'));
+
+        $checkout = $fake->subscriptionBuilder($this->profile())->toPlan('plan_basic')->create();
+
+        $this->assertSame('https://checkout.vatly.test/default', $checkout->links->checkoutUrl->href);
+    }
+
+    public function test_checkout_builder_records_the_product(): void
+    {
+        $fake = new FakeVatly();
+
+        $fake->checkoutBuilder($this->profile())->create(
+            items: [['id' => 'product_xyz', 'quantity' => 1]],
+            redirectUrlSuccess: 'https://app/success',
+            redirectUrlCanceled: 'https://app/cancel',
+        );
+
+        $fake->assertCheckoutCreated(productId: 'product_xyz');
+    }
+
+    public function test_swap_and_cancel_are_recorded(): void
+    {
+        $fake = new FakeVatly();
+
+        $subscription = Mockery::mock(SubscriptionInterface::class);
+        $subscription->shouldReceive('getPlanId')->andReturn('plan_starter');
+        $subscription->shouldReceive('getVatlyId')->andReturn('subscription_42');
+
+        $handle = $fake->subscription($subscription);
+        $handle->swap('plan_pro');
+
+        $fake->assertSubscriptionSwapped(from: 'plan_starter', to: 'plan_pro');
+        $fake->assertNothingCanceled();
+
+        $handle->cancel();
+        $fake->assertSubscriptionCanceled('subscription_42');
+    }
+
+    public function test_assert_nothing_created_passes_on_a_fresh_fake(): void
+    {
+        (new FakeVatly())->assertNothingCreated();
+    }
+
+    public function test_it_is_a_drop_in_for_the_real_vatly(): void
+    {
+        $this->assertInstanceOf(\Vatly\Fluent\Vatly::class, new FakeVatly());
+    }
+}


### PR DESCRIPTION
Closes #71.

## What

A `Vatly\Fluent\Testing` namespace so consumers stop hand-rolling a Mockery stub for every fluent entry point (brittle: any new fluent method breaks their tests via a missing `shouldReceive`).

```php
$fake = (new FakeVatly())->onSubscriptionCreate(
    fn (string $planId) => FakeCheckout::make('https://checkout.vatly.test/chk_1'),
);
$this->app->instance(Vatly::class, $fake);

$this->get('/vatly/subscription-checkout/plan_pro')
    ->assertRedirect('https://checkout.vatly.test/chk_1');

$fake->assertSubscriptionCreated('plan_pro');
$fake->assertNothingCanceled();
```

- **`FakeVatly`** (extends `Vatly`, so it's a true drop-in for `$this->app->instance(Vatly::class, …)`) — hands out recording builders/handles, returns scriptable `Checkout`s via `onSubscriptionCreate` / `onCheckoutCreate` / `withDefaultCheckout`.
- **`FakeCheckout::make($url)`** — minimal `Checkout` with a working `links->checkoutUrl->href`.
- **`FakeSubscriptionBuilder` / `FakeCheckoutBuilder`** — inherit the real fluent setter surface; only `create()` short-circuits the API and records.
- **`FakeSubscriptionHandle`** — records `swap` / `swapAndInvoice` / `cancel` / `resume` / `updateBilling` without API calls; state accessors delegate to the `SubscriptionInterface` you pass.
- **Assertions** — `assertSubscriptionCreated`, `assertCheckoutCreated(productId:)`, `assertSubscriptionSwapped(from:, to:)`, `assertSubscriptionCanceled`, `assertNothingCanceled`, `assertNothingCreated`.

## Notes
- Ships in-package (Cashier-style). `PHPUnit\Framework\Assert` is only referenced from the `assert*` method bodies, so production code paths never load it.
- Scope: focused on the high-friction creation + swap/cancel flows from the issue. Webhook-event factories (`FakeOrderPaid::for(...)` etc.) and a `FakeRepository` set can follow once the chargeback repo (#70) lands — the typed events are already directly constructible meanwhile.

283 tests green, PHPStan clean.