### PR TITLE
feat: adopt order.payment_failed rename + add OrderWasCreatedFromWebhook & WebhookSetupReceived

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ A driver is a thin glue package (e.g. `vatly-laravel`) that supplies fluent with
 
 For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in reaction that calls back into your repos. A driver author only needs to implement the repo methods — the wiring is fixed. For the full event → reaction → repo-method matrix **including the fields each `Store*Data` / event carries**, see [docs/webhook-flow.md](docs/webhook-flow.md).
 
-> The typed webhook event DTOs (`OrderPaid`, `PaymentFailed`, `SubscriptionStarted`, …) live in **`vatly-api-php`** under the `Vatly\API\Webhooks\Events\*` namespace and are consumed by fluent — fluent no longer ships its own copies. Import them from `Vatly\API\Webhooks\Events\…` when you handle dispatched events. Fluent still owns the orchestration (`WebhookEventFactory`, the reactions, `WebhookProcessor`) plus the internal `Vatly\Fluent\Events\{SubscriptionWasCreatedFromWebhook,NullEventDispatcher}`.
+> The typed webhook event DTOs (`OrderPaid`, `OrderPaymentFailed`, `SubscriptionStarted`, …) live in **`vatly-api-php`** under the `Vatly\API\Webhooks\Events\*` namespace and are consumed by fluent — fluent no longer ships its own copies. Import them from `Vatly\API\Webhooks\Events\…` when you handle dispatched events. Fluent still owns the orchestration (`WebhookEventFactory`, the reactions, `WebhookProcessor`) plus the driver-side `Vatly\Fluent\Events\{SubscriptionWasCreatedFromWebhook,OrderWasCreatedFromWebhook,NullEventDispatcher}`.
 
 | Vatly event              | Dispatched event class                                            | Built-in reaction              | Repo method(s) called                                |
 |--------------------------|-------------------------------------------------------------------|--------------------------------|------------------------------------------------------|
-| `order.paid`             | `OrderPaid`                                                       | `StoreOrderOnPaid`             | `OrderWriter::store` (new) / `OrderWriter::update` (existing) |
+| `order.paid`             | `OrderPaid`                                                       | `StoreOrderOnPaid`             | `OrderWriter::store` (new, then dispatches `OrderWasCreatedFromWebhook`) / `OrderWriter::update` (existing) |
+| `order.payment_failed`   | `OrderPaymentFailed`                                              | `StoreOrderOnPaymentFailed`    | `OrderWriter::store` (new) / `OrderWriter::update` (existing); mirrors upstream status (typically `pending` during dunning) |
 | `order.canceled`         | `OrderCanceled`                                                   | `CancelOrderOnCanceled`        | `OrderWriter::update` (mirrors `canceled` status)    |
 | `order.chargeback_received` | `OrderChargebackReceived`                                   | `SyncChargebackOnStatusChange` *(opt-in, persistence)* | `ChargebackWriter::store` (new) |
 | `order.chargeback_reversed` | `OrderChargebackReversed`                                   | `SyncChargebackOnStatusChange` *(opt-in, persistence)* | `ChargebackWriter::update` (existing) |
@@ -114,8 +115,9 @@ For incoming Vatly webhooks, fluent dispatches a typed event and runs a built-in
 | `subscription.canceled`  | `SubscriptionCanceledImmediately` / `SubscriptionCanceledWithGracePeriod` | `CancelSubscriptionOnCanceled` | `SubscriptionWriter::update`                         |
 | `subscription.cancellation_grace_period_completed` | `SubscriptionCancellationGracePeriodCompleted` | `EndSubscriptionOnGracePeriodCompleted` | `SubscriptionWriter::update` (stamps actual end date) |
 | `checkout.paid` / `checkout.failed` / `checkout.canceled` / `checkout.expired` | `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` | — (dispatched only) | none — driver-handled |
+| `webhook.setup`          | `WebhookSetupReceived`                                            | — (dispatched only)            | none — endpoint verification ping; acknowledge with `2xx` |
 
-`OrderWriter::store`, `SubscriptionWriter::store`, and `RefundWriter::store` may return `null` if your driver can't route the data (see the adapter recipe below). Built-in reactions tolerate null — `SyncSubscriptionOnStarted` skips its follow-up `SubscriptionWasCreatedFromWebhook` dispatch when store returns null.
+`OrderWriter::store`, `SubscriptionWriter::store`, and `RefundWriter::store` may return `null` if your driver can't route the data (see the adapter recipe below). Built-in reactions tolerate null — `SyncSubscriptionOnStarted` skips its follow-up `SubscriptionWasCreatedFromWebhook` dispatch (and `StoreOrderOnPaid` its `OrderWasCreatedFromWebhook` dispatch) when store returns null. Both driver-side events fire exactly once per brand-new local row (not on the update path).
 
 `subscription.billing_updated`, `subscription.resumed`, and `order.canceled` are find-or-skip: they update an existing local record but never create one. `subscription.billing_updated` re-fetches the subscription to keep the stored mandate (card last-4, masked IBAN) in step with the payment method on file; `subscription.resumed` clears the stored end date so a resume reactivates the derived state; `order.canceled` mirrors Vatly's `canceled` status onto the local order.
 
@@ -604,6 +606,7 @@ Dispatched by webhook reactions through your `EventDispatcherInterface`. Subscri
 
 - `WebhookReceived` — raw webhook envelope (typed shape; `object` is the resource payload)
 - `OrderPaid` — order with full `taxSummary` breakdown, ready to materialize local invoices
