### PR TITLE
docs: clarify checkout price override + point to openapi.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,12 +443,26 @@ $vatly = $container->get(Vatly::class);
 use Vatly\Fluent\CustomerProfile;
 
 // Each checkout item id is a Vatly product: `one_off_product_…` for a one-off
-// product or `subscription_plan_…` for a subscription plan.
+// product or `subscription_plan_…` for a subscription plan. Create the product
+// in the Vatly dashboard first — there is no API to make one on the fly.
+// Items accept only: `id`, `quantity`, `price`, `trialDays`, `metadata`.
+// There is NO item-level `unitPrice`, `name`, or `currency`.
 $checkout = $vatly
     ->checkoutBuilder(new CustomerProfile(vatlyId: $user->vatly_id))
     ->withRedirectUrlSuccess('https://app.example.com/done')
     ->withRedirectUrlCanceled('https://app.example.com/oops')
     ->create([['id' => 'one_off_product_3Qb8Wz1Yt', 'quantity' => 1]], '...', '...');
+
+// Need a custom amount? Override the product's price with a Money object
+// (`value` is a decimal string; precision follows the currency). The item id
+// still points at a pre-configured product.
+$checkout = $vatly
+    ->checkoutBuilder(new CustomerProfile(vatlyId: $user->vatly_id))
+    ->create([[
+        'id' => 'one_off_product_3Qb8Wz1Yt',
+        'quantity' => 1,
+        'price' => ['value' => '49.99', 'currency' => 'EUR'],
+    ]], 'https://app.example.com/done', 'https://app.example.com/oops');
 
 // Subscribe
 $checkout = $vatly
@@ -484,6 +498,8 @@ $url = $vatly->subscription($localSubscription)->updateBilling([
     ],
 ]);
 ```
+
+> **Source of truth for payload fields.** Fluent passes checkout/subscription payloads through to `vatly-api-php`, whose schema is the canonical [`openapi.yaml`](https://docs.vatly.com/openapi.yaml) (also vendored at `vendor/vatly/vatly-api-php/openapi.yaml`). If you — or an AI assistant — are unsure whether a field exists or what it's named, read the spec rather than guessing from an example. Checkout items, for instance, accept only `id`, `quantity`, `price` (a `Money` override), `trialDays`, and `metadata`; incoming webhook deliveries are the `WebhookDelivery` envelope (`id`, `resource`, `eventName`, `entityType`, `entityId`, `object`, `createdAt`, `testmode`) — but you normally consume them as the typed events above, not as raw arrays.
 
 **Customer helper.** For host-first flows where you create a Vatly customer for a known host entity and want the link recorded automatically:
 

--- a/README.md
+++ b/README.md
@@ -445,8 +445,6 @@ use Vatly\Fluent\CustomerProfile;
 // Each checkout item id is a Vatly product: `one_off_product_…` for a one-off
 // product or `subscription_plan_…` for a subscription plan. Create the product
 // in the Vatly dashboard first — there is no API to make one on the fly.
-// Items accept only: `id`, `quantity`, `price`, `trialDays`, `metadata`.
-// There is NO item-level `unitPrice`, `name`, or `currency`.
 $checkout = $vatly
     ->checkoutBuilder(new CustomerProfile(vatlyId: $user->vatly_id))
     ->withRedirectUrlSuccess('https://app.example.com/done')
@@ -499,7 +497,7 @@ $url = $vatly->subscription($localSubscription)->updateBilling([
 ]);
 ```
 
-> **Source of truth for payload fields.** Fluent passes checkout/subscription payloads through to `vatly-api-php`, whose schema is the canonical [`openapi.yaml`](https://docs.vatly.com/openapi.yaml) (also vendored at `vendor/vatly/vatly-api-php/openapi.yaml`). If you — or an AI assistant — are unsure whether a field exists or what it's named, read the spec rather than guessing from an example. Checkout items, for instance, accept only `id`, `quantity`, `price` (a `Money` override), `trialDays`, and `metadata`; incoming webhook deliveries are the `WebhookDelivery` envelope (`id`, `resource`, `eventName`, `entityType`, `entityId`, `object`, `createdAt`, `testmode`) — but you normally consume them as the typed events above, not as raw arrays.
+> **Source of truth for payload fields.** Fluent passes checkout/subscription payloads through to `vatly-api-php`, whose schema is the canonical [`openapi.yaml`](https://docs.vatly.com/openapi.yaml) (also vendored at `vendor/vatly/vatly-api-php/openapi.yaml`). For the authoritative API request/response fields and the incoming webhook delivery shape, read the spec rather than guessing from an example.
 
 **Customer helper.** For host-first flows where you create a Vatly customer for a known host entity and want the link recorded automatically:
 


### PR DESCRIPTION
## Why

Internal dogfooding by a Vatly team member (George, @ag84ark) — integrating via this SDK with an AI assistant — hit two avoidable problems:

1. The assistant invented item-level `unitPrice` / `name` / `currency` fields.
2. After being corrected, it concluded **custom pricing is impossible** — but the checkout API supports a per-item `price` **`Money` override**, which fluent already passes straight through. Nothing in the README showed it.

The README also didn't name a single source of truth, so neither the integration nor the AI knew to check `openapi.yaml`.

## Changes (README only)

- Add a **custom-price checkout example** using a per-item `price` Money override on a pre-configured product id.
- Spell out that checkout items accept only `id`, `quantity`, `price`, `trialDays`, `metadata` — **no** item-level `unitPrice`/`name`/`currency`.
- Add a **source-of-truth** note pointing at `openapi.yaml` (published at docs.vatly.com and vendored under `vendor/vatly/vatly-api-php/`), covering both checkout fields and the `WebhookDelivery` envelope shape — while reminding consumers they normally handle webhooks as typed events, not raw arrays.

Part of a cross-repo sweep (api-php, fluent-php, fluentcart-wp, docs) prompted by the same integration feedback.