### PR TITLE
feat: persist order lines (first-class) for product/subscription↔order traversal (closes #81)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vatly/vatly-api-php": "^0.1.0-alpha.14"
+        "vatly/vatly-api-php": "^0.1.0-alpha.15"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/src/Contracts/OrderLineInterface.php
+++ b/src/Contracts/OrderLineInterface.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Interface for order line entities.
+ *
+ * Mirrors {@see RefundInterface}: a thin read surface over the driver's own
+ * persisted order-line row, populated from Vatly's `order.paid` webhook.
+ *
+ * The order↔subscription link lives here, at the line level, as a generic
+ * (`productType`, `productId`) pair — a line links to a subscription when
+ * `getProductType() === 'subscription'` → `getProductId()` is the
+ * `subscription_…` id. `productType` is the raw API string (no fluent enum)
+ * so new backend product types stay queryable without a fluent release.
+ */
+interface OrderLineInterface
+{
+    /**
+     * Get the Vatly order-line ID (the `order_item_…` id).
+     */
+    public function getVatlyId(): string;
+
+    /**
+     * Get the Vatly ID of the parent order this line belongs to.
+     */
+    public function getOrderId(): string;
+
+    /**
+     * Get the line description.
+     */
+    public function getDescription(): string;
+
+    /**
+     * Get the line quantity.
+     */
+    public function getQuantity(): int;
+
+    /**
+     * Get the line base price (per-unit, before quantity), in integer cents.
+     */
+    public function getBasePrice(): int;
+
+    /**
+     * Get the line total (gross, including tax), in integer cents.
+     */
+    public function getTotal(): int;
+
+    /**
+     * Get the line subtotal (net of tax), in integer cents.
+     */
+    public function getSubtotal(): int;
+
+    /**
+     * Get the raw Vatly product type this line links to (e.g. "subscription",
+     * "one_off_product"), or null when the backend has not (yet) attributed it.
+     */
+    public function getProductType(): ?string;
+
+    /**
+     * Get the linked product's id (e.g. a `subscription_…` id for a
+     * subscription line), or null when unattributed.
+     */
+    public function getProductId(): ?string;
+}

--- a/src/Contracts/OrderLineReader.php
+++ b/src/Contracts/OrderLineReader.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Read-side of the order-line repository contract.
+ *
+ * Pairs with {@see OrderLineWriter}.
+ */
+interface OrderLineReader
+{
+    /**
+     * List every line tracked locally for a given order.
+     *
+     * Drives {@see \Vatly\Fluent\OrderHandle::lines()}.
+     *
+     * @return OrderLineInterface[]
+     */
+    public function listForOrder(string $vatlyOrderId): array;
+
+    /**
+     * List every line that links to a given subscription — i.e. lines whose
+     * `productType === 'subscription'` and `productId === $subscriptionId`.
+     *
+     * Keeps the join/query concern in the driver's repository (mirroring
+     * {@see RefundReader::listForOrder()}); drivers index `(product_type,
+     * product_id)` to back this. Lets consumers reach the orders a
+     * subscription generated (initial + renewals) from local state.
+     *
+     * @return OrderLineInterface[]
+     */
+    public function listForSubscription(string $subscriptionId): array;
+}

--- a/src/Contracts/OrderLineRepositoryInterface.php
+++ b/src/Contracts/OrderLineRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+/**
+ * Full order-line repository — both read and write sides.
+ *
+ * Supplying this to {@see \Vatly\Fluent\Wiring} is optional: when present the
+ * built-in {@see \Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid} reaction
+ * persists each line carried on `order.paid`; when absent orders are still
+ * persisted (sans lines) and {@see \Vatly\Fluent\OrderHandle::lines()} returns
+ * an empty array — keeping existing drivers back-compatible.
+ */
+interface OrderLineRepositoryInterface extends OrderLineReader, OrderLineWriter
+{
+    //
+}

--- a/src/Contracts/OrderLineWriter.php
+++ b/src/Contracts/OrderLineWriter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Contracts;
+
+use Vatly\Fluent\Data\OrderLineData;
+
+/**
+ * Write-side of the order-line repository contract.
+ *
+ * Pairs with {@see OrderLineReader}.
+ *
+ * Order lines are immutable once an order is paid, so — unlike
+ * {@see RefundWriter} — there is no update path: the built-in
+ * {@see \Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid} reaction only
+ * stores lines when first persisting a new order.
+ */
+interface OrderLineWriter
+{
+    /**
+     * Store a new order line from Vatly.
+     *
+     * Returns `null` when the driver legitimately cannot route the store
+     * (e.g. it can't locate the parent order locally). Built-in reactions
+     * tolerate null.
+     */
+    public function store(OrderLineData $data, string $vatlyOrderId): ?OrderLineInterface;
+}

--- a/src/Data/OrderLineData.php
+++ b/src/Data/OrderLineData.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Data;
+
+use Vatly\API\Resources\OrderLine as ApiOrderLine;
+use Vatly\Fluent\Types\Money;
+use Vatly\Fluent\Types\TaxSummary;
+
+/**
+ * Data for a single order line from Vatly.
+ *
+ * Carries the per-line breakdown so drivers can persist first-class order
+ * lines and traverse subscription↔orders via the generic
+ * (`productType`, `productId`) pair. A line links to a subscription when
+ * `productType === 'subscription'` → `productId` is the `subscription_…` id.
+ *
+ * `productType` is carried as the raw API string (no fluent enum) so new
+ * backend product types flow through without a fluent release.
+ *
+ * @immutable
+ */
+class OrderLineData
+{
+    public function __construct(
+        public string $vatlyId,
+        public string $description,
+        public int $quantity,
+        public int $basePrice,
+        public int $total,
+        public int $subtotal,
+        public ?TaxSummary $taxSummary = null,
+        public ?string $productType = null,
+        public ?string $productId = null,
+    ) {}
+
+    public static function fromApiOrderLine(ApiOrderLine $line): self
+    {
+        return new self(
+            vatlyId: $line->id,
+            description: $line->description,
+            quantity: $line->quantity,
+            basePrice: Money::fromApiMoneyToCents($line->basePrice),
+            total: Money::fromApiMoneyToCents($line->total),
+            subtotal: Money::fromApiMoneyToCents($line->subtotal),
+            taxSummary: TaxSummary::fromApiResource($line->taxes),
+            productType: $line->productType,
+            productId: $line->productId,
+        );
+    }
+}

--- a/src/Data/StoreOrderData.php
+++ b/src/Data/StoreOrderData.php
@@ -26,5 +26,13 @@ class StoreOrderData
         public ?string $hostCustomerId = null,
         /** @var array<string, mixed>|null */
         public ?array $metadata = null,
+        /**
+         * The order's lines, persisted as first-class read entities. Defaults
+         * to empty for back-compat: drivers/reactions that don't carry lines
+         * keep working unchanged.
+         *
+         * @var OrderLineData[]
+         */
+        public array $lines = [],
     ) {}
 }

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Events;
 
 use Vatly\API\Resources\Order as ApiOrder;
 use Vatly\API\Types\WebhookEventName;