+- `OrderPaymentFailed` — failed payment attempt (typically the start of dunning); carries the full order shape, mirroring `OrderPaid`
 - `OrderCanceled`
 - `OrderChargebackReceived` / `OrderChargebackReversed` — dispute signals carrying the affected `orderId`
 - `RefundCompleted` / `RefundFailed` / `RefundCanceled` — each with full `taxSummary` breakdown
@@ -612,8 +615,15 @@ Dispatched by webhook reactions through your `EventDispatcherInterface`. Subscri
 - `SubscriptionResumed`
 - `SubscriptionCanceledImmediately`
 - `SubscriptionCanceledWithGracePeriod`
-- `SubscriptionWasCreatedFromWebhook`
+- `SubscriptionCancellationGracePeriodCompleted`
+- `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired`
+- `WebhookSetupReceived` — endpoint verification ping (`webhook.setup`); dispatched-only, acknowledge with `2xx`
 - `UnsupportedWebhookReceived`
+
+Driver-side events (namespace `Vatly\Fluent\Events`, carrying the freshly persisted local record — fired exactly once per brand-new row):
+
+- `SubscriptionWasCreatedFromWebhook` — dispatched by `SyncSubscriptionOnStarted` on a brand-new subscription
+- `OrderWasCreatedFromWebhook` — dispatched by `StoreOrderOnPaid` on a brand-new order
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vatly/vatly-api-php": "^0.1.0-alpha.16"
+        "vatly/vatly-api-php": "^0.1.0-alpha.17"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",

--- a/docs/webhook-flow.md
+++ b/docs/webhook-flow.md
@@ -2,7 +2,7 @@
 
 A driver author shouldn't have to read four directories (the event DTOs in `vatly-api-php`'s `Vatly\API\Webhooks\Events\*`, `src/Webhooks/Reactions/`, `WebhookEventFactory`, `src/Contracts/`) to answer *"if I implement `OrderWriter::store`, which webhooks flow into it and with what data?"* This page is that single reference.
 
