### PR TITLE
ci: run PHPStan in CI

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,28 @@
+name: PHPStan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Run PHPStan
+        run: composer analyse


### PR DESCRIPTION
The repo has `phpstan/phpstan`, a `phpstan.neon`, and a `composer analyse` script — but CI only ran phpunit, so static-analysis errors could merge green.

Adds a `PHPStan` workflow mirroring the tests workflow (PHP 8.4, `composer update` since no lock is committed). Companion to vatly/vatly-laravel#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)