+use Vatly\Fluent\Data\OrderLineData;
 use Vatly\Fluent\Types\Money;
 use Vatly\Fluent\Types\TaxSummary;
 
@@ -34,6 +35,13 @@ class OrderPaid
         public ?string $paymentMethod,
         /** @var array<string, mixed>|null */
         public ?array $metadata = null,
+        /**
+         * The order's lines, mapped from the enriched API order. Empty for
+         * back-compat when an order carries none.
+         *
+         * @var OrderLineData[]
+         */
+        public array $lines = [],
     ) {
         //
     }
@@ -51,7 +59,28 @@ class OrderPaid
             invoiceNumber: $order->invoiceNumber,
             paymentMethod: $order->paymentMethod,
             metadata: self::normalizeMetadata($order->metadata),
+            lines: self::mapLines($order),
         );
+    }
+
+    /**
+     * Map the enriched API order's lines (the `OrderLineCollection` returned
+     * by `GetOrder`) into immutable {@see OrderLineData} DTOs.
+     *
+     * `productType`/`productId` are read straight off the API line (nullable as
+     * of api-php alpha.15) and carried as raw strings.
+     *
+     * @return OrderLineData[]
+     */
+    private static function mapLines(ApiOrder $order): array
+    {
+        $lines = [];
+
+        foreach ($order->lines() as $line) {
+            $lines[] = OrderLineData::fromApiOrderLine($line);
+        }
+
+        return $lines;
     }
 
     /**

--- a/src/OrderHandle.php
+++ b/src/OrderHandle.php
@@ -9,6 +9,8 @@ use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\ChargebackInterface;
 use Vatly\Fluent\Contracts\ChargebackReader;
 use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\OrderLineInterface;
+use Vatly\Fluent\Contracts\OrderLineReader;
 use Vatly\Fluent\Contracts\RefundInterface;
 use Vatly\Fluent\Contracts\RefundReader;
 use Vatly\Fluent\Types\Money;
@@ -41,6 +43,12 @@ class OrderHandle
          * empty array.
          */
         private readonly ?ChargebackReader $chargebacks = null,
+        /**
+         * Optional: supplied by {@see Vatly::order()} when an order-line
+         * repository is wired. Without it, {@see self::lines()} returns an empty
+         * array rather than reaching into driver internals.
+         */
+        private readonly ?OrderLineReader $orderLines = null,
     ) {
         //
     }
@@ -194,5 +202,20 @@ class OrderHandle
     public function chargebacks(): array
     {
         return $this->chargebacks?->listForOrder($this->order->getVatlyId()) ?? [];
+    }
+
+    /**
+     * The lines recorded locally for this order, per the driver's
+     * {@see OrderLineReader} implementation.
+     *
+     * Reads only local state (no API call). Returns an empty array when no
+     * order-line repository is wired, so callers can render line-item detail
+     * unconditionally without feature-detecting the wiring.
+     *
+     * @return OrderLineInterface[]
+     */
+    public function lines(): array
+    {
+        return $this->orderLines?->listForOrder($this->order->getVatlyId()) ?? [];
     }
 }

--- a/src/Vatly.php
+++ b/src/Vatly.php
@@ -251,6 +251,7 @@ class Vatly
             getOrderAction: $this->getOrder(),
             refunds: $this->wiring->refunds,
             chargebacks: $this->wiring->chargebacks,