-> **Where the event DTOs live:** the typed webhook events (`OrderPaid`, `PaymentFailed`, `SubscriptionStarted`, …) are owned by **`vatly-api-php`** under `Vatly\API\Webhooks\Events\*` and consumed by fluent — fluent no longer ships its own `src/Events/` copies (only the internal `SubscriptionWasCreatedFromWebhook` / `NullEventDispatcher` remain in `Vatly\Fluent\Events\`). Their `taxSummary` field is a `Vatly\API\Types\TaxSummaryCollection` whose items expose `taxRate` (a `TaxSummaryRate`) + `amount` (a `Money`); call `$item->amount->toCents()` for integer cents. Order lines are `Vatly\API\Data\OrderLineData[]`. The orchestration (`WebhookEventFactory`, the reactions, `WebhookProcessor`) stays in fluent.
+> **Where the event DTOs live:** the typed webhook events (`OrderPaid`, `OrderPaymentFailed`, `SubscriptionStarted`, …) are owned by **`vatly-api-php`** under `Vatly\API\Webhooks\Events\*` and consumed by fluent — fluent no longer ships its own `src/Events/` copies (only the driver-side `SubscriptionWasCreatedFromWebhook` / `OrderWasCreatedFromWebhook` / `NullEventDispatcher` remain in `Vatly\Fluent\Events\`). Their `taxSummary` field is a `Vatly\API\Types\TaxSummaryCollection` whose items expose `taxRate` (a `TaxSummaryRate`) + `amount` (a `Money`); call `$item->amount->toCents()` for integer cents. Order lines are `Vatly\API\Data\OrderLineData[]`. The orchestration (`WebhookEventFactory`, the reactions, `WebhookProcessor`) stays in fluent.
 
 The [README's "Webhook pipeline at a glance"](../README.md#webhook-pipeline-at-a-glance) table is the quick version; this one adds the **fields drivers care about** column so you know exactly what each `Store*Data` / event carries.
 
@@ -10,7 +10,7 @@ The [README's "Webhook pipeline at a glance"](../README.md#webhook-pipeline-at-a
 
 Some events are built straight from the webhook payload; others are **enriched** with a follow-up API GET before dispatch, because the raw webhook is sparse (gross total only — no subtotal/tax breakdown). Enrichment matters because it determines whether a transient API error can block the delivery:
 
-- **`order.paid`, `payment.failed`, `refund.*`** — enriched via `GetOrder` / `GetRefund`. Tax data is compliance-critical, so these **rethrow** on enrichment failure (Vatly retries the delivery) rather than persist a degraded row.
+- **`order.paid`, `order.payment_failed`, `refund.*`** — enriched via `GetOrder` / `GetRefund`. Tax data is compliance-critical, so these **rethrow** on enrichment failure (Vatly retries the delivery) rather than persist a degraded row.
 - **`subscription.started`, `subscription.billing_updated`** — enriched via `GetSubscription` for the mandate summary, but **fall back** to the webhook payload (which embeds the mandate) on failure — enrichment here is non-lossy.
 - **`order.chargeback_*`** — enriched via `GetChargeback` when that action is wired (customer id, dispute status, tax breakdown), but **fall back** to the sparse payload otherwise — best-effort.
 - **`order.canceled`, `checkout.*`, `subscription.cancellation_grace_period_completed`** — built straight from the payload; no GET needed.
@@ -21,7 +21,8 @@ Refund events are only enriched (and thus only reported as supported) when a `Ge
 
 | Vatly event | Typed event | Built-in reaction | Repo method called | Fields drivers care about |
 | --- | --- | --- | --- | --- |
-| `order.paid` | `OrderPaid` | `StoreOrderOnPaid` | `OrderWriter::store(StoreOrderData)` if `findByVatlyId` is null, else `OrderWriter::update(…, UpdateOrderData)` | `hostCustomerId` (pre-resolved via binding repo), `customerId`, `total`, `subtotal`, `currency`, `invoiceNumber`, `paymentMethod`, `taxSummary`, `metadata` |
+| `order.paid` | `OrderPaid` | `StoreOrderOnPaid` | `OrderWriter::store(StoreOrderData)` if `findByVatlyId` is null (then dispatches `OrderWasCreatedFromWebhook`, skipped if store returns null), else `OrderWriter::update(…, UpdateOrderData)` | `hostCustomerId` (pre-resolved via binding repo), `customerId`, `total`, `subtotal`, `currency`, `invoiceNumber`, `paymentMethod`, `taxSummary`, `metadata`, `lines` |
+| `order.payment_failed` | `OrderPaymentFailed` | `StoreOrderOnPaymentFailed` | `OrderWriter::store(StoreOrderData)` if new, else `OrderWriter::update(…, UpdateOrderData)` | same as `order.paid` (sans `lines`); persists whatever status the enriched order carries (typically `pending` during dunning) — mirrors, never synthesises a `failed` status |
 | `order.canceled` | `OrderCanceled` | `CancelOrderOnCanceled` | `OrderWriter::update(…, UpdateOrderData{status})` | `status` (== `canceled`) — find-or-skip, never creates |
 | `refund.completed` / `refund.failed` / `refund.canceled` | `RefundCompleted` / `RefundFailed` / `RefundCanceled` | `SyncRefundOnStatusChange` *(opt-in: needs `RefundRepositoryInterface`)* | `RefundWriter::store(StoreRefundData)` if new, else `RefundWriter::update(…, UpdateRefundData)` | `refundId`, `originalOrderId`, `customerId`, `hostCustomerId`, `status`, `total`, `subtotal`, `currency`, `taxSummary` |
 | `subscription.started` | `SubscriptionStarted` | `SyncSubscriptionOnStarted` | `SubscriptionWriter::store(StoreSubscriptionData)` then dispatches `SubscriptionWasCreatedFromWebhook` (skipped if store returns null) | `hostCustomerId`, `customerId`, `planId`, `name`, `quantity`, `type`, `mandate` |
@@ -32,6 +33,7 @@ Refund events are only enriched (and thus only reported as supported) when a `Ge
 | `subscription.cancellation_grace_period_completed` | `SubscriptionCancellationGracePeriodCompleted` | `EndSubscriptionOnGracePeriodCompleted` | `SubscriptionWriter::update(…, UpdateSubscriptionData{endsAt})` | `endsAt` (actual end; self-heals a missed/out-of-order cancel webhook) |
 | `order.chargeback_received` / `order.chargeback_reversed` | `OrderChargebackReceived` / `OrderChargebackReversed` | `SyncChargebackOnStatusChange` *(opt-in: needs `ChargebackRepositoryInterface`)* | `ChargebackWriter::store(StoreChargebackData)` if new, else `ChargebackWriter::update(…, UpdateChargebackData)` | `chargebackId`, `originalOrderId`, `customerId`, `hostCustomerId`, `status`, `total`, `subtotal`, `currency`, `taxSummary`, `reason` |
 | `checkout.paid` / `checkout.failed` / `checkout.canceled` / `checkout.expired` | `CheckoutPaid` / `CheckoutFailed` / `CheckoutCanceled` / `CheckoutExpired` | — *(dispatched only)* | none — driver-handled | `checkoutId`, `customerId` (nullable for anonymous), `orderId`, `status`, `metadata` |
+| `webhook.setup` | `WebhookSetupReceived` | — *(dispatched only)* | none — endpoint verification ping; acknowledge with `2xx` | raw `WebhookReceived` envelope (`object` is the secret-free endpoint config) |
 | *(any unmapped event)* | `UnsupportedWebhookReceived` | — | none | raw `WebhookReceived` envelope |
 
 ## Reading the matrix

--- a/src/Events/OrderWasCreatedFromWebhook.php
+++ b/src/Events/OrderWasCreatedFromWebhook.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vatly\Fluent\Events;
+
+use Vatly\Fluent\Contracts\OrderInterface;
+
+/**
+ * Event dispatched when a new local order record is created from an
+ * `order.paid` webhook.
+ *
+ * This is a driver-side domain event (vs the raw webhook event DTOs from
+ * Vatly). It carries the freshly persisted local `OrderInterface` and fires
+ * exactly once per brand-new order row.
+ *
+ * @immutable
+ */
+class OrderWasCreatedFromWebhook
+{
+    public function __construct(
+        public OrderInterface $order,
+    ) {
+        //
+    }
+}

--- a/src/Webhooks/Reactions/StoreOrderOnPaid.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaid.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Vatly\Fluent\Webhooks\Reactions;
 
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\Fluent\Data\StoreOrderData;
 use Vatly\Fluent\Data\UpdateOrderData;
+use Vatly\Fluent\Events\OrderWasCreatedFromWebhook;
 use Vatly\API\Webhooks\Events\OrderPaid;
 
 /**
@@ -19,6 +21,7 @@ class StoreOrderOnPaid implements WebhookReactionInterface
     public function __construct(
         private OrderRepositoryInterface $orders,
         private CustomerBindingRepository $bindings,
+        private EventDispatcherInterface $dispatcher,
     ) {}
 
     public function supports(object $event): bool
@@ -55,7 +58,7 @@ class StoreOrderOnPaid implements WebhookReactionInterface
             $this->bindings->record($event->customerId);
         }
 
-        $this->orders->store(new StoreOrderData(
+        $order = $this->orders->store(new StoreOrderData(
             vatlyId: $event->orderId,
             customerId: $event->customerId,
             status: $event->status,
@@ -71,5 +74,15 @@ class StoreOrderOnPaid implements WebhookReactionInterface
             // initial store — the update path above leaves existing lines as-is.
             lines: $event->lines,
         ));
+
+        // Driver may legitimately decline to persist (store() returns null) —
+        // only announce the local order when a row was actually created. This
+        // fires exactly once per brand-new order (not on the update path above),
+        // mirroring SyncSubscriptionOnStarted.
+        if ($order === null) {
+            return;
+        }
+
+        $this->dispatcher->dispatch(new OrderWasCreatedFromWebhook($order));
     }
 }

--- a/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
+++ b/src/Webhooks/Reactions/StoreOrderOnPaymentFailed.php
@@ -9,11 +9,11 @@ use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\Fluent\Data\StoreOrderData;
 use Vatly\Fluent\Data\UpdateOrderData;
-use Vatly\API\Webhooks\Events\PaymentFailed;
+use Vatly\API\Webhooks\Events\OrderPaymentFailed;
 
 /**
  * Mirrors {@see StoreOrderOnPaid}: ensures the local order row reflects the
- * upstream order state after a `payment.failed` webhook. The persisted status
+ * upstream order state after an `order.payment_failed` webhook. The persisted status
  * is whatever Vatly's enriched Order resource currently reports (typically
  * `pending` during dunning) — we deliberately don't synthesise a
  * driver-specific status like `'failed'`, so `OrderInterface::getStatus()`
@@ -30,12 +30,12 @@ class StoreOrderOnPaymentFailed implements WebhookReactionInterface
 
     public function supports(object $event): bool
     {
-        return $event instanceof PaymentFailed;
+        return $event instanceof OrderPaymentFailed;
     }
 
     public function handle(object $event): void
     {
-        /** @var PaymentFailed $event */
+        /** @var OrderPaymentFailed $event */
         $existing = $this->orders->findByVatlyId($event->orderId);
 
         if ($existing !== null) {

--- a/src/Webhooks/WebhookEventFactory.php
+++ b/src/Webhooks/WebhookEventFactory.php
@@ -17,7 +17,7 @@ use Vatly\API\Webhooks\Events\OrderCanceled;
 use Vatly\API\Webhooks\Events\OrderChargebackReceived;
 use Vatly\API\Webhooks\Events\OrderChargebackReversed;
 use Vatly\API\Webhooks\Events\OrderPaid;
-use Vatly\API\Webhooks\Events\PaymentFailed;
+use Vatly\API\Webhooks\Events\OrderPaymentFailed;
 use Vatly\API\Webhooks\Events\RefundCanceled;
 use Vatly\API\Webhooks\Events\RefundCompleted;
 use Vatly\API\Webhooks\Events\RefundFailed;
@@ -29,6 +29,7 @@ use Vatly\API\Webhooks\Events\SubscriptionResumed;
 use Vatly\API\Webhooks\Events\SubscriptionStarted;
 use Vatly\API\Webhooks\Events\UnsupportedWebhookReceived;
 use Vatly\API\Webhooks\Events\WebhookReceived;
+use Vatly\API\Webhooks\Events\WebhookSetupReceived;
 
 class WebhookEventFactory
 {
@@ -55,7 +56,7 @@ class WebhookEventFactory
     /**
      * Create a typed event from a raw webhook.
      *
-     * For order-scoped events (`order.paid`, `payment.failed`) the factory
+     * For order-scoped events (`order.paid`, `order.payment_failed`) the factory
      * performs a follow-up API GET so the dispatched event carries the full
      * tax breakdown — webhook payloads themselves only include gross total.
      *
@@ -84,7 +85,7 @@ class WebhookEventFactory
      * and end timestamp, all present on the wire. They are dispatched-only — no
      * built-in reaction mutates local state.
      *
-     * @return SubscriptionStarted|SubscriptionBillingUpdated|SubscriptionResumed|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|SubscriptionCancellationGracePeriodCompleted|OrderPaid|OrderCanceled|OrderChargebackReceived|OrderChargebackReversed|PaymentFailed|CheckoutPaid|CheckoutFailed|CheckoutCanceled|CheckoutExpired|RefundCompleted|RefundFailed|RefundCanceled|UnsupportedWebhookReceived
+     * @return SubscriptionStarted|SubscriptionBillingUpdated|SubscriptionResumed|SubscriptionCanceledImmediately|SubscriptionCanceledWithGracePeriod|SubscriptionCancellationGracePeriodCompleted|OrderPaid|OrderCanceled|OrderChargebackReceived|OrderChargebackReversed|OrderPaymentFailed|CheckoutPaid|CheckoutFailed|CheckoutCanceled|CheckoutExpired|RefundCompleted|RefundFailed|RefundCanceled|WebhookSetupReceived|UnsupportedWebhookReceived
      */
     public function createFromWebhook(WebhookReceived $webhook): object
     {
@@ -99,7 +100,7 @@ class WebhookEventFactory
             OrderCanceled::VATLY_EVENT_NAME => OrderCanceled::fromWebhook($webhook),
             OrderChargebackReceived::VATLY_EVENT_NAME => $this->createOrderChargebackReceived($webhook),
             OrderChargebackReversed::VATLY_EVENT_NAME => $this->createOrderChargebackReversed($webhook),
-            PaymentFailed::VATLY_EVENT_NAME => $this->createPaymentFailed($webhook),
+            OrderPaymentFailed::VATLY_EVENT_NAME => $this->createOrderPaymentFailed($webhook),
             CheckoutPaid::VATLY_EVENT_NAME => CheckoutPaid::fromWebhook($webhook),
             CheckoutFailed::VATLY_EVENT_NAME => CheckoutFailed::fromWebhook($webhook),
             CheckoutCanceled::VATLY_EVENT_NAME => CheckoutCanceled::fromWebhook($webhook),
@@ -113,6 +114,7 @@ class WebhookEventFactory
             RefundCanceled::VATLY_EVENT_NAME => $this->getRefund !== null
                 ? RefundCanceled::fromApiRefund($this->getRefund->execute($webhook->entityId))
                 : UnsupportedWebhookReceived::fromWebhook($webhook),
+            WebhookSetupReceived::VATLY_EVENT_NAME => WebhookSetupReceived::fromWebhook($webhook),
             default => UnsupportedWebhookReceived::fromWebhook($webhook),
         };
     }
@@ -222,15 +224,15 @@ class WebhookEventFactory
     }
 
     /**
-     * Build a PaymentFailed event from the enriched API resource.
+     * Build an OrderPaymentFailed event from the enriched API resource.
      *
      * Same rationale as {@see self::createOrderPaid()}: rethrows on enrichment
      * failure rather than writing a degraded row. Tax breakdown is critical
      * for dunning-notification accuracy and downstream reconciliation.
      */
-    private function createPaymentFailed(WebhookReceived $webhook): PaymentFailed
+    private function createOrderPaymentFailed(WebhookReceived $webhook): OrderPaymentFailed
     {
-        return PaymentFailed::fromApiOrder($this->getOrder->execute($webhook->entityId));
+        return OrderPaymentFailed::fromApiOrder($this->getOrder->execute($webhook->entityId));
     }
 
     /**
@@ -274,11 +276,12 @@ class WebhookEventFactory
             OrderCanceled::VATLY_EVENT_NAME,
             OrderChargebackReceived::VATLY_EVENT_NAME,
             OrderChargebackReversed::VATLY_EVENT_NAME,
-            PaymentFailed::VATLY_EVENT_NAME,
+            OrderPaymentFailed::VATLY_EVENT_NAME,
             CheckoutPaid::VATLY_EVENT_NAME,
             CheckoutFailed::VATLY_EVENT_NAME,
             CheckoutCanceled::VATLY_EVENT_NAME,
             CheckoutExpired::VATLY_EVENT_NAME,
+            WebhookSetupReceived::VATLY_EVENT_NAME,
         ];
 
         // Refund events require `GetRefund` enrichment; only report them as

--- a/src/Webhooks/WebhookProcessorFactory.php
+++ b/src/Webhooks/WebhookProcessorFactory.php
@@ -73,7 +73,7 @@ class WebhookProcessorFactory
             new ResumeSubscriptionOnResumed($subscriptions),
             new CancelSubscriptionOnCanceled($subscriptions),
             new EndSubscriptionOnGracePeriodCompleted($subscriptions),
-            new StoreOrderOnPaid($orders, $bindings),
+            new StoreOrderOnPaid($orders, $bindings, $dispatcher),
             new StoreOrderOnPaymentFailed($orders, $bindings),
             new CancelOrderOnCanceled($orders),
         ];

--- a/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaidTest.php
@@ -6,6 +6,7 @@ namespace Vatly\Fluent\Tests\Webhooks\Reactions;
 
 use Mockery;
 use Vatly\Fluent\Contracts\CustomerBindingRepository;
+use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\API\Data\OrderLineData;
@@ -14,6 +15,7 @@ use Vatly\API\Webhooks\Events\OrderPaid;
 use Vatly\API\Webhooks\Events\SubscriptionStarted;
 use Vatly\Fluent\Data\StoreOrderData;
 use Vatly\Fluent\Data\UpdateOrderData;
+use Vatly\Fluent\Events\OrderWasCreatedFromWebhook;
 use Vatly\Fluent\Tests\TestCase;
 use Vatly\Fluent\Webhooks\Reactions\StoreOrderOnPaid;
 
@@ -24,6 +26,7 @@ class StoreOrderOnPaidTest extends TestCase
         $reaction = new StoreOrderOnPaid(
             Mockery::mock(OrderRepositoryInterface::class),
             Mockery::mock(CustomerBindingRepository::class),
+            Mockery::mock(EventDispatcherInterface::class),
         );
 
         $this->assertTrue($reaction->supports($this->makeEvent()));
@@ -34,6 +37,7 @@ class StoreOrderOnPaidTest extends TestCase
         $reaction = new StoreOrderOnPaid(
             Mockery::mock(OrderRepositoryInterface::class),
             Mockery::mock(CustomerBindingRepository::class),
+            Mockery::mock(EventDispatcherInterface::class),
         );
 
         $event = new SubscriptionStarted('cus_1', 'sub_1', 'plan_1', 'default', 'Monthly', 1);
@@ -46,6 +50,7 @@ class StoreOrderOnPaidTest extends TestCase
         $taxSummary = $this->makeTaxSummary();
         $event = $this->makeEvent(taxSummary: $taxSummary);
 
+        $order = Mockery::mock(OrderInterface::class);
         $repo = Mockery::mock(OrderRepositoryInterface::class);
         $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
         $repo->shouldReceive('store')->once()->with(Mockery::on(function (StoreOrderData $data) use ($taxSummary) {
@@ -59,17 +64,23 @@ class StoreOrderOnPaidTest extends TestCase
                 && $data->invoiceNumber === 'INV-001'
                 && $data->paymentMethod === 'card'
                 && $data->hostCustomerId === 'host_7';
-        }))->andReturn(Mockery::mock(OrderInterface::class));
+        }))->andReturn($order);
 
         $bindings = Mockery::mock(CustomerBindingRepository::class);
         $bindings->shouldReceive('hostCustomerIdFor')->with('cus_1')->once()->andReturn('host_7');
         $bindings->shouldReceive('record')->with('cus_1')->once();
 
-        $reaction = new StoreOrderOnPaid($repo, $bindings);
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldReceive('dispatch')->once()->with(Mockery::on(function ($event) use ($order) {
+            return $event instanceof OrderWasCreatedFromWebhook
+                && $event->order === $order;
+        }));
+
+        $reaction = new StoreOrderOnPaid($repo, $bindings, $dispatcher);
         $reaction->handle($event);
     }
 
-    public function test_it_updates_an_existing_order_without_consulting_bindings(): void
+    public function test_it_updates_an_existing_order_without_consulting_bindings_or_dispatching(): void
     {
         $taxSummary = $this->makeTaxSummary();
         $event = $this->makeEvent(taxSummary: $taxSummary);
@@ -89,7 +100,29 @@ class StoreOrderOnPaidTest extends TestCase
         $bindings->shouldNotReceive('hostCustomerIdFor');
         $bindings->shouldNotReceive('record');
 
-        $reaction = new StoreOrderOnPaid($repo, $bindings);
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        $reaction = new StoreOrderOnPaid($repo, $bindings, $dispatcher);
+        $reaction->handle($event);
+    }
+
+    public function test_it_does_not_dispatch_order_created_when_store_returns_null(): void
+    {
+        $event = $this->makeEvent();
+
+        $repo = Mockery::mock(OrderRepositoryInterface::class);
+        $repo->shouldReceive('findByVatlyId')->with('ord_1')->once()->andReturnNull();
+        $repo->shouldReceive('store')->once()->andReturnNull();
+
+        $bindings = Mockery::mock(CustomerBindingRepository::class);
+        $bindings->shouldReceive('hostCustomerIdFor')->with('cus_1')->once()->andReturnNull();
+        $bindings->shouldReceive('record')->with('cus_1')->once();
+
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        $reaction = new StoreOrderOnPaid($repo, $bindings, $dispatcher);
         $reaction->handle($event);
     }
 
@@ -119,7 +152,10 @@ class StoreOrderOnPaidTest extends TestCase
         $bindings->shouldNotReceive('hostCustomerIdFor');
         $bindings->shouldNotReceive('record');
 
-        (new StoreOrderOnPaid($repo, $bindings))->handle($event);
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldReceive('dispatch')->once();
+
+        (new StoreOrderOnPaid($repo, $bindings, $dispatcher))->handle($event);
     }
 
     public function test_it_plumbs_metadata_through_store_and_update_paths(): void
@@ -148,7 +184,10 @@ class StoreOrderOnPaidTest extends TestCase
         $bindings->shouldReceive('hostCustomerIdFor')->andReturn(null);
         $bindings->shouldReceive('record')->once();
 
-        (new StoreOrderOnPaid($repo, $bindings))->handle($event);
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldReceive('dispatch')->once();
+
+        (new StoreOrderOnPaid($repo, $bindings, $dispatcher))->handle($event);
 
         $existing = Mockery::mock(OrderInterface::class);
         $updateRepo = Mockery::mock(OrderRepositoryInterface::class);
@@ -157,7 +196,10 @@ class StoreOrderOnPaidTest extends TestCase
             fn (UpdateOrderData $data) => $data->metadata === $metadata,
         ))->andReturn($existing);
 
-        (new StoreOrderOnPaid($updateRepo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
+        $updateDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $updateDispatcher->shouldNotReceive('dispatch');
+
+        (new StoreOrderOnPaid($updateRepo, Mockery::mock(CustomerBindingRepository::class), $updateDispatcher))->handle($event);
     }
 
     public function test_it_forwards_order_lines_into_store_order_data(): void
@@ -199,7 +241,10 @@ class StoreOrderOnPaidTest extends TestCase
         $bindings->shouldReceive('hostCustomerIdFor')->andReturn(null);
         $bindings->shouldReceive('record')->once();
 
-        (new StoreOrderOnPaid($repo, $bindings))->handle($event);
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldReceive('dispatch')->once();
+
+        (new StoreOrderOnPaid($repo, $bindings, $dispatcher))->handle($event);
     }
 
     public function test_it_does_not_re_write_lines_for_an_already_persisted_order(): void
@@ -212,7 +257,10 @@ class StoreOrderOnPaidTest extends TestCase
         $repo->shouldReceive('update')->once()->andReturn($existing);
         $repo->shouldNotReceive('store');
 
-        (new StoreOrderOnPaid($repo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
+        $dispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $dispatcher->shouldNotReceive('dispatch');
+
+        (new StoreOrderOnPaid($repo, Mockery::mock(CustomerBindingRepository::class), $dispatcher))->handle($event);
     }
 
     private function makeEvent(?TaxSummaryCollection $taxSummary = null): OrderPaid

--- a/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
+++ b/tests/Webhooks/Reactions/StoreOrderOnPaymentFailedTest.php
@@ -10,7 +10,7 @@ use Vatly\Fluent\Contracts\OrderInterface;
 use Vatly\Fluent\Contracts\OrderRepositoryInterface;
 use Vatly\API\Types\TaxSummaryCollection;
 use Vatly\API\Webhooks\Events\OrderPaid;
-use Vatly\API\Webhooks\Events\PaymentFailed;
+use Vatly\API\Webhooks\Events\OrderPaymentFailed;
 use Vatly\Fluent\Data\StoreOrderData;
 use Vatly\Fluent\Data\UpdateOrderData;
 use Vatly\Fluent\Tests\TestCase;
@@ -122,7 +122,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
 
     public function test_it_skips_bindings_when_customer_id_is_empty(): void
     {
-        $event = new PaymentFailed(
+        $event = new OrderPaymentFailed(
             customerId: '',
             orderId: 'ord_anon',
             status: 'pending',
@@ -152,7 +152,7 @@ class StoreOrderOnPaymentFailedTest extends TestCase
     public function test_it_plumbs_metadata_through_store_and_update_paths(): void
     {
         $metadata = ['fluentcart_transaction_id' => 'tx_42'];
-        $event = new PaymentFailed(
+        $event = new OrderPaymentFailed(
             customerId: 'cus_1',
             orderId: 'ord_1',
             status: 'pending',
@@ -187,9 +187,9 @@ class StoreOrderOnPaymentFailedTest extends TestCase
         (new StoreOrderOnPaymentFailed($updateRepo, Mockery::mock(CustomerBindingRepository::class)))->handle($event);
     }
 
-    private function makeEvent(?TaxSummaryCollection $taxSummary = null, string $status = 'pending'): PaymentFailed
+    private function makeEvent(?TaxSummaryCollection $taxSummary = null, string $status = 'pending'): OrderPaymentFailed
     {
-        return new PaymentFailed(
+        return new OrderPaymentFailed(
             customerId: 'cus_1',
             orderId: 'ord_1',
             status: $status,

--- a/tests/Webhooks/WebhookEventFactoryTest.php
+++ b/tests/Webhooks/WebhookEventFactoryTest.php
@@ -25,7 +25,7 @@ use Vatly\API\Webhooks\Events\OrderCanceled;
 use Vatly\API\Webhooks\Events\OrderChargebackReceived;
 use Vatly\API\Webhooks\Events\OrderChargebackReversed;
 use Vatly\API\Webhooks\Events\OrderPaid;
-use Vatly\API\Webhooks\Events\PaymentFailed;
+use Vatly\API\Webhooks\Events\OrderPaymentFailed;
 use Vatly\API\Webhooks\Events\RefundCanceled;
 use Vatly\API\Webhooks\Events\RefundCompleted;
 use Vatly\API\Webhooks\Events\RefundFailed;
@@ -37,6 +37,7 @@ use Vatly\API\Webhooks\Events\SubscriptionResumed;
 use Vatly\API\Webhooks\Events\SubscriptionStarted;
 use Vatly\API\Webhooks\Events\UnsupportedWebhookReceived;
 use Vatly\API\Webhooks\Events\WebhookReceived;
+use Vatly\API\Webhooks\Events\WebhookSetupReceived;
 use Vatly\Fluent\Tests\TestCase;
 use Vatly\Fluent\Webhooks\WebhookEventFactory;
 
@@ -549,7 +550,7 @@ class WebhookEventFactoryTest extends TestCase
         $webhook = new WebhookReceived(
             id: 'webhook_event_pf',
             resource: 'webhook_event',
-            eventName: 'payment.failed',
+            eventName: 'order.payment_failed',
             entityType: 'order',
             entityId: 'ord_dunning_1',
             testmode: false,
@@ -562,7 +563,7 @@ class WebhookEventFactoryTest extends TestCase
 
         $event = $this->factory->createFromWebhook($webhook);
 
-        $this->assertInstanceOf(PaymentFailed::class, $event);
+        $this->assertInstanceOf(OrderPaymentFailed::class, $event);
         $this->assertSame('cus_456', $event->customerId);
         $this->assertSame('ord_dunning_1', $event->orderId);
         $this->assertSame('pending', $event->status);
@@ -924,6 +925,28 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertSame('unknown.event', $event->eventName);
     }
 
+    public function test_it_creates_webhook_setup_received_event_from_webhook(): void
+    {
+        $webhook = new WebhookReceived(
+            id: 'webhook_event_setup',
+            resource: 'webhook_event',
+            eventName: 'webhook.setup',
+            entityType: 'webhook',
+            entityId: 'wh_123',
+            testmode: false,
+            createdAt: '2024-01-15T10:00:00Z',
+            object: ['url' => 'https://example.test/webhooks/vatly'],
+        );
+
+        $event = $this->factory->createFromWebhook($webhook);
+
+        // Regression: `webhook.setup` used to fall through to Unsupported.
+        $this->assertInstanceOf(WebhookSetupReceived::class, $event);
+        $this->assertSame('webhook.setup', $event->eventName);
+        $this->assertSame('wh_123', $event->entityId);
+        $this->assertSame(['url' => 'https://example.test/webhooks/vatly'], $event->object);
+    }
+
     public function test_it_returns_list_of_supported_events(): void
     {
         $supported = $this->factory->getSupportedEvents();
@@ -938,7 +961,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertContains('order.canceled', $supported);
         $this->assertContains('order.chargeback_received', $supported);
         $this->assertContains('order.chargeback_reversed', $supported);
-        $this->assertContains('payment.failed', $supported);
+        $this->assertContains('order.payment_failed', $supported);
         $this->assertContains('checkout.paid', $supported);
         $this->assertContains('checkout.failed', $supported);
         $this->assertContains('checkout.canceled', $supported);
@@ -946,6 +969,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertContains('refund.completed', $supported);
         $this->assertContains('refund.failed', $supported);
         $this->assertContains('refund.canceled', $supported);
+        $this->assertContains('webhook.setup', $supported);
     }
 
     public function test_it_checks_if_event_is_supported(): void
@@ -957,7 +981,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertTrue($this->factory->isSupported('order.canceled'));
         $this->assertTrue($this->factory->isSupported('order.chargeback_received'));
         $this->assertTrue($this->factory->isSupported('order.chargeback_reversed'));
-        $this->assertTrue($this->factory->isSupported('payment.failed'));
+        $this->assertTrue($this->factory->isSupported('order.payment_failed'));
         $this->assertTrue($this->factory->isSupported('checkout.paid'));
         $this->assertTrue($this->factory->isSupported('checkout.failed'));
         $this->assertTrue($this->factory->isSupported('checkout.canceled'));
@@ -966,6 +990,7 @@ class WebhookEventFactoryTest extends TestCase
         $this->assertTrue($this->factory->isSupported('refund.completed'));
         $this->assertTrue($this->factory->isSupported('refund.failed'));
         $this->assertTrue($this->factory->isSupported('refund.canceled'));
+        $this->assertTrue($this->factory->isSupported('webhook.setup'));
         $this->assertFalse($this->factory->isSupported('unknown.event'));
     }
 

--- a/tests/Webhooks/WebhookProcessorTest.php
+++ b/tests/Webhooks/WebhookProcessorTest.php
@@ -17,7 +17,7 @@ use Vatly\Fluent\Contracts\EventDispatcherInterface;
 use Vatly\Fluent\Contracts\WebhookCallRepositoryInterface;
 use Vatly\Fluent\Contracts\WebhookReactionInterface;
 use Vatly\API\Webhooks\Events\CheckoutPaid;
-use Vatly\API\Webhooks\Events\PaymentFailed;
+use Vatly\API\Webhooks\Events\OrderPaymentFailed;
 use Vatly\API\Webhooks\Events\SubscriptionStarted;
 use Vatly\API\Webhooks\Events\UnsupportedWebhookReceived;
 use Vatly\Fluent\Exceptions\InvalidWebhookSignatureException;
@@ -177,7 +177,7 @@ class WebhookProcessorTest extends TestCase
     {
         $payload = $this->makePayload(
             id: 'webhook_event_pf',
-            eventName: 'payment.failed',
+            eventName: 'order.payment_failed',
             entityType: 'order',
             entityId: 'ord_dunning_1',
             object: [
@@ -214,7 +214,7 @@ class WebhookProcessorTest extends TestCase
             ->shouldReceive('dispatch')
             ->once()
             ->withArgs(function (object $event) {
-                return $event instanceof PaymentFailed
+                return $event instanceof OrderPaymentFailed
                     && $event->customerId === 'cus_456'
                     && $event->orderId === 'ord_dunning_1'
                     && $event->status === 'pending'


### PR DESCRIPTION
## Wave R2 — fluent adopts api-php v0.1.0-alpha.17

Bumps `vatly/vatly-api-php` to `^0.1.0-alpha.17` and adopts the upstream changes.

### 1. `PaymentFailed` → `OrderPaymentFailed` rename
Upstream renamed the DTO and the `WebhookEventName` constant (`PAYMENT_FAILED`→`ORDER_PAYMENT_FAILED`, wire `payment.failed`→`order.payment_failed`). Repointed:
- `WebhookEventFactory` mapping + enrichment helper (`createOrderPaymentFailed`).
- `StoreOrderOnPaymentFailed` reaction (`use` + `instanceof` + `supports()`; class name unchanged).
- All referencing tests + README/docs prose.

### 2. NEW driver-side event `OrderWasCreatedFromWebhook`
- `src/Events/OrderWasCreatedFromWebhook.php` (`Vatly\Fluent\Events`, immutable, carries `public OrderInterface $order`) — mirrors `SubscriptionWasCreatedFromWebhook`.
- `StoreOrderOnPaid` now captures the `?OrderInterface` from `store()` and dispatches `OrderWasCreatedFromWebhook` **only on a brand-new store** (skipped on the update path and when `store()` returns `null`), mirroring `SyncSubscriptionOnStarted`. Required injecting `EventDispatcherInterface`; `WebhookProcessorFactory` wiring updated to pass the already-available dispatcher.

### 3. NEW `webhook.setup` → `WebhookSetupReceived`
- `WebhookEventFactory` now maps `WebhookEventName::WEBHOOK_SETUP` → `WebhookSetupReceived::fromWebhook($webhook)` (previously fell through to `UnsupportedWebhookReceived`) and lists it in `getSupportedEvents()`.

### Verify
- `vendor/bin/phpunit`: **249 tests, 726 assertions — green** (incl. new dispatch tests for `OrderWasCreatedFromWebhook` on new/null/update paths, and a factory test asserting `webhook.setup` yields `WebhookSetupReceived`).
- PHPStan level 6: **no errors**.
- Grep clean: zero stray `PaymentFailed` / `PAYMENT_FAILED` / `payment.failed` remain.

Recommended next tag: **v0.8.0-alpha.16**.