+            orderLines: $this->wiring->orderLines,
         );
     }
 

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -67,6 +67,9 @@ class StoreOrderOnPaid implements WebhookReactionInterface
             taxSummary: $event->taxSummary,
             hostCustomerId: $hostCustomerId,
             metadata: $event->metadata,
+            // Lines are immutable once paid, so they're only written on the
+            // initial store — the update path above leaves existing lines as-is.
+            lines: $event->lines,
         ));
     }
 }

--- a/src/Wiring.php
+++ b/src/Wiring.php
@@ -8,6 +8,7 @@ use Vatly\Fluent\Contracts\ChargebackRepositoryInterface;
 use Vatly\Fluent\Contracts\ConfigurationInterface;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\EventDispatcherInterface;
+use Vatly\Fluent\Contracts\OrderLineRepositoryInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\Fluent\Contracts\RefundRepositoryInterface;
 use Vatly\Fluent\Contracts\SubscriptionRepositoryInterface;
@@ -36,6 +37,7 @@ final class Wiring
         public readonly ConfigurationInterface $config,
         public readonly ?SubscriptionRepositoryInterface $subscriptions = null,
         public readonly ?OrderRepositoryInterface $orders = null,
+        public readonly ?OrderLineRepositoryInterface $orderLines = null,
         public readonly ?RefundRepositoryInterface $refunds = null,
         public readonly ?ChargebackRepositoryInterface $chargebacks = null,
         public readonly ?WebhookCallRepositoryInterface $webhookCalls = null,

--- a/tests/Contracts/OrderLineInterfaceTest.php
+++ b/tests/Contracts/OrderLineInterfaceTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Contracts;
+
+use Vatly\Fluent\Contracts\OrderLineInterface;
+use Vatly\Fluent\Tests\TestCase;
+
+class OrderLineInterfaceTest extends TestCase
+{
+    public function test_it_can_be_implemented_and_used(): void
+    {
+        $line = $this->createMockLine();
+
+        $this->assertSame('order_item_123', $line->getVatlyId());
+        $this->assertSame('ord_456', $line->getOrderId());
+        $this->assertSame('Pro plan — monthly', $line->getDescription());
+        $this->assertSame(1, $line->getQuantity());
+        $this->assertSame(2000, $line->getBasePrice());
+        $this->assertSame(2420, $line->getTotal());
+        $this->assertSame(2000, $line->getSubtotal());
+        $this->assertSame('subscription', $line->getProductType());
+        $this->assertSame('subscription_abc', $line->getProductId());
+    }
+
+    public function test_product_fields_may_be_null(): void
+    {
+        $line = new class implements OrderLineInterface {
+            public function getVatlyId(): string
+            {
+                return 'order_item_legacy';
+            }
+
+            public function getOrderId(): string
+            {
+                return 'ord_456';
+            }
+
+            public function getDescription(): string
+            {
+                return 'Legacy line';
+            }
+
+            public function getQuantity(): int
+            {
+                return 1;
+            }
+
+            public function getBasePrice(): int
+            {
+                return 1000;
+            }
+
+            public function getTotal(): int
+            {
+                return 1000;
+            }
+
+            public function getSubtotal(): int
+            {
+                return 1000;
+            }
+
+            public function getProductType(): ?string
+            {
+                return null;
+            }
+
+            public function getProductId(): ?string
+            {
+                return null;
+            }
+        };
+
+        $this->assertNull($line->getProductType());
+        $this->assertNull($line->getProductId());
+    }
+
+    private function createMockLine(): OrderLineInterface
+    {
+        return new class implements OrderLineInterface {
+            public function getVatlyId(): string
+            {
+                return 'order_item_123';
+            }
+
+            public function getOrderId(): string
+            {
+                return 'ord_456';
+            }
+
+            public function getDescription(): string
+            {
+                return 'Pro plan — monthly';
+            }
+
+            public function getQuantity(): int
+            {
+                return 1;
+            }
+
+            public function getBasePrice(): int
+            {
+                return 2000;
+            }
+
+            public function getTotal(): int
+            {
+                return 2420;
+            }
+
+            public function getSubtotal(): int
+            {
+                return 2000;
+            }
+
+            public function getProductType(): ?string
+            {
+                return 'subscription';
+            }
+
+            public function getProductId(): ?string
+            {
+                return 'subscription_abc';
+            }
+        };
+    }
+}

--- a/tests/Contracts/OrderLineReaderTest.php
+++ b/tests/Contracts/OrderLineReaderTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Contracts;
+
+use Vatly\Fluent\Contracts\OrderLineInterface;
+use Vatly\Fluent\Contracts\OrderLineReader;
+use Vatly\Fluent\Tests\TestCase;
+
+/**
+ * Contract-level test for {@see OrderLineReader} semantics, using an in-memory
+ * repository double. `listForSubscription` is the load-bearing query: it
+ * returns lines whose `productType === 'subscription'` and
+ * `productId === $subscriptionId`, which is how a driver reaches the orders a
+ * subscription generated (initial + renewals).
+ */
+class OrderLineReaderTest extends TestCase
+{
+    public function test_list_for_order_returns_only_lines_of_that_order(): void
+    {
+        $reader = $this->makeReader([
+            $this->line('order_item_1', 'ord_1', 'subscription', 'subscription_a'),
+            $this->line('order_item_2', 'ord_1', 'one_off_product', 'product_x'),
+            $this->line('order_item_3', 'ord_2', 'subscription', 'subscription_a'),
+        ]);
+
+        $lines = $reader->listForOrder('ord_1');
+
+        $this->assertCount(2, $lines);
+        $this->assertSame(['order_item_1', 'order_item_2'], array_map(
+            fn (OrderLineInterface $l) => $l->getVatlyId(),
+            $lines,
+        ));
+    }
+
+    public function test_list_for_subscription_matches_product_type_and_id(): void
+    {
+        $reader = $this->makeReader([
+            // Renewal #1 for subscription_a.
+            $this->line('order_item_1', 'ord_1', 'subscription', 'subscription_a'),
+            // A non-subscription line that happens to share the id — must NOT match.
+            $this->line('order_item_2', 'ord_1', 'one_off_product', 'subscription_a'),
+            // Renewal #2 for subscription_a (different order).
+            $this->line('order_item_3', 'ord_2', 'subscription', 'subscription_a'),
+            // A different subscription — must NOT match.
+            $this->line('order_item_4', 'ord_3', 'subscription', 'subscription_b'),
+        ]);
+
+        $lines = $reader->listForSubscription('subscription_a');
+
+        $this->assertCount(2, $lines);
+        $this->assertSame(['order_item_1', 'order_item_3'], array_map(
+            fn (OrderLineInterface $l) => $l->getVatlyId(),
+            $lines,
+        ));
+    }
+
+    public function test_list_for_subscription_is_empty_when_nothing_matches(): void
+    {
+        $reader = $this->makeReader([
+            $this->line('order_item_1', 'ord_1', 'one_off_product', 'product_x'),
+        ]);
+
+        $this->assertSame([], $reader->listForSubscription('subscription_a'));
+    }
+
+    /**
+     * @param OrderLineInterface[] $lines
+     */
+    private function makeReader(array $lines): OrderLineReader
+    {
+        return new class($lines) implements OrderLineReader {
+            /**
+             * @param OrderLineInterface[] $lines
+             */
+            public function __construct(private array $lines) {}
+
+            public function listForOrder(string $vatlyOrderId): array
+            {
+                return array_values(array_filter(
+                    $this->lines,
+                    fn (OrderLineInterface $l) => $l->getOrderId() === $vatlyOrderId,
+                ));
+            }
+
+            public function listForSubscription(string $subscriptionId): array
+            {
+                return array_values(array_filter(
+                    $this->lines,
+                    fn (OrderLineInterface $l) => $l->getProductType() === 'subscription'
+                        && $l->getProductId() === $subscriptionId,
+                ));
+            }
+        };
+    }
+
+    private function line(string $id, string $orderId, ?string $productType, ?string $productId): OrderLineInterface
+    {
+        return new class($id, $orderId, $productType, $productId) implements OrderLineInterface {
+            public function __construct(
+                private string $id,
+                private string $orderId,
+                private ?string $productType,
+                private ?string $productId,
+            ) {}
+
+            public function getVatlyId(): string
+            {
+                return $this->id;
+            }
+
+            public function getOrderId(): string
+            {
+                return $this->orderId;
+            }
+
+            public function getDescription(): string
+            {
+                return 'Line '.$this->id;
+            }
+
+            public function getQuantity(): int
+            {
+                return 1;
+            }
+
+            public function getBasePrice(): int
+            {
+                return 1000;
+            }
+
+            public function getTotal(): int
+            {
+                return 1000;
+            }
+
+            public function getSubtotal(): int
+            {
+                return 1000;
+            }
+
+            public function getProductType(): ?string
+            {
+                return $this->productType;
+            }
+
+            public function getProductId(): ?string
+            {
+                return $this->productId;
+            }
+        };
+    }
+}

--- a/tests/Data/OrderLineDataTest.php
+++ b/tests/Data/OrderLineDataTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Tests\Data;
+
+use Mockery;
+use Vatly\API\Resources\OrderLine as ApiOrderLine;
+use Vatly\API\Types\Money;
+use Vatly\API\Types\TaxSummaryCollection;
+use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Data\OrderLineData;
+use Vatly\Fluent\Tests\TestCase;
+use Vatly\Fluent\Types\TaxSummary;
+
+class OrderLineDataTest extends TestCase
+{
+    public function test_it_can_be_instantiated_with_all_properties(): void
+    {
+        $taxSummary = TaxSummary::empty();
+
+        $data = new OrderLineData(
+            vatlyId: 'order_item_1',
+            description: 'PDF Book',
+            quantity: 2,
+            basePrice: 1000,
+            total: 2420,
+            subtotal: 2000,
+            taxSummary: $taxSummary,
+            productType: 'one_off_product',
+            productId: 'product_book',
+        );
+
+        $this->assertSame('order_item_1', $data->vatlyId);
+        $this->assertSame('PDF Book', $data->description);
+        $this->assertSame(2, $data->quantity);
+        $this->assertSame(1000, $data->basePrice);
+        $this->assertSame(2420, $data->total);
+        $this->assertSame(2000, $data->subtotal);
+        $this->assertSame($taxSummary, $data->taxSummary);
+        $this->assertSame('one_off_product', $data->productType);
+        $this->assertSame('product_book', $data->productId);
+    }
+
+    public function test_product_fields_and_tax_summary_default_to_null(): void
+    {
+        $data = new OrderLineData(
+            vatlyId: 'order_item_1',
+            description: 'Line',
+            quantity: 1,
+            basePrice: 1000,
+            total: 1000,
+            subtotal: 1000,
+        );
+
+        $this->assertNull($data->taxSummary);
+        $this->assertNull($data->productType);
+        $this->assertNull($data->productId);
+    }
+
+    public function test_it_builds_from_an_api_order_line_converting_money_to_cents(): void
+    {
+        $line = new ApiOrderLine(Mockery::mock(VatlyApiClient::class));
+        $line->id = 'order_item_sub';
+        $line->resource = 'orderline';
+        $line->description = 'Pro plan';
+        $line->quantity = 1;
+        $line->productType = 'subscription';
+        $line->productId = 'subscription_abc';
+        $line->basePrice = new Money('EUR', '20.00');
+        $line->total = new Money('EUR', '24.20');
+        $line->subtotal = new Money('EUR', '20.00');
+        $line->taxes = new TaxSummaryCollection([
+            [
+                'taxRate' => ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                'amount' => ['currency' => 'EUR', 'value' => '4.20'],
+            ],
+        ]);
+
+        $data = OrderLineData::fromApiOrderLine($line);
+
+        $this->assertSame('order_item_sub', $data->vatlyId);
+        $this->assertSame('Pro plan', $data->description);
+        $this->assertSame(1, $data->quantity);
+        $this->assertSame(2000, $data->basePrice);
+        $this->assertSame(2420, $data->total);
+        $this->assertSame(2000, $data->subtotal);
+        $this->assertSame('subscription', $data->productType);
+        $this->assertSame('subscription_abc', $data->productId);
+        $this->assertNotNull($data->taxSummary);
+        $this->assertCount(1, $data->taxSummary);
+        $this->assertSame(420, $data->taxSummary->items[0]->amount);
+        $this->assertSame('VAT', $data->taxSummary->items[0]->rate->name);
+    }
+
+    public function test_it_carries_null_product_fields_when_the_api_line_is_unattributed(): void
+    {
+        $line = new ApiOrderLine(Mockery::mock(VatlyApiClient::class));
+        $line->id = 'order_item_legacy';
+        $line->resource = 'orderline';
+        $line->description = 'Legacy line';
+        $line->quantity = 1;
+        $line->productType = null;
+        $line->productId = null;
+        $line->basePrice = new Money('EUR', '10.00');
+        $line->total = new Money('EUR', '10.00');
+        $line->subtotal = new Money('EUR', '10.00');
+        $line->taxes = new TaxSummaryCollection([]);
+
+        $data = OrderLineData::fromApiOrderLine($line);
+
+        $this->assertNull($data->productType);
+        $this->assertNull($data->productId);
+        $this->assertNotNull($data->taxSummary);
+        $this->assertCount(0, $data->taxSummary);
+    }
+}

--- a/tests/Events/OrderPaidTest.php
+++ b/tests/Events/OrderPaidTest.php
@@ -6,9 +6,11 @@ namespace Vatly\Fluent\Tests\Events;
 
 use Mockery;
 use Vatly\API\Resources\Order as ApiOrder;
+use Vatly\API\Resources\OrderLine as ApiOrderLine;
 use Vatly\API\Types\Money;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\VatlyApiClient;
+use Vatly\Fluent\Data\OrderLineData;
 use Vatly\Fluent\Events\OrderPaid;
 use Vatly\Fluent\Tests\TestCase;
 use Vatly\Fluent\Types\TaxSummary;
@@ -61,6 +63,7 @@ class OrderPaidTest extends TestCase
                 'amount' => ['currency' => 'USD', 'value' => '8.68'],
             ],
         ]);
+        $apiOrder->lines = [];
 
         $event = OrderPaid::fromApiOrder($apiOrder);
 
@@ -88,6 +91,7 @@ class OrderPaidTest extends TestCase
         $apiOrder->paymentMethod = null;
         $apiOrder->status = 'paid';
         $apiOrder->taxSummary = new TaxSummaryCollection([]);
+        $apiOrder->lines = [];
 
         $event = OrderPaid::fromApiOrder($apiOrder);
 
@@ -126,6 +130,92 @@ class OrderPaidTest extends TestCase
         $this->assertSame(['fluentcart_transaction_id' => 'tx_42'], $event->metadata);
     }
 
+    public function test_it_maps_api_order_lines_with_product_fields_and_money_to_cents(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->lines = [
+            $this->makeApiLine(
+                id: 'order_item_sub',
+                description: 'Pro plan — monthly',
+                quantity: 1,
+                basePrice: '20.00',
+                total: '24.20',
+                subtotal: '20.00',
+                productType: 'subscription',
+                productId: 'subscription_abc',
+            ),
+            $this->makeApiLine(
+                id: 'order_item_addon',
+                description: 'Seat add-on',
+                quantity: 3,
+                basePrice: '5.00',
+                total: '18.15',
+                subtotal: '15.00',
+                productType: 'one_off_product',
+                productId: 'product_seat',
+            ),
+        ];
+
+        $event = OrderPaid::fromApiOrder($apiOrder);
+
+        $this->assertCount(2, $event->lines);
+        $this->assertContainsOnlyInstancesOf(OrderLineData::class, $event->lines);
+
+        $sub = $event->lines[0];
+        $this->assertSame('order_item_sub', $sub->vatlyId);
+        $this->assertSame('Pro plan — monthly', $sub->description);
+        $this->assertSame(1, $sub->quantity);
+        $this->assertSame(2000, $sub->basePrice);
+        $this->assertSame(2420, $sub->total);
+        $this->assertSame(2000, $sub->subtotal);
+        $this->assertSame('subscription', $sub->productType);
+        $this->assertSame('subscription_abc', $sub->productId);
+        $this->assertCount(1, $sub->taxSummary);
+        $this->assertSame('VAT', $sub->taxSummary->items[0]->rate->name);
+
+        $addon = $event->lines[1];
+        $this->assertSame('order_item_addon', $addon->vatlyId);
+        $this->assertSame(3, $addon->quantity);
+        $this->assertSame(500, $addon->basePrice);
+        $this->assertSame(1815, $addon->total);
+        $this->assertSame(1500, $addon->subtotal);
+        $this->assertSame('one_off_product', $addon->productType);
+        $this->assertSame('product_seat', $addon->productId);
+    }
+
+    public function test_it_maps_a_line_with_null_product_attribution(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->lines = [
+            $this->makeApiLine(
+                id: 'order_item_unattributed',
+                description: 'Legacy line',
+                quantity: 1,
+                basePrice: '10.00',
+                total: '10.00',
+                subtotal: '10.00',
+                productType: null,
+                productId: null,
+            ),
+        ];
+
+        $event = OrderPaid::fromApiOrder($apiOrder);
+
+        $this->assertCount(1, $event->lines);
+        $this->assertNull($event->lines[0]->productType);
+        $this->assertNull($event->lines[0]->productId);
+    }
+
+    public function test_it_carries_an_empty_lines_array_when_the_order_has_no_lines(): void
+    {
+        $apiOrder = $this->makeApiOrder();
+        $apiOrder->lines = [];
+
+        $event = OrderPaid::fromApiOrder($apiOrder);
+
+        $this->assertSame([], $event->lines);
+    }
+
     private function makeApiOrder(): ApiOrder
     {
         $apiOrder = new ApiOrder(Mockery::mock(VatlyApiClient::class));
@@ -137,7 +227,42 @@ class OrderPaidTest extends TestCase
         $apiOrder->paymentMethod = null;
         $apiOrder->status = 'paid';
         $apiOrder->taxSummary = new TaxSummaryCollection([]);
+        $apiOrder->lines = [];
 
         return $apiOrder;
+    }
+
+    /**
+     * Build a raw API order-line, shaped as the decoded JSON object the
+     * api-php {@see ApiOrderLine} hydrates from (so `Order::lines()` rebuilds
+     * Money/TaxSummary value objects exactly as in production).
+     */
+    private function makeApiLine(
+        string $id,
+        string $description,
+        int $quantity,
+        string $basePrice,
+        string $total,
+        string $subtotal,
+        ?string $productType,
+        ?string $productId,
+    ): object {
+        return (object) [
+            'id' => $id,
+            'resource' => 'orderline',
+            'description' => $description,
+            'quantity' => $quantity,
+            'productType' => $productType,
+            'productId' => $productId,
+            'basePrice' => (object) ['currency' => 'EUR', 'value' => $basePrice],
+            'total' => (object) ['currency' => 'EUR', 'value' => $total],
+            'subtotal' => (object) ['currency' => 'EUR', 'value' => $subtotal],
+            'taxes' => [
+                (object) [
+                    'taxRate' => (object) ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0],
+                    'amount' => (object) ['currency' => 'EUR', 'value' => '4.20'],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/OrderHandleTest.php
+++ b/tests/OrderHandleTest.php
@@ -14,6 +14,8 @@ use Vatly\Fluent\Actions\GetOrder;
 use Vatly\Fluent\Contracts\ChargebackInterface;
 use Vatly\Fluent\Contracts\ChargebackReader;
 use Vatly\Fluent\Contracts\OrderInterface;
+use Vatly\Fluent\Contracts\OrderLineInterface;
+use Vatly\Fluent\Contracts\OrderLineReader;
 use Vatly\Fluent\Contracts\RefundInterface;
 use Vatly\Fluent\Contracts\RefundReader;
 use Vatly\Fluent\OrderHandle;
@@ -137,6 +139,38 @@ class OrderHandleTest extends TestCase
         );
 
         $this->assertSame([], $handle->chargebacks());
+    }
+
+    public function test_lines_returns_local_lines_for_the_order(): void
+    {
+        $lineA = Mockery::mock(OrderLineInterface::class);
+        $lineB = Mockery::mock(OrderLineInterface::class);
+
+        $reader = Mockery::mock(OrderLineReader::class);
+        $reader->shouldReceive('listForOrder')->with('order_abc')->once()->andReturn([$lineA, $lineB]);
+
+        $order = Mockery::mock(OrderInterface::class);
+        $order->shouldReceive('getVatlyId')->andReturn('order_abc');
+
+        $handle = new OrderHandle(
+            order: $order,
+            getOrderAction: Mockery::mock(GetOrder::class),
+            orderLines: $reader,
+        );
+
+        $this->assertSame([$lineA, $lineB], $handle->lines());
+    }
+
+    public function test_lines_is_empty_when_no_order_line_reader_is_wired(): void
+    {
+        $order = Mockery::mock(OrderInterface::class);
+
+        $handle = new OrderHandle(
+            order: $order,
+            getOrderAction: Mockery::mock(GetOrder::class),
+        );
+
+        $this->assertSame([], $handle->lines());
     }
 
     public function test_reversal_helpers_read_the_live_api_order(): void

--- a/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
@@ -8,6 +8,7 @@ use Mockery;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
 use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
+use Vatly\Fluent\Data\OrderLineData;
 use Vatly\Fluent\Data\StoreOrderData;
 use Vatly\Fluent\Data\UpdateOrderData;
 use Vatly\Fluent\Events\OrderPaid;
@@ -159,6 +160,61 @@ class StoreOrderOnPaidTest extends TestCase
         ))->andReturn($existing);
 
         (new StoreOrderOnPaid($updateRepo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
+    }
+
+    public function test_it_forwards_order_lines_into_store_order_data(): void
+    {
+        $lines = [
+            new OrderLineData(
+                vatlyId: 'order_item_sub',
+                description: 'Pro plan',
+                quantity: 1,
+                basePrice: 2000,
+                total: 2420,
+                subtotal: 2000,
+                taxSummary: TaxSummary::empty(),
+                productType: 'subscription',
+                productId: 'subscription_abc',
+            ),
+        ];
+
+        $event = new OrderPaid(
+            customerId: 'cus_1',
+            orderId: 'ord_1',
+            status: 'paid',
+            total: 9900,
+            subtotal: 8182,
+            taxSummary: TaxSummary::empty(),
+            currency: 'EUR',
+            invoiceNumber: 'INV-001',
+            paymentMethod: 'card',
+            lines: $lines,
+        );
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->with(Mockery::on(
+            fn (StoreOrderData $data) => $data->lines === $lines,
+        ))->andReturn(Mockery::mock(OrderInterface::class));
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->andReturn(null);
+        $bindings->shouldReceive('record')->once();
+
+        (new StoreOrderOnPaid($repo, $bindings))->handle($event);
+    }
+
+    public function test_it_does_not_re_write_lines_for_an_already_persisted_order(): void
+    {
+        $event = $this->makeEvent();
+
+        $existing = Mockery::mock(OrderInterface::class);
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturn($existing);
+        $repo->shouldReceive('update')->once()->andReturn($existing);
+        $repo->shouldNotReceive('store');
+
+        (new StoreOrderOnPaid($repo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
     }
 
     private function makeEvent(?TaxSummary $taxSummary = null): OrderPaid

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -461,6 +461,71 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('EUR', $event->taxSummary->items[0]->currency);
     }
 
+    public function test_order_paid_event_carries_mapped_order_lines_from_the_enriched_order(): void
+    {
+        $apiOrder = $this->buildApiOrder([
+            'id' => 'ord_123',
+            'customerId' => 'cus_456',
+            'total' => ['currency' => 'EUR', 'value' => '99.00'],
+            'subtotal' => ['currency' => 'EUR', 'value' => '81.82'],
+            'taxRates' => [
+                ['name' => 'VAT', 'percentage' => 21.0, 'taxablePercentage' => 100.0, 'amount' => '17.18'],
+            ],
+            'invoiceNumber' => 'INV-2024-001',
+            'paymentMethod' => 'credit_card',
+            'lines' => [
+                [
+                    'id' => 'order_item_sub',
+                    'description' => 'Pro plan',
+                    'quantity' => 1,
+                    'basePrice' => '20.00',
+                    'total' => '24.20',
+                    'subtotal' => '20.00',
+                    'productType' => 'subscription',
+                    'productId' => 'subscription_abc',
+                ],
+                [
+                    'id' => 'order_item_legacy',
+                    'description' => 'Unattributed line',
+                    'quantity' => 2,
+                    'basePrice' => '5.00',
+                    'total' => '12.10',
+                    'subtotal' => '10.00',
+                ],
+            ],
+        ]);
+
+        $this->getOrder->shouldReceive('execute')->once()->with('ord_123')->andReturn($apiOrder);
+
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_abc',
+            resource: 'webhook_event',
+            eventName: 'order.paid',
+            entityType: 'order',
+            entityId: 'ord_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['customerId' => 'cus_456'],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        $this->assertInstanceOf(OrderPaid::class, $event);
+        $this->assertCount(2, $event->lines);
+
+        $this->assertSame('order_item_sub', $event->lines[0]->vatlyId);
+        $this->assertSame(2000, $event->lines[0]->basePrice);
+        $this->assertSame(2420, $event->lines[0]->total);
+        $this->assertSame(2000, $event->lines[0]->subtotal);
+        $this->assertSame('subscription', $event->lines[0]->productType);
+        $this->assertSame('subscription_abc', $event->lines[0]->productId);
+
+        $this->assertSame('order_item_legacy', $event->lines[1]->vatlyId);
+        $this->assertSame(2, $event->lines[1]->quantity);
+        $this->assertNull($event->lines[1]->productType);
+        $this->assertNull($event->lines[1]->productId);
+    }
+
     public function test_it_creates_payment_failed_event_from_webhook_with_enriched_order(): void
     {
         $apiOrder = $this->buildApiOrder([
@@ -964,6 +1029,22 @@ class WebhookEventFactoryTest extends TestCase
             $data['taxRates'],
         );
         $order->taxSummary = new TaxSummaryCollection($taxItems);
+
+        $order->lines = array_map(
+            fn (array $line) => (object) [
+                'id' => $line['id'],
+                'resource' => 'orderline',
+                'description' => $line['description'],
+                'quantity' => $line['quantity'],
+                'productType' => $line['productType'] ?? null,
+                'productId' => $line['productId'] ?? null,
+                'basePrice' => (object) ['currency' => $data['total']['currency'], 'value' => $line['basePrice']],
+                'total' => (object) ['currency' => $data['total']['currency'], 'value' => $line['total']],
+                'subtotal' => (object) ['currency' => $data['total']['currency'], 'value' => $line['subtotal']],
+                'taxes' => [],
+            ],
+            $data['lines'] ?? [],
+        );
 
         return $order;
     }


### PR DESCRIPTION
Implements **Option A** from #81: persist each order line as a first-class read entity, mirroring the refund/chargeback surface. This lets drivers traverse subscription↔orders (renewals) and render line-item/invoice detail from local state. The order↔subscription link lives at the **line level** as a generic (`productType`, `productId`) pair — a line links to a subscription when `productType === 'subscription'` → `productId` is the `subscription_…` id.

This is **step 3** of the cross-repo sequence in #81 (backend → vatly-api-php → **fluent-php** → vatly-laravel). It consumes vatly-api-php **v0.1.0-alpha.15**, which adds nullable `productType`/`productId` to the `OrderLine` resource (fields stay null until the backend ships data).

## Surface added
- **`Data/OrderLineData`** — immutable DTO: `vatlyId`, `description`, `quantity:int`, `basePrice:int`, `total:int`, `subtotal:int` (all cents), `taxSummary:?TaxSummary`, `productType:?string`, `productId:?string`. Built from the API line via `Types\Money::fromApiMoneyToCents` (same helper the order code uses). `productType` is the **raw API string** (no fluent enum) — forward-compatible with new backend product types.
- **`StoreOrderData`** — adds `array $lines = []` (`OrderLineData[]`, last param, back-compat).
- **`OrderPaid`** event — carries `OrderLineData[]`, mapped from `apiOrder->lines()` in `fromApiOrder()`. The factory already enriches the order via `GetOrder`, so no extra API call.
- **`StoreOrderOnPaid`** — forwards `lines` into `StoreOrderData` on the initial store. Lines are immutable once paid, so the existing `update` path leaves them untouched (matching how the reaction already treats existing orders).
- **Contracts** — `OrderLineInterface` (getters incl. `getOrderId`, `getProductType`, `getProductId`), `OrderLineReader` (`listForOrder` + **`listForSubscription`**), `OrderLineWriter`, `OrderLineRepositoryInterface` — same reader/writer/repository split as refunds. `listForSubscription` keeps the join/query concern in the driver's repo.
- **`Wiring`** — optional `?OrderLineRepositoryInterface $orderLines` (nullable; existing drivers don't break).
- **`OrderHandle::lines()`** — reads via the optional reader, returns `[]` when unwired. Injected through `Vatly::order()` like `refunds`/`chargebacks`.

## Wiring through WebhookEventFactory
No factory signature change: `WebhookEventFactory::createOrderPaid()` already fetches the full API order via `GetOrder` (enriching total/subtotal/taxSummary). `OrderPaid::fromApiOrder()` now also iterates `apiOrder->lines()` (the `OrderLineCollection`) → `OrderLineData[]`, reading `$line->productType`/`$line->productId` (nullable as of api-php alpha.15).

## Dependency
- `vatly/vatly-api-php`: `^0.1.0-alpha.14` → **`^0.1.0-alpha.15`** (composer.lock is gitignored in this repo; constraint bumped in composer.json).

## Tests
Added/extended unit tests (faked API-order lines): DTO Money→cents + product-field propagation (incl. null), `OrderPaid` carrying mapped lines (direct + through the factory), `StoreOrderOnPaid` forwarding into `StoreOrderData` (and not re-writing on an existing order), `OrderHandle::lines()` wired/unwired, and contract-level `OrderLineReader` semantics for `listForOrder`/`listForSubscription`.

`vendor/bin/phpunit` → 320 tests, 1004 assertions, green. `composer analyse` (PHPStan, level per phpstan.neon) → no errors.

Closes